### PR TITLE
Fix Linux ONNX runtime loading for colgrep

### DIFF
--- a/colgrep/src/onnx_runtime.rs
+++ b/colgrep/src/onnx_runtime.rs
@@ -132,15 +132,7 @@ pub fn ensure_onnx_runtime() -> Result<PathBuf> {
     if let Ok(path) = env::var("ORT_DYLIB_PATH") {
         let path = PathBuf::from(&path);
         if path.exists() {
-            // For CUDA on Linux, also ensure LD_LIBRARY_PATH includes the directory and check cuDNN
-            #[cfg(all(target_os = "linux", feature = "cuda"))]
-            {
-                if let Some(parent) = path.parent() {
-                    prepend_ld_library_path(parent);
-                }
-                // Check for cuDNN availability (result is stored in CUDNN_AVAILABLE)
-                let _ = check_cudnn_available();
-            }
+            pin_runtime_library(&path);
             return Ok(path);
         }
     }
@@ -148,23 +140,29 @@ pub fn ensure_onnx_runtime() -> Result<PathBuf> {
     // 2. Search common locations (skip for CUDA - we want our managed GPU version)
     #[cfg(not(feature = "cuda"))]
     if let Some(path) = find_onnx_runtime() {
-        env::set_var("ORT_DYLIB_PATH", &path);
+        pin_runtime_library(&path);
         return Ok(path);
     }
 
     // 3. Download and cache
     let path = download_onnx_runtime()?;
-    env::set_var("ORT_DYLIB_PATH", &path);
+    pin_runtime_library(&path);
+    Ok(path)
+}
 
-    // For CUDA on Linux, set LD_LIBRARY_PATH so provider libraries can be found
-    #[cfg(all(target_os = "linux", feature = "cuda"))]
+fn pin_runtime_library(path: &Path) {
+    env::set_var("ORT_DYLIB_PATH", path);
+
+    #[cfg(target_os = "linux")]
     if let Some(parent) = path.parent() {
         prepend_ld_library_path(parent);
+    }
+
+    #[cfg(all(target_os = "linux", feature = "cuda"))]
+    {
         // Check for cuDNN availability (result is stored in CUDNN_AVAILABLE)
         let _ = check_cudnn_available();
     }
-
-    Ok(path)
 }
 
 /// Find the cuDNN library directory (without setting any global state)
@@ -200,7 +198,7 @@ fn find_cudnn_directory() -> Option<PathBuf> {
 }
 
 /// Prepend a directory to LD_LIBRARY_PATH
-#[cfg(all(target_os = "linux", feature = "cuda"))]
+#[cfg(target_os = "linux")]
 fn prepend_ld_library_path(dir: &Path) {
     let dir_str = dir.to_string_lossy();
     let current = env::var("LD_LIBRARY_PATH").unwrap_or_default();
@@ -462,9 +460,9 @@ fn get_search_paths() -> Vec<PathBuf> {
         // System paths (Linux)
         #[cfg(target_os = "linux")]
         {
-            paths.push(PathBuf::from("/usr/lib"));
-            paths.push(PathBuf::from("/usr/local/lib"));
-            paths.push(PathBuf::from("/usr/lib/x86_64-linux-gnu"));
+            // Intentionally do not probe system-wide libonnxruntime locations on Linux.
+            // A stale /usr/local/lib copy can be ABI-incompatible with the `ort` version
+            // used by this binary, which caused startup panics.
         }
     }
 

--- a/next-plaid-onnx/src/lib.rs
+++ b/next-plaid-onnx/src/lib.rs
@@ -84,7 +84,13 @@ static ORT_INIT: Once = Once::new();
 /// Initialize ONNX Runtime by finding and loading the dynamic library.
 fn init_ort_runtime() {
     ORT_INIT.call_once(|| {
-        // If ORT_DYLIB_PATH is already set, ort will use it
+        #[cfg(target_os = "linux")]
+        if let Ok(path) = std::env::var("ORT_DYLIB_PATH") {
+            let _ = ort::init_from(path).map(|builder| builder.commit());
+            return;
+        }
+
+        #[cfg(not(target_os = "linux"))]
         if std::env::var("ORT_DYLIB_PATH").is_ok() {
             return;
         }
@@ -92,6 +98,8 @@ fn init_ort_runtime() {
         // Try to find ONNX Runtime in common locations
         if let Some(lib_path) = find_onnxruntime_library() {
             std::env::set_var("ORT_DYLIB_PATH", &lib_path);
+            #[cfg(target_os = "linux")]
+            let _ = ort::init_from(lib_path).map(|builder| builder.commit());
         }
     });
 }
@@ -125,10 +133,6 @@ fn find_onnxruntime_library() -> Option<String> {
         // Conda environments
         format!("{}/anaconda3/lib/libonnxruntime.so*", home),
         format!("{}/miniconda3/lib/libonnxruntime.so*", home),
-        // System locations
-        "/usr/local/lib/libonnxruntime.so*".to_string(),
-        "/usr/lib/libonnxruntime.so*".to_string(),
-        "/usr/lib/x86_64-linux-gnu/libonnxruntime.so*".to_string(),
     ];
 
     for pattern in search_patterns {


### PR DESCRIPTION
Closes: #29 

 colgrep on Linux could panic during first search or indexing when a stale system-wide ONNX Runtime library was present, even though colgrep is supposed to manage its own compatible runtime.

  On affected machines, startup reached model initialization and then failed inside the Rust ort loader with a version mismatch similar to:

  expected version >= '1.23.x', but got '1.22.0'

  The practical trigger was `/usr/local/lib/libonnxruntime.so` on Linux. colgrep discovered that library, accepted it, and ort then panicked because it was ABI-incompatible with the version expected by this build. The panic
  was especially opaque because it happened while stderr was temporarily suppressed during model setup.

  This change fixes that Linux-specific failure mode while preserving existing cross-platform behavior. The runtime discovery flow in colgrep still supports the existing cache, venv, uv, conda, and platform-specific
  lookup paths, but Linux no longer falls back to arbitrary system-wide libonnxruntime locations that can hijack startup with an incompatible version. In addition, next-plaid-onnx now performs the explicit
  ort::init_from(...) initialization only on Linux, using the already selected ORT_DYLIB_PATH, so the dynamic loader does not silently drift back to /usr/local/lib.

  The result is that Linux builds continue to use managed or user-scoped runtimes as before, but avoid crashing when an older system ONNX Runtime is installed globally. Locally, the rebuilt debug binary now completes
  search successfully and strace no longer ends with the ONNX version-mismatch panic.
