### PR TITLE
Stack Overflow Recursion Guard

### DIFF
--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -208,6 +208,9 @@ colgrep settings --parallel 8
 # Set batch size per session (default: 1 for CPU, 64 for CUDA)
 colgrep settings --batch-size 2
 
+# Set parser recursion depth guard (default: 1024)
+colgrep settings --max-recursion-depth 1024
+
 # Enable verbose output by default
 colgrep settings --verbose
 

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -199,6 +199,9 @@ EXAMPLES:
     # Set batch size per session (default: 1)
     colgrep settings --batch-size 2
 
+    # Set parser recursion guard depth (default: 1024)
+    colgrep settings --max-recursion-depth 1024
+
     # Set both at once
     colgrep settings --k 25 --n 8
 
@@ -212,7 +215,8 @@ NOTES:
     • Default output is compact (filepath:lines). Use -v or --verbose for full content
     • FP32 (full-precision) is the default
     • Pool factor 2 (default) reduces index size by ~50%. Use 1 to disable pooling
-    • Parallel sessions default to CPU count. Batch-size 1 (default) maximizes throughput";
+    • Parallel sessions default to CPU count. Batch-size 1 (default) maximizes throughput
+    • Parser recursion depth defaults to 1024. Increase only if needed for deep ASTs";
 
 #[derive(Parser)]
 #[command(
