### PR TITLE
fix: atomic write for state.json to prevent corruption under concurrency

### DIFF
--- a/colgrep/src/index/state.rs
+++ b/colgrep/src/index/state.rs
@@ -56,8 +56,8 @@ impl IndexState {
         // Atomic write: write to a temp file in the same directory, then rename.
         // rename(2) on the same filesystem is atomic on POSIX systems.
         // Use PID + thread ID to avoid collisions between concurrent writers.
-        let tid = format!("{:?}", std::thread::current().id())
-            .replace(|c: char| !c.is_ascii_digit(), "");
+        let tid =
+            format!("{:?}", std::thread::current().id()).replace(|c: char| !c.is_ascii_digit(), "");
         let tmp_name = format!("state.{}.{}.json.tmp", std::process::id(), tid);
         let tmp_path = index_dir.join(tmp_name);
         fs::write(&tmp_path, content)?;
@@ -306,8 +306,10 @@ mod tests {
                 for i in 0..iterations {
                     if t % 2 == 0 {
                         // Writer: save with incrementing search_count
-                        let mut state = IndexState::default();
-                        state.search_count = (t * iterations + i) as u64;
+                        let mut state = IndexState {
+                            search_count: (t * iterations + i) as u64,
+                            ..Default::default()
+                        };
                         state.files.insert(
                             PathBuf::from(format!("file_{t}_{i}.rs")),
                             FileInfo {


### PR DESCRIPTION
## Summary

- `IndexState::save()` used `fs::write()` which truncates the target file before writing. When multiple colgrep processes run concurrently, a reader can see a 0-byte file between truncation and write, causing `EOF while parsing a value at line 1 column 0`
- Fix: write to a unique temp file (PID + thread ID), then `rename()` into place. `rename(2)` on the same filesystem is atomic on POSIX, so readers always see complete content
- Adds `test_concurrent_save_and_load` (8 threads, 4 writers + 4 readers, 50 iterations each) that fails without the fix and passes with it
- Fixes rustfmt and clippy CI failures from the original PR

## Original author

This PR is based on the work by @rawwerks in #21. The CI lint issues (rustfmt formatting + clippy `field_reassign_with_default`) have been resolved in a follow-up commit.

## Test plan

- [x] All existing tests pass
- [x] New `test_concurrent_save_and_load` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)