### PR TITLE
Pipeline encoding + multi-GPU indexing

### DIFF
--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -27,7 +27,7 @@ use state::{get_mtime, hash_file, FileInfo, IndexState};
 
 /// Estimates ETA based on character throughput rather than item count.
 /// Since encoding time scales with text length, tracking time-per-character
-/// gives accurate estimates even when items are sorted by length.
+/// gives more accurate estimates than counting items.
 struct EtaEstimator {
     /// Total characters processed so far
     total_chars: usize,
@@ -924,10 +924,7 @@ impl IndexBuilder {
             self.delete_file_from_index(index_path_str, file_path)?;
         }
 
-        // Sort units by embedding text length (shortest first) to minimize padding waste
-        sort_units_by_length(&mut new_units);
-
-        // Track ETA based on character throughput (accurate even with length-sorted units)
+        // Track ETA based on character throughput
         let total_chars: usize = new_units
             .iter()
             .map(|u| build_embedding_text(u).len())
@@ -1414,10 +1411,7 @@ impl IndexBuilder {
                 self.delete_file_from_index(index_path_str, file_path)?;
             }
 
-            // Sort units by embedding text length (shortest first) to minimize padding waste
-            sort_units_by_length(&mut new_units);
-
-            // Track ETA based on character throughput (accurate even with length-sorted units)
+            // Track ETA based on character throughput
             let total_chars: usize = new_units
                 .iter()
                 .map(|u| build_embedding_text(u).len())
@@ -1698,14 +1692,6 @@ pub fn path_contains_ignored_dir(path: &Path) -> Option<&'static str> {
     None
 }
 
-/// Sort code units by embedding text length (shortest first) to minimize padding waste
-/// within encoding batches. Units with similar lengths end up in the same batch,
-/// reducing the amount of padding needed. Shortest-first ordering lets users see
-/// progress on smaller units first, with larger units processed at the end.
-fn sort_units_by_length(units: &mut [CodeUnit]) {
-    units.sort_by_cached_key(|u| build_embedding_text(u).len());
-}
-
 /// Check if a path should be ignored, considering user-configured overrides.
 ///
 /// `extra_ignore` - additional patterns to ignore (on top of IGNORED_DIRS)
@@ -1940,21 +1926,14 @@ impl IndexBuilder {
         // Compute effective pool factor based on batch size
         let effective_pool_factor = self.effective_pool_factor(units.len());
 
-        // Sort units by embedding text length (shortest first) to minimize padding waste
-        let mut sorted_units: Vec<CodeUnit> = units.to_vec();
-        sort_units_by_length(&mut sorted_units);
-
-        // Track ETA based on character throughput (accurate even with length-sorted units)
-        let total_chars: usize = sorted_units
-            .iter()
-            .map(|u| build_embedding_text(u).len())
-            .sum();
+        // Track ETA based on character throughput
+        let total_chars: usize = units.iter().map(|u| build_embedding_text(u).len()).sum();
         let mut eta = EtaEstimator::new(total_chars);
         let mut was_interrupted = false;
 
         let mut pending_update: Option<std::thread::JoinHandle<Result<()>>> = None;
 
-        for (chunk_idx, unit_chunk) in sorted_units.chunks(PIPELINE_CHUNK_SIZE).enumerate() {
+        for (chunk_idx, unit_chunk) in units.chunks(PIPELINE_CHUNK_SIZE).enumerate() {
             // Build embedding text for this chunk
             let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
             let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
@@ -1979,7 +1958,7 @@ impl IndexBuilder {
 
                 if let Some(ref pb) = pb {
                     let progress = chunk_idx * PIPELINE_CHUNK_SIZE + chunk_embeddings.len();
-                    pb.set_position(progress.min(sorted_units.len()) as u64);
+                    pb.set_position(progress.min(units.len()) as u64);
                     pb.set_message(eta.eta_message());
                 }
             }


### PR DESCRIPTION
## Summary

- **Pipelined encode/index**: encoding continues on the main thread while the index write (vector index + filtering DB + FTS5) runs on a background thread
- **Multi-GPU encoding**: when multiple CUDA GPUs are available and enough units need indexing (>= 2000/GPU), chunks are automatically split across all visible GPUs and encoded in parallel
- GPU detection respects `CUDA_VISIBLE_DEVICES` — if set, only those GPUs are used; otherwise all system GPUs are available
- Adds `ColbertBuilder::with_device_id()` so ONNX sessions can target specific GPUs within the visible set

## Benchmarks (rust-analyzer, 34,872 units, 1,709 files, 8x H100)

| Version | Mean wall-clock | Speedup |
|---------|----------------|---------|
| Baseline (`main`, sequential) | 6m33s | 1.0x |
| Pipelined (single GPU) | 4m45s | 1.38x |
| **Multi-GPU (8x H100)** | **3m07s** | **2.1x** |

CPU time dropped from ~170m (baseline) to ~51m (multi-GPU), confirming encoding work is distributed across GPUs.

## Key design details

- `PIPELINE_CHUNK_SIZE = 1000` — each chunk is split evenly across GPUs via `std::thread::scope`
- `MIN_UNITS_PER_GPU = 2000` — each GPU needs enough work to justify initialization overhead
- `CriticalSectionGuard` for interrupt safety works across threads (global atomics)
- `commit_chunk_to_index()` takes only owned data — no `&self` borrow conflict with encoding
- At most one background index update at a time (waits on `JoinHandle` before spawning new one)

## Test plan

- [x] Verified all 8 GPUs show real SM utilization via `nvidia-smi dmon`
- [x] Verified `CUDA_VISIBLE_DEVICES=4,5` correctly restricts to physical GPUs 4 and 5 only
- [x] Verified single-GPU fallback for small repos (< 2000 units)
- [x] Verified search results are correct on multi-GPU built index
- [ ] Test on single-GPU machine
- [ ] Test incremental update path