### PR TITLE
Use character-throughput ETA estimator for length-sorted encoding

### DIFF
--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -25,69 +25,41 @@ use paths::{
 };
 use state::{get_mtime, hash_file, FileInfo, IndexState};
 
-/// Estimates ETA using exponentially weighted moving average over recent batches.
-/// Gives more weight to the last ~25 iterations so the estimate adapts quickly
-/// when encoding speed changes (e.g., due to varying input lengths).
+/// Estimates ETA based on character throughput rather than item count.
+/// Since encoding time scales with text length, tracking time-per-character
+/// gives accurate estimates even when items are sorted by length.
 struct EtaEstimator {
-    /// Cumulative time from all batches (for global average fallback)
+    /// Total characters processed so far
+    total_chars: usize,
+    /// Cumulative encoding time
     total_duration: std::time::Duration,
-    /// Total items processed
-    total_processed: usize,
-    /// Ring buffer of (batch_size, batch_duration) for recent batches
-    recent: std::collections::VecDeque<(usize, std::time::Duration)>,
-    /// Sum of items in the recent window
-    recent_items: usize,
-    /// Sum of durations in the recent window
-    recent_duration: std::time::Duration,
-    /// Target number of recent items to keep
-    window_size: usize,
+    /// Total characters across all items (set once at init)
+    grand_total_chars: usize,
 }
 
 impl EtaEstimator {
-    fn new(window_size: usize) -> Self {
+    fn new(total_chars: usize) -> Self {
         Self {
+            total_chars: 0,
             total_duration: std::time::Duration::ZERO,
-            total_processed: 0,
-            recent: std::collections::VecDeque::new(),
-            recent_items: 0,
-            recent_duration: std::time::Duration::ZERO,
-            window_size,
+            grand_total_chars: total_chars,
         }
     }
 
-    fn record_batch(&mut self, count: usize, duration: std::time::Duration) {
+    fn record_batch(&mut self, batch_chars: usize, duration: std::time::Duration) {
+        self.total_chars += batch_chars;
         self.total_duration += duration;
-        self.total_processed += count;
-        self.recent.push_back((count, duration));
-        self.recent_items += count;
-        self.recent_duration += duration;
-
-        // Evict oldest entries until we're within the window
-        while self.recent_items > self.window_size && self.recent.len() > 1 {
-            if let Some((old_count, old_dur)) = self.recent.pop_front() {
-                self.recent_items -= old_count;
-                self.recent_duration -= old_dur;
-            }
-        }
     }
 
-    /// Returns ETA string like "Encoding... (2m 15s)" for the given remaining count.
-    fn eta_message(&self, remaining: usize) -> String {
-        if self.total_processed == 0 {
+    /// Returns ETA string like "Encoding... (2m 15s)" based on character throughput.
+    fn eta_message(&self) -> String {
+        if self.total_chars == 0 {
             return "Encoding...".to_string();
         }
 
-        // Blend recent rate (weight=0.7) with global rate (weight=0.3)
-        // so the estimate is responsive but not too jumpy
-        let global_rate = self.total_duration.as_secs_f64() / self.total_processed as f64;
-        let time_per_doc = if self.recent_items > 0 {
-            let recent_rate = self.recent_duration.as_secs_f64() / self.recent_items as f64;
-            0.7 * recent_rate + 0.3 * global_rate
-        } else {
-            global_rate
-        };
-
-        let eta_secs = (time_per_doc * remaining as f64) as u64;
+        let remaining_chars = self.grand_total_chars.saturating_sub(self.total_chars);
+        let time_per_char = self.total_duration.as_secs_f64() / self.total_chars as f64;
+        let eta_secs = (time_per_char * remaining_chars as f64) as u64;
         let eta_mins = eta_secs / 60;
         let eta_secs_rem = eta_secs % 60;
         if eta_mins > 0 {
@@ -894,12 +866,16 @@ impl IndexBuilder {
             self.delete_file_from_index(index_path_str, file_path)?;
         }
 
-        // Track encoding time with recency-weighted ETA (excluding write time)
-        let mut eta = EtaEstimator::new(25);
-        let mut was_interrupted = false;
-
         // Sort units by embedding text length (shortest first) to minimize padding waste
         sort_units_by_length(&mut new_units);
+
+        // Track ETA based on character throughput (accurate even with length-sorted units)
+        let total_chars: usize = new_units
+            .iter()
+            .map(|u| build_embedding_text(u).len())
+            .sum();
+        let mut eta = EtaEstimator::new(total_chars);
+        let mut was_interrupted = false;
 
         for (chunk_idx, unit_chunk) in new_units.chunks(INDEX_CHUNK_SIZE).enumerate() {
             let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
@@ -913,20 +889,18 @@ impl IndexBuilder {
                     break;
                 }
 
+                let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
                 let batch_start = std::time::Instant::now();
                 let batch_embeddings = self
                     .model()
                     .encode_documents(batch, effective_pool_factor)
                     .context("Failed to encode documents")?;
-                let batch_len = batch_embeddings.len();
-                eta.record_batch(batch_len, batch_start.elapsed());
+                eta.record_batch(batch_chars, batch_start.elapsed());
                 chunk_embeddings.extend(batch_embeddings);
 
                 let progress = chunk_idx * INDEX_CHUNK_SIZE + chunk_embeddings.len();
                 pb.set_position(progress.min(new_units.len()) as u64);
-
-                let remaining = new_units.len().saturating_sub(eta.total_processed);
-                pb.set_message(eta.eta_message(remaining));
+                pb.set_message(eta.eta_message());
             }
 
             // If interrupted during encoding, break out of chunk loop
@@ -1390,11 +1364,15 @@ impl IndexBuilder {
                 self.delete_file_from_index(index_path_str, file_path)?;
             }
 
-            // Track encoding time with recency-weighted ETA (excluding write time)
-            let mut eta = EtaEstimator::new(25);
-
             // Sort units by embedding text length (shortest first) to minimize padding waste
             sort_units_by_length(&mut new_units);
+
+            // Track ETA based on character throughput (accurate even with length-sorted units)
+            let total_chars: usize = new_units
+                .iter()
+                .map(|u| build_embedding_text(u).len())
+                .sum();
+            let mut eta = EtaEstimator::new(total_chars);
 
             for (chunk_idx, unit_chunk) in new_units.chunks(INDEX_CHUNK_SIZE).enumerate() {
                 let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
@@ -1408,20 +1386,18 @@ impl IndexBuilder {
                         break;
                     }
 
+                    let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
                     let batch_start = std::time::Instant::now();
                     let batch_embeddings = self
                         .model()
                         .encode_documents(batch, effective_pool_factor)
                         .context("Failed to encode documents")?;
-                    let batch_len = batch_embeddings.len();
-                    eta.record_batch(batch_len, batch_start.elapsed());
+                    eta.record_batch(batch_chars, batch_start.elapsed());
                     chunk_embeddings.extend(batch_embeddings);
 
                     let progress = chunk_idx * INDEX_CHUNK_SIZE + chunk_embeddings.len();
                     pb.set_position(progress.min(new_units.len()) as u64);
-
-                    let remaining = new_units.len().saturating_sub(eta.total_processed);
-                    pb.set_message(eta.eta_message(remaining));
+                    pb.set_message(eta.eta_message());
                 }
 
                 // If interrupted during encoding, break out of chunk loop
@@ -1916,13 +1892,17 @@ impl IndexBuilder {
         // Compute effective pool factor based on batch size
         let effective_pool_factor = self.effective_pool_factor(units.len());
 
-        // Track encoding time with recency-weighted ETA (excluding write time)
-        let mut eta = EtaEstimator::new(25);
-        let mut was_interrupted = false;
-
         // Sort units by embedding text length (shortest first) to minimize padding waste
         let mut sorted_units: Vec<CodeUnit> = units.to_vec();
         sort_units_by_length(&mut sorted_units);
+
+        // Track ETA based on character throughput (accurate even with length-sorted units)
+        let total_chars: usize = sorted_units
+            .iter()
+            .map(|u| build_embedding_text(u).len())
+            .sum();
+        let mut eta = EtaEstimator::new(total_chars);
+        let mut was_interrupted = false;
 
         for (chunk_idx, unit_chunk) in sorted_units.chunks(INDEX_CHUNK_SIZE).enumerate() {
             // Build embedding text for this chunk
@@ -1938,21 +1918,19 @@ impl IndexBuilder {
                     break;
                 }
 
+                let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
                 let batch_start = std::time::Instant::now();
                 let batch_embeddings = self
                     .model()
                     .encode_documents(batch, effective_pool_factor)
                     .context("Failed to encode documents")?;
-                let batch_len = batch_embeddings.len();
-                eta.record_batch(batch_len, batch_start.elapsed());
+                eta.record_batch(batch_chars, batch_start.elapsed());
                 chunk_embeddings.extend(batch_embeddings);
 
                 if let Some(ref pb) = pb {
                     let progress = chunk_idx * INDEX_CHUNK_SIZE + chunk_embeddings.len();
                     pb.set_position(progress.min(sorted_units.len()) as u64);
-
-                    let remaining = sorted_units.len().saturating_sub(eta.total_processed);
-                    pb.set_message(eta.eta_message(remaining));
+                    pb.set_message(eta.eta_message());
                 }
             }
 


### PR DESCRIPTION
When code units are sorted by length, item-count-based ETA is inaccurate because short items encode much faster than long ones. Tracking time-per-character instead gives stable, accurate estimates regardless of item ordering.