### PR TITLE
fix: drop mmap handles before set_len to fix Windows os error 1224

### DIFF
--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -882,6 +882,21 @@ impl MmapIndex {
         self.codec.embedding_dim()
     }
 
+    /// Release all memory-mapped file handles.
+    ///
+    /// On Windows, files that are memory-mapped cannot be deleted, renamed, or
+    /// truncated (OS error 1224 / ERROR_USER_MAPPED_FILE). This method replaces
+    /// file-backed mmaps with anonymous (non-file) mmaps so that subsequent
+    /// file operations on the index directory can proceed.
+    ///
+    /// After calling this, the index is not usable for search — it must be
+    /// reloaded via `Self::load()`.
+    fn release_mmaps(&mut self) {
+        self.mmap_codes = crate::mmap::MmapNpyArray1I64::empty();
+        self.mmap_residuals = crate::mmap::MmapNpyArray2U8::empty();
+        self.codec.centroids = crate::codec::CentroidStore::Owned(Array2::zeros((0, 0)));
+    }
+
     /// Reconstruct embeddings for specific documents.
     ///
     /// This method retrieves the compressed codes and residuals for each document
@@ -999,6 +1014,12 @@ impl MmapIndex {
         let path_str = self.path.clone();
         let index_path = std::path::Path::new(&path_str);
         let num_new_docs = embeddings.len();
+
+        // Release mmap handles before any file operations (delete, rename,
+        // truncate). On Windows, files that are memory-mapped cannot be
+        // modified, causing OS error 1224 (ERROR_USER_MAPPED_FILE).
+        // The index will be fully reloaded from disk at the end of this method.
+        self.release_mmaps();
 
         // ==================================================================
         // Start-from-scratch mode (fast-plaid update.py:312-346)
@@ -1218,7 +1239,11 @@ impl MmapIndex {
     /// This should be called after delete operations to refresh the in-memory
     /// representation with the updated on-disk state.
     pub fn reload(&mut self) -> Result<()> {
-        *self = Self::load(&self.path)?;
+        let path = self.path.clone();
+        // Release mmap handles before reloading so that merge_*_chunks can
+        // rename/overwrite the merged files on Windows (OS error 1224).
+        self.release_mmaps();
+        *self = Self::load(&path)?;
         Ok(())
     }
 
@@ -1253,6 +1278,11 @@ impl MmapIndex {
     /// The number of documents actually deleted
     pub fn delete_with_options(&mut self, doc_ids: &[i64], delete_metadata: bool) -> Result<usize> {
         let path = self.path.clone();
+
+        // Release mmap handles before deletion. delete_from_index calls
+        // clear_merged_files which removes the memory-mapped merged files.
+        // On Windows this fails with OS error 1224 if the mmaps are active.
+        self.release_mmaps();
 
         // Perform the deletion using standalone function
         let deleted = crate::delete::delete_from_index(doc_ids, &path)?;
@@ -1377,6 +1407,10 @@ mod tests {
                 .expect("Failed to create index");
         assert_eq!(index1.metadata.num_documents, 5);
         assert_eq!(doc_ids1, vec![0, 1, 2, 3, 4]);
+
+        // Drop previous index to release mmap handles before updating.
+        // On Windows, files cannot be modified while memory-mapped.
+        drop(index1);
 
         // Second call - updates existing index with 3 more documents
         let embeddings2 = create_embeddings(3, 5);

--- a/next-plaid/src/mmap.rs
+++ b/next-plaid/src/mmap.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use fs2::FileExt;
-use memmap2::Mmap;
+use memmap2::{Mmap, MmapMut};
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
 
 use crate::error::{Error, Result};
@@ -741,6 +741,22 @@ pub struct MmapNpyArray1I64 {
 }
 
 impl MmapNpyArray1I64 {
+    /// Create an empty instance backed by an anonymous mmap (no file).
+    ///
+    /// Used to release file-backed mmap handles before file operations on Windows,
+    /// where deleting or renaming a memory-mapped file causes OS error 1224.
+    pub fn empty() -> Self {
+        let mmap = MmapMut::map_anon(1)
+            .expect("failed to create anonymous mmap")
+            .make_read_only()
+            .expect("failed to make anonymous mmap read-only");
+        Self {
+            _mmap: mmap,
+            len: 0,
+            data_offset: 0,
+        }
+    }
+
     /// Load a 1D i64 array from an NPY file.
     pub fn from_npy_file(path: &Path) -> Result<Self> {
         let file = File::open(path)
@@ -939,6 +955,22 @@ pub struct MmapNpyArray2U8 {
 }
 
 impl MmapNpyArray2U8 {
+    /// Create an empty instance backed by an anonymous mmap (no file).
+    ///
+    /// Used to release file-backed mmap handles before file operations on Windows,
+    /// where deleting or renaming a memory-mapped file causes OS error 1224.
+    pub fn empty() -> Self {
+        let mmap = MmapMut::map_anon(1)
+            .expect("failed to create anonymous mmap")
+            .make_read_only()
+            .expect("failed to make anonymous mmap read-only");
+        Self {
+            _mmap: mmap,
+            shape: (0, 0),
+            data_offset: 0,
+        }
+    }
+
     /// Load a 2D u8 array from an NPY file.
     pub fn from_npy_file(path: &Path) -> Result<Self> {
         let file = File::open(path)

--- a/next-plaid/tests/metadata_sync_test.rs
+++ b/next-plaid/tests/metadata_sync_test.rs
@@ -203,10 +203,14 @@ fn test_metadata_sync_update_or_create_existing() {
 
     // Create initial index
     let emb1 = random_embeddings(5, 8, 64);
-    let (_index, doc_ids1) =
+    let (initial_index, doc_ids1) =
         MmapIndex::update_or_create(&emb1, path, &index_config, &update_config).unwrap();
     assert_eq!(read_num_documents_from_file(path).unwrap(), 5);
     assert_eq!(doc_ids1, vec![0, 1, 2, 3, 4]);
+
+    // Drop previous index to release mmap handles before updating.
+    // On Windows, files cannot be modified while memory-mapped.
+    drop(initial_index);
 
     // Update existing index
     let emb2 = random_embeddings(5, 8, 64);


### PR DESCRIPTION
## Problem
`colgrep init` crashes on Windows with:
```
Error: IO error: os error 1224 (ERROR_USER_MAPPED_FILE)
```
Windows forbids `set_len()` / truncate / delete / rename on a file that has an active `Mmap` or `MmapMut` handle open. Linux/macOS silently allow it.

The crash occurs because `MmapIndex` holds active mmap handles on `merged_codes.npy`, `merged_residuals.npy`, and `centroids.npy` (via `mmap_codes`, `mmap_residuals`, and `codec.centroids`) while `update()`, `delete_with_options()`, and `reload()` call functions that delete, rename, or overwrite those same files.

## Fix
Ensure all `Mmap` handles are dropped before calling file operations on the same files:

- Add `MmapNpyArray1I64::empty()` and `MmapNpyArray2U8::empty()` constructors that create anonymous (non-file-backed) mmaps
- Add `MmapIndex::release_mmaps()` that replaces file-backed mmaps with anonymous ones
- Call `release_mmaps()` early in `update()`, `delete_with_options()`, and `reload()` before any file I/O
- Fix tests that held stale `MmapIndex` references across `update_or_create` calls

## Testing
- [x] All 84 existing tests pass on Windows (68 unit + 9 filtering integration + 7 metadata sync)
- [x] `test_update_or_create_existing_index` — previously crashed with os error 1224, now passes
- [x] `test_metadata_sync_update_or_create_existing` — previously crashed with os error 1224, now passes
- [ ] `colgrep init` completes successfully on Windows
- [ ] Existing tests pass on Linux/macOS