@@ -534,6 +538,10 @@ pub enum Commands {
         /// Smaller batches work better with parallel sessions.
         #[arg(long = "batch-size", value_name = "SIZE")]
         batch_size: Option<usize>,
+
+        /// Set parser recursion depth guard (use 0 to reset to default 1024)
+        #[arg(long = "max-recursion-depth", value_name = "DEPTH")]
+        max_recursion_depth: Option<usize>,
 
         /// Enable verbose output by default (show full content with syntax highlighting)
         #[arg(long)]

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -14,6 +14,8 @@ const CONFIG_FILE: &str = "config.json";
 
 /// Default pool factor for embedding compression: 2 (2x compression)
 pub const DEFAULT_POOL_FACTOR: usize = 2;
+/// Default parser recursion depth guard.
+pub const DEFAULT_MAX_RECURSION_DEPTH: usize = 1024;
 
 /// Default batch size per encoding session for CPU
 /// Testing shows batch_size=1 gives best performance with parallel sessions on CPU
@@ -128,6 +130,11 @@ pub struct Config {
     /// When true, shows full content grouped by file with syntax highlighting
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verbose: Option<bool>,
+
+    /// Maximum recursion depth for parser/analysis AST walks (default: 1024)
+    /// Protects against pathological files that would otherwise overflow the stack.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_recursion_depth: Option<usize>,
 }
 
 impl Config {
@@ -291,6 +298,23 @@ impl Config {
     /// Clear the verbose setting (revert to default: false)
     pub fn clear_verbose(&mut self) {
         self.verbose = None;
+    }
+
+    /// Get the max parser recursion depth.
+    /// Returns configured value or default (1024).
+    pub fn get_max_recursion_depth(&self) -> usize {
+        self.max_recursion_depth
+            .unwrap_or(DEFAULT_MAX_RECURSION_DEPTH)
+    }
+
+    /// Set max parser recursion depth (minimum 1).
+    pub fn set_max_recursion_depth(&mut self, depth: usize) {
+        self.max_recursion_depth = Some(depth.max(1));
+    }
+
+    /// Clear max parser recursion depth setting (revert to default).
+    pub fn clear_max_recursion_depth(&mut self) {
+        self.max_recursion_depth = None;
     }
 }
 

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -15,7 +15,7 @@ pub mod parser;
 pub mod signal;
 pub mod stderr;
 
-pub use config::{Config, DEFAULT_BATCH_SIZE, DEFAULT_POOL_FACTOR};
+pub use config::{Config, DEFAULT_BATCH_SIZE, DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_POOL_FACTOR};
 pub use embed::build_embedding_text;
 pub use index::paths::{
     acquire_index_lock, find_parent_index, get_colgrep_data_dir, get_index_dir_for_project,

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -217,6 +217,7 @@ fn main() -> Result<()> {
             pool_factor,
             parallel_sessions,
             batch_size,
+            max_recursion_depth,
             verbose,
             no_verbose,
         }) => cmd_config(
@@ -227,6 +228,7 @@ fn main() -> Result<()> {
             pool_factor,
             parallel_sessions,
             batch_size,
+            max_recursion_depth,
             verbose,
             no_verbose,
         ),

--- a/colgrep/src/parser/html.rs
+++ b/colgrep/src/parser/html.rs
@@ -14,8 +14,6 @@ use super::types::{CodeUnit, Language, UnitType};
 use std::path::Path;
 use tree_sitter::{Node, Parser};
 
-const MAX_AST_RECURSION_DEPTH: usize = 1024;
-
 /// A block extracted from an HTML file
 struct HtmlBlock {
     content: String,
@@ -200,6 +198,7 @@ pub fn extract_html_units(path: &Path, source: &str) -> Vec<CodeUnit> {
 /// Parse script content as JavaScript and extract code units.
 fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, bool) {
     let lang = Language::JavaScript;
+    let max_depth = super::max_recursion_depth();
 
     let mut parser = Parser::new();
     if parser
@@ -230,6 +229,7 @@ fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, boo
         None,
         &file_imports,
         0,
+        max_depth,
         &mut depth_limit_hit,
     );
 
@@ -237,7 +237,7 @@ fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, boo
         eprintln!(
             "⚠️  Skipping {} (AST nesting exceeded max depth: {})",
             path.display(),
-            MAX_AST_RECURSION_DEPTH
+            max_depth
         );
         return (Vec::new(), true);
     }
@@ -262,12 +262,13 @@ fn extract_from_node(
     parent_class: Option<&str>,
     file_imports: &[String],
     depth: usize,
+    max_depth: usize,
     depth_limit_hit: &mut bool,
 ) {
     if *depth_limit_hit {
         return;
     }
-    if depth > MAX_AST_RECURSION_DEPTH {
+    if depth > max_depth {
         *depth_limit_hit = true;
         return;
     }
@@ -298,6 +299,7 @@ fn extract_from_node(
                         Some(&class_name),
                         file_imports,
                         depth + 1,
+                        max_depth,
                         depth_limit_hit,
                     );
                 }
@@ -322,6 +324,7 @@ fn extract_from_node(
             parent_class,
             file_imports,
             depth + 1,
+            max_depth,
             depth_limit_hit,
         );
     }

--- a/colgrep/src/parser/vue.rs
+++ b/colgrep/src/parser/vue.rs
@@ -14,8 +14,6 @@ use super::types::{CodeUnit, Language, UnitType};
 use std::path::Path;
 use tree_sitter::{Node, Parser};
 
-const MAX_AST_RECURSION_DEPTH: usize = 1024;
-
 /// A block extracted from a Vue SFC
 struct VueBlock {
     content: String,
@@ -200,6 +198,7 @@ pub fn extract_vue_units(path: &Path, source: &str) -> Vec<CodeUnit> {
 fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, bool) {
     // Use TypeScript for parsing (works for both TS and JS in Vue)
     let lang = Language::TypeScript;
+    let max_depth = super::max_recursion_depth();
 
     let mut parser = Parser::new();
     if parser
@@ -230,6 +229,7 @@ fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, boo
         None,
         &file_imports,
         0,
+        max_depth,
         &mut depth_limit_hit,
     );
 
@@ -237,7 +237,7 @@ fn parse_script_content(path: &Path, script_source: &str) -> (Vec<CodeUnit>, boo
         eprintln!(
             "⚠️  Skipping {} (AST nesting exceeded max depth: {})",
             path.display(),
-            MAX_AST_RECURSION_DEPTH
+            max_depth
         );
         return (Vec::new(), true);
     }
@@ -262,12 +262,13 @@ fn extract_from_node(
     parent_class: Option<&str>,
     file_imports: &[String],
     depth: usize,
+    max_depth: usize,
     depth_limit_hit: &mut bool,
 ) {
     if *depth_limit_hit {
         return;
     }
-    if depth > MAX_AST_RECURSION_DEPTH {
+    if depth > max_depth {
         *depth_limit_hit = true;
         return;
     }
@@ -303,6 +304,7 @@ fn extract_from_node(
                         Some(&class_name),
                         file_imports,
                         depth + 1,
+                        max_depth,
                         depth_limit_hit,
                     );
                 }
@@ -330,6 +332,7 @@ fn extract_from_node(
             parent_class,
             file_imports,
             depth + 1,
+            max_depth,
             depth_limit_hit,
         );
     }


### PR DESCRIPTION
The AST parsing will stack overflow when dealing with pathological files. This happens regularly when trying to index compiler code, like LLVM for example.

Add a configurable recursion depth to skip pathological files.