### PR TITLE
Add pipelined GPU encoding, FTS5 hybrid search, and acceleration controls

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -161,6 +161,19 @@ EXAMPLES:
     # Use a specific model
     colgrep init --model lightonai/LateOn-Code-edge
 
+    # Override model/session batch size for this run
+    colgrep init --batch-size 2
+
+    # Override outer encoding batch size for benchmarking/tuning
+    colgrep init --encode-batch-size 1024
+
+    # Override outer index chunk size for benchmarking/tuning
+    colgrep init --index-chunk-size 4096
+
+    # Compare batch sort orders during encoding
+    colgrep init --batch-sort-order big-first
+    colgrep init --batch-sort-order small-first
+
 NOTES:
     • Creates a new index if none exists
     • Incrementally updates the index if files changed
@@ -502,6 +515,10 @@ pub enum Commands {
         /// Automatically confirm indexing without prompting (for large codebases > 10K code units)
         #[arg(short = 'y', long = "yes")]
         auto_confirm: bool,
+
+        /// Use strict batch-size batching instead of fixed dynamic GPU batching
+        #[arg(long = "static-batch")]
+        static_batch: bool,
     },
 
     /// Show index status for a project
@@ -556,6 +573,22 @@ pub enum Commands {
         /// Automatically confirm indexing without prompting (for large codebases > 10K code units)
         #[arg(short = 'y', long = "yes")]
         auto_confirm: bool,
+
+        /// Override model/session batch size for this run
+        #[arg(long = "batch-size", value_name = "SIZE")]
+        batch_size: Option<usize>,
+
+        /// Override outer encoding batch size for this run
+        #[arg(long = "encode-batch-size", value_name = "SIZE")]
+        encode_batch_size: Option<usize>,
+
+        /// Override outer index chunk size for this run
+        #[arg(long = "index-chunk-size", value_name = "SIZE")]
+        index_chunk_size: Option<usize>,
+
+        /// Use strict batch-size batching instead of fixed dynamic GPU batching
+        #[arg(long = "static-batch")]
+        static_batch: bool,
     },
 
     /// View or set configuration options (default k, n values)

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -6,13 +6,18 @@ use colgrep::{ensure_model, find_parent_index, index_exists, Config, IndexBuilde
 
 use crate::commands::search::{resolve_model, resolve_pool_factor};
 
-pub fn cmd_init(
-    path: &PathBuf,
-    cli_model: Option<&str>,
-    no_pool: bool,
-    pool_factor: Option<usize>,
-    auto_confirm: bool,
-) -> Result<()> {
+pub struct InitOptions<'a> {
+    pub cli_model: Option<&'a str>,
+    pub no_pool: bool,
+    pub pool_factor: Option<usize>,
+    pub auto_confirm: bool,
+    pub batch_size: Option<usize>,
+    pub encode_batch_size: Option<usize>,
+    pub index_chunk_size: Option<usize>,
+    pub static_batch: bool,
+}
+
+pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let path = std::fs::canonicalize(path)
         .map_err(|_| anyhow::anyhow!("Path does not exist: {}", path.display()))?;
 
@@ -20,13 +25,17 @@ pub fn cmd_init(
         anyhow::bail!("Path is not a directory: {}", path.display());
     }
 
-    let model = resolve_model(cli_model);
-    let pool_factor = resolve_pool_factor(pool_factor, no_pool);
+    let model = resolve_model(options.cli_model);
+    let pool_factor = resolve_pool_factor(options.pool_factor, options.no_pool);
 
     let config = Config::load().unwrap_or_default();
     let quantized = !config.use_fp32();
     let parallel_sessions = Some(config.get_parallel_sessions());
-    let batch_size = Some(config.get_batch_size());
+    let batch_size = Some(
+        options
+            .batch_size
+            .unwrap_or_else(|| config.get_batch_size()),
+    );
 
     // Check if index already exists
     let has_existing_index = index_exists(&path) || find_parent_index(&path)?.is_some();
@@ -42,8 +51,15 @@ pub fn cmd_init(
         parallel_sessions,
         batch_size,
     )?;
-    builder.set_auto_confirm(auto_confirm);
+    builder.set_auto_confirm(options.auto_confirm);
     builder.set_model_name(&model);
+    builder.set_dynamic_batch(!options.static_batch);
+    if let Some(encode_batch_size) = options.encode_batch_size {
+        builder.set_encode_batch_size(encode_batch_size.max(1));
+    }
+    if let Some(index_chunk_size) = options.index_chunk_size {
+        builder.set_index_chunk_size(index_chunk_size.max(1));
+    }
 
     let stats = builder.index(None, false)?;
 

--- a/colgrep/src/commands/mod.rs
+++ b/colgrep/src/commands/mod.rs
@@ -10,7 +10,7 @@ mod update;
 pub use clear::cmd_clear;
 pub use config::{cmd_config, cmd_set_model};
 pub use hooks::{cmd_session_hook, cmd_task_hook};
-pub use init::cmd_init;
+pub use init::{cmd_init, InitOptions};
 pub use search::cmd_search;
 pub use stats::{cmd_reset_stats, cmd_stats};
 pub use status::cmd_status;

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -377,6 +377,7 @@ pub fn cmd_search(
     alpha: Option<f32>,
     pool_factor: Option<usize>,
     auto_confirm: bool,
+    static_batch: bool,
 ) -> Result<()> {
     // Resolve context_lines: CLI > config > default (20)
     let context_lines = resolve_context_lines(cli_context_lines, 20);
@@ -406,6 +407,7 @@ pub fn cmd_search(
             alpha,
             pool_factor,
             auto_confirm,
+            static_batch,
         ) {
             Ok(results) => all_results.extend(results),
             Err(e) => {
@@ -831,6 +833,7 @@ fn search_single_path(
     alpha: Option<f32>,
     pool_factor: Option<usize>,
     auto_confirm: bool,
+    static_batch: bool,
 ) -> Result<Vec<colgrep::SearchResult>> {
     let path = match std::fs::canonicalize(path) {
         Ok(p) => p,
@@ -936,6 +939,7 @@ fn search_single_path(
         )?;
         builder.set_auto_confirm(auto_confirm);
         builder.set_model_name(&model);
+        builder.set_dynamic_batch(!static_batch);
 
         // Try non-blocking index update
         match builder.try_index(None, false) {
@@ -998,6 +1002,7 @@ fn search_single_path(
                     )?;
                     new_builder.set_auto_confirm(auto_confirm);
                     new_builder.set_model_name(&model);
+                    new_builder.set_dynamic_batch(!static_batch);
                     new_builder.index(None, false)?;
                 } else {
                     return Err(e);
@@ -1108,6 +1113,7 @@ fn search_single_path(
             )?;
             builder.set_auto_confirm(auto_confirm);
             builder.set_model_name(&model);
+            builder.set_dynamic_batch(!static_batch);
             builder.index(None, false)?;
 
             load_searcher()?

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -630,14 +630,36 @@ mod tests {
         // Verify the constant is set to 16
         assert_eq!(MAX_PARALLEL_SESSIONS_CPU, 16);
 
-        // Verify get_default_parallel_sessions returns min(cpu_count, 16)
         let sessions = get_default_parallel_sessions();
-        let cpu_count = std::thread::available_parallelism()
+        #[cfg(feature = "cuda")]
+        let expected = match env_acceleration_mode_lossy() {
+            AccelerationMode::ForceCpu => std::thread::available_parallelism()
+                .map(|p| p.get())
+                .unwrap_or(16)
+                .min(MAX_PARALLEL_SESSIONS_CPU),
+            AccelerationMode::ForceGpu => DEFAULT_PARALLEL_SESSIONS_GPU,
+            AccelerationMode::Auto => {
+                if crate::onnx_runtime::is_cudnn_available() {
+                    DEFAULT_PARALLEL_SESSIONS_GPU
+                } else {
+                    std::thread::available_parallelism()
+                        .map(|p| p.get())
+                        .unwrap_or(16)
+                        .min(MAX_PARALLEL_SESSIONS_CPU)
+                }
+            }
+        };
+        #[cfg(not(feature = "cuda"))]
+        let expected = std::thread::available_parallelism()
             .map(|p| p.get())
-            .unwrap_or(16);
-        let expected = cpu_count.min(MAX_PARALLEL_SESSIONS_CPU);
+            .unwrap_or(16)
+            .min(MAX_PARALLEL_SESSIONS_CPU);
+
         assert_eq!(sessions, expected);
-        assert!(sessions <= 16, "Sessions should never exceed 16");
+        assert!(
+            sessions <= MAX_PARALLEL_SESSIONS_CPU || sessions == DEFAULT_PARALLEL_SESSIONS_GPU,
+            "Sessions should match either the capped CPU default or the fixed GPU default"
+        );
     }
 
     #[test]

--- a/colgrep/src/embed.rs
+++ b/colgrep/src/embed.rs
@@ -2,6 +2,9 @@ use std::path::Path;
 
 use crate::parser::{CodeUnit, UnitType};
 
+const MAX_EMBEDDING_TEXT_CHARS: usize = 8 * 1024;
+const TRUNCATION_MARKER: &str = "\n[...truncated...]\n";
+
 /// Shorten a file path to keep only the filename and up to 3 parent folders.
 /// This makes paths easier for language models to encode and process.
 fn shorten_path(path: &Path) -> String {
@@ -74,12 +77,41 @@ fn normalize_path_for_embedding(path_str: &str) -> String {
     format!("{} {}", normalized, original_filename)
 }
 
+fn count_chars(s: &str) -> usize {
+    s.chars().count()
+}
+
+fn prefix_by_chars(s: &str, max_chars: usize) -> &str {
+    if max_chars == 0 {
+        return "";
+    }
+
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+fn truncate_text(text: &str, max_chars: usize) -> String {
+    if count_chars(text) <= max_chars {
+        return text.to_string();
+    }
+
+    let marker_chars = count_chars(TRUNCATION_MARKER);
+    if max_chars <= marker_chars {
+        return prefix_by_chars(TRUNCATION_MARKER, max_chars).to_string();
+    }
+
+    let kept = prefix_by_chars(text, max_chars - marker_chars).trim_end();
+    format!("{kept}{TRUNCATION_MARKER}")
+}
+
 /// Build text representation combining all 5 analysis layers.
 /// This rich text is what gets embedded by ColBERT for semantic search.
 pub fn build_embedding_text(unit: &CodeUnit) -> String {
     // For RawCode and Constant units, return just the raw code content
     if unit.unit_type == UnitType::RawCode || unit.unit_type == UnitType::Constant {
-        return unit.code.clone();
+        return truncate_text(&unit.code, MAX_EMBEDDING_TEXT_CHARS);
     }
 
     let mut parts = Vec::new();
@@ -153,18 +185,19 @@ pub fn build_embedding_text(unit: &CodeUnit) -> String {
         parts.push(format!("Uses: {}", unit.imports.join(", ")));
     }
 
+    // === File Path (shortened for better LLM encoding) ===
+    let file_part = format!(
+        "File: {}",
+        normalize_path_for_embedding(&shorten_path(&unit.file))
+    );
+    parts.push(file_part);
+
     // === Full Source Code ===
     if !unit.code.is_empty() {
         parts.push(format!("Code:\n{}", unit.code));
     }
 
-    // === File Path (shortened for better LLM encoding) ===
-    parts.push(format!(
-        "File: {}",
-        normalize_path_for_embedding(&shorten_path(&unit.file))
-    ));
-
-    parts.join("\n")
+    truncate_text(&parts.join("\n"), MAX_EMBEDDING_TEXT_CHARS)
 }
 
 #[cfg(test)]
@@ -252,6 +285,48 @@ mod tests {
     #[test]
     fn test_normalize_simple_filename() {
         assert_eq!(normalize_path_for_embedding("main.rs"), "main main.rs");
+    }
+
+    #[test]
+    fn test_build_embedding_text_truncates_raw_code_early() {
+        let mut unit = CodeUnit::new(
+            "raw".to_string(),
+            "src/huge.rs".into(),
+            1,
+            1,
+            crate::parser::Language::Rust,
+            UnitType::RawCode,
+            None,
+        );
+        unit.code = "x".repeat(MAX_EMBEDDING_TEXT_CHARS + 100);
+
+        let text = build_embedding_text(&unit);
+        assert_eq!(count_chars(&text), MAX_EMBEDDING_TEXT_CHARS);
+        assert!(text.contains("[...truncated...]"));
+    }
+
+    #[test]
+    fn test_build_embedding_text_puts_file_before_code_and_truncates_tail() {
+        let mut unit = CodeUnit::new(
+            "huge_fn".to_string(),
+            "src/some/deep/module/very_long_name.rs".into(),
+            1,
+            10,
+            crate::parser::Language::Rust,
+            UnitType::Function,
+            None,
+        );
+        unit.signature = "fn huge_fn()".to_string();
+        unit.code = "a".repeat(MAX_EMBEDDING_TEXT_CHARS + 500);
+
+        let text = build_embedding_text(&unit);
+        assert!(count_chars(&text) <= MAX_EMBEDDING_TEXT_CHARS);
+        assert!(text.contains("[...truncated...]"));
+        assert!(text.contains("File: "));
+        assert!(text.contains("File: some deep module very long name very_long_name.rs"));
+        let file_idx = text.find("File: ").unwrap();
+        let code_idx = text.find("Code:\n").unwrap();
+        assert!(file_idx < code_idx);
     }
 
     #[test]

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -1,8 +1,10 @@
 pub mod paths;
 pub mod state;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Arc};
+use std::thread;
 
 use anyhow::{Context, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -10,11 +12,18 @@ use ignore::gitignore::GitignoreBuilder;
 use ignore::WalkBuilder;
 use indicatif::{ProgressBar, ProgressStyle};
 use next_plaid::{
-    delete_from_index, filtering, IndexConfig, Metadata, MmapIndex, SearchParameters, UpdateConfig,
+    delete_from_index, encode_index_chunk, filtering, prepare_codec_artifacts,
+    write_index_from_encoded_chunks, EncodedIndexChunk, IndexConfig, Metadata, MmapIndex,
+    SearchParameters, UpdateConfig,
 };
-use next_plaid_onnx::{Colbert, ExecutionProvider};
+use next_plaid_onnx::{pool_document_embeddings, Colbert, ExecutionProvider};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use xxhash_rust::xxh3::xxh3_64;
 
+#[cfg(feature = "cuda")]
+use crate::acceleration::apply_acceleration_mode;
+use crate::acceleration::{env_acceleration_mode_lossy, AccelerationMode};
 use crate::embed::build_embedding_text;
 use crate::parser::{build_call_graph, detect_language, extract_units, CodeUnit, Language};
 use crate::signal::{is_interrupted, is_interrupted_outside_critical, CriticalSectionGuard};
@@ -25,51 +34,6 @@ use paths::{
 };
 use state::{get_mtime, hash_file, FileInfo, IndexState};
 
-/// Estimates ETA based on character throughput rather than item count.
-/// Since encoding time scales with text length, tracking time-per-character
-/// gives more accurate estimates than counting items.
-struct EtaEstimator {
-    /// Total characters processed so far
-    total_chars: usize,
-    /// Cumulative encoding time
-    total_duration: std::time::Duration,
-    /// Total characters across all items (set once at init)
-    grand_total_chars: usize,
-}
-
-impl EtaEstimator {
-    fn new(total_chars: usize) -> Self {
-        Self {
-            total_chars: 0,
-            total_duration: std::time::Duration::ZERO,
-            grand_total_chars: total_chars,
-        }
-    }
-
-    fn record_batch(&mut self, batch_chars: usize, duration: std::time::Duration) {
-        self.total_chars += batch_chars;
-        self.total_duration += duration;
-    }
-
-    /// Returns ETA string like "Encoding... (2m 15s)" based on character throughput.
-    fn eta_message(&self) -> String {
-        if self.total_chars == 0 {
-            return "Encoding...".to_string();
-        }
-
-        let remaining_chars = self.grand_total_chars.saturating_sub(self.total_chars);
-        let time_per_char = self.total_duration.as_secs_f64() / self.total_chars as f64;
-        let eta_secs = (time_per_char * remaining_chars as f64) as u64;
-        let eta_mins = eta_secs / 60;
-        let eta_secs_rem = eta_secs % 60;
-        if eta_mins > 0 {
-            format!("Encoding... ({}m {}s)", eta_mins, eta_secs_rem)
-        } else {
-            format!("Encoding... ({}s)", eta_secs)
-        }
-    }
-}
-
 /// Maximum file size to index (512 KB)
 /// Files larger than this are skipped to avoid:
 /// - Slow parsing of generated/minified code
@@ -78,9 +42,8 @@ impl EtaEstimator {
 const MAX_FILE_SIZE: u64 = 512 * 1024;
 
 /// Number of documents to process before writing to the index.
-/// After encoding a chunk, the index write is offloaded to a background thread
-/// so encoding of the next chunk can proceed in parallel.
-const PIPELINE_CHUNK_SIZE: usize = 1000;
+/// Larger values reduce I/O overhead but use more memory.
+const INDEX_CHUNK_SIZE: usize = 1024;
 
 /// Threshold for switching to higher pool factor (fewer embeddings per doc).
 /// When encoding more than this many units, use LARGE_BATCH_POOL_FACTOR.
@@ -90,10 +53,20 @@ const LARGE_BATCH_THRESHOLD: usize = 10_000;
 /// Higher value = fewer embeddings = faster indexing and smaller index.
 const LARGE_BATCH_POOL_FACTOR: usize = 2;
 
+const DEFAULT_ENCODE_BATCH_SIZE: usize = 64;
+
 /// Threshold for forcing CPU encoding even when CUDA is available.
 /// For small batches (< this many units), CPU is faster due to GPU initialization overhead.
 #[cfg(feature = "cuda")]
 const SMALL_BATCH_CPU_THRESHOLD: usize = 300;
+const POOLED_EMBEDDING_QUEUE_CAPACITY: usize = 4;
+const METADATA_QUEUE_CAPACITY: usize = 8;
+struct ParsedFileResult {
+    path: PathBuf,
+    units: Vec<CodeUnit>,
+    file_info: Option<FileInfo>,
+    skip_reason: Option<String>,
+}
 
 #[derive(Debug)]
 pub struct UpdateStats {
@@ -112,65 +85,518 @@ pub struct UpdatePlan {
     pub unchanged: usize,
 }
 
+struct SortedUnit {
+    unit: Arc<CodeUnit>,
+    text: Arc<str>,
+}
+
+struct PreparedChunk {
+    units: Vec<Arc<CodeUnit>>,
+    unique_texts: Vec<Arc<str>>,
+    original_to_unique: Vec<usize>,
+}
+
+struct TokenizedChunk {
+    units: Vec<Arc<CodeUnit>>,
+    prepared_batches: Vec<next_plaid_onnx::PreparedDocumentBatch>,
+    original_to_unique: Vec<usize>,
+}
+
+struct RawEncodedChunk {
+    units: Vec<Arc<CodeUnit>>,
+    raw_embeddings: Vec<ndarray::Array2<f32>>,
+    original_to_unique: Vec<usize>,
+}
+
+struct PooledChunkForIndex {
+    units: Vec<Arc<CodeUnit>>,
+    embeddings: Vec<ndarray::Array2<f32>>,
+}
+
+struct IndexedChunkForMetadata {
+    units: Vec<Arc<CodeUnit>>,
+    doc_ids: Vec<i64>,
+}
+
+struct ChunkPipelineConfig<'a> {
+    index_chunk_size: usize,
+    effective_pool_factor: Option<usize>,
+    index_path: &'a str,
+    config: IndexConfig,
+    update_config: UpdateConfig,
+    pb: Option<&'a ProgressBar>,
+}
+
+struct ChunkForCoding {
+    embeddings: Vec<ndarray::Array2<f32>>,
+}
+
 /// Threshold for prompting user confirmation before indexing.
 /// When encoding more than this many units, prompt the user unless auto_confirm is set.
 pub const CONFIRMATION_THRESHOLD: usize = 30_000;
 
-/// Commit a chunk of embeddings + metadata to the index on the current thread.
-/// This is the unit of work that gets offloaded to a background thread in pipelined mode.
-fn commit_chunk_to_index(
-    embeddings: Vec<ndarray::Array2<f32>>,
-    metadata: Vec<serde_json::Value>,
-    index_path: String,
-    config: IndexConfig,
-    update_config: UpdateConfig,
-    is_full_rebuild: bool,
-) -> Result<()> {
-    let _guard = CriticalSectionGuard::new();
+fn prepare_units_for_encoding(
+    units: &[CodeUnit],
+    sample_prefix_size: usize,
+) -> Vec<SortedUnit> {
+    let mut items: Vec<SortedUnit> = units
+        .iter()
+        .map(|unit| SortedUnit {
+            unit: Arc::new(unit.clone()),
+            text: Arc::<str>::from(build_embedding_text(unit)),
+        })
+        .collect();
 
-    // STEP 1: Update vector index
-    let (_, doc_ids) =
-        MmapIndex::update_or_create(&embeddings, &index_path, &config, &update_config)?;
+    // Group by parent folder, then sort by text length within each folder.
+    // This keeps related code units together (better for incremental indexing
+    // locality) while still allowing the GPU batcher to form length-homogeneous
+    // micro-batches within each folder group.
+    items.sort_unstable_by(|a, b| {
+        let dir_a = a.unit.file.parent().unwrap_or_else(|| std::path::Path::new(""));
+        let dir_b = b.unit.file.parent().unwrap_or_else(|| std::path::Path::new(""));
+        dir_a
+            .cmp(dir_b)
+            .then_with(|| a.text.len().cmp(&b.text.len()))
+    });
 
-    // STEP 2: Update filtering DB
-    let db_result = if is_full_rebuild && !filtering::exists(&index_path) {
-        filtering::create(&index_path, &metadata, &doc_ids)
-    } else {
-        filtering::update(&index_path, &metadata, &doc_ids)
-    };
-
-    if let Err(e) = db_result {
-        // ROLLBACK: Remove docs we just added to index
-        if let Err(rollback_err) = delete_from_index(&doc_ids, &index_path) {
-            eprintln!("⚠️  Rollback failed: {}", rollback_err);
-        }
-        return Err(e.into());
+    // Take a deterministic pseudo-shuffled prefix for the k-means seed so the
+    // first chunk is representative instead of biased towards one folder.
+    let sample_prefix_size = sample_prefix_size.min(items.len());
+    if sample_prefix_size > 0 {
+        items[..sample_prefix_size].sort_unstable_by_key(|item| {
+            xxh3_64(item.text.as_bytes())
+        });
     }
 
-    // STEP 3: Index metadata into FTS5 for hybrid keyword search
-    if let Err(e) = next_plaid::text_search::index(
-        &index_path,
-        &metadata,
-        &doc_ids,
-        &next_plaid::FtsTokenizer::Trigram,
-    ) {
-        eprintln!("⚠️  FTS indexing failed (non-fatal): {}", e);
+    items
+}
+
+fn prepare_deduplicated_chunk(unit_chunk: &[SortedUnit]) -> PreparedChunk {
+    let mut index_by_text: HashMap<&str, usize> = HashMap::new();
+    let mut unique_texts: Vec<Arc<str>> = Vec::new();
+    let mut original_to_unique: Vec<usize> = Vec::with_capacity(unit_chunk.len());
+
+    for item in unit_chunk.iter() {
+        if let Some(&unique_idx) = index_by_text.get(item.text.as_ref()) {
+            original_to_unique.push(unique_idx);
+        } else {
+            let unique_idx = unique_texts.len();
+            index_by_text.insert(item.text.as_ref(), unique_idx);
+            unique_texts.push(Arc::clone(&item.text));
+            original_to_unique.push(unique_idx);
+        }
+    }
+
+    PreparedChunk {
+        units: unit_chunk
+            .iter()
+            .map(|item| Arc::clone(&item.unit))
+            .collect(),
+        unique_texts,
+        original_to_unique,
+    }
+}
+
+fn run_encode_stage(
+    receiver: mpsc::Receiver<TokenizedChunk>,
+    sender: mpsc::Sender<RawEncodedChunk>,
+    model: Colbert,
+) -> Result<()> {
+    while let Ok(chunk) = receiver.recv() {
+        let raw_embeddings = model.encode_prepared_document_batches(chunk.prepared_batches)?;
+
+        sender
+            .send(RawEncodedChunk {
+                units: chunk.units,
+                raw_embeddings,
+                original_to_unique: chunk.original_to_unique,
+            })
+            .context("Failed to send raw embeddings to pooling stage")?;
     }
 
     Ok(())
 }
 
-/// Wait for a previous background index update to complete, propagating errors.
-fn wait_for_pending_update(handle: Option<std::thread::JoinHandle<Result<()>>>) -> Result<()> {
-    if let Some(h) = handle {
-        match h.join() {
-            Ok(result) => result?,
-            Err(panic_payload) => {
-                anyhow::bail!("Index update thread panicked: {:?}", panic_payload);
+fn run_tokenize_stage(
+    receiver: mpsc::Receiver<PreparedChunk>,
+    sender: mpsc::Sender<TokenizedChunk>,
+    model: Colbert,
+) -> Result<()> {
+    while let Ok(chunk) = receiver.recv() {
+        let text_refs: Vec<&str> = chunk
+            .unique_texts
+            .iter()
+            .map(|text| text.as_ref())
+            .collect();
+        let prepared_batches = model.tokenize_documents_in_batches(&text_refs)?;
+
+        sender
+            .send(TokenizedChunk {
+                units: chunk.units,
+                prepared_batches,
+                original_to_unique: chunk.original_to_unique,
+            })
+            .context("Failed to send tokenized chunk to encode stage")?;
+    }
+
+    Ok(())
+}
+
+fn run_pool_stage(
+    receiver: mpsc::Receiver<RawEncodedChunk>,
+    sender: mpsc::SyncSender<PooledChunkForIndex>,
+    effective_pool_factor: Option<usize>,
+) -> Result<()> {
+    while let Ok(chunk) = receiver.recv() {
+        let pooled_unique = pool_document_embeddings(chunk.raw_embeddings, effective_pool_factor);
+        let embeddings = chunk
+            .original_to_unique
+            .into_iter()
+            .map(|unique_idx| pooled_unique[unique_idx].clone())
+            .collect();
+
+        sender
+            .send(PooledChunkForIndex {
+                units: chunk.units,
+                embeddings,
+            })
+            .context("Failed to send pooled embeddings to index stage")?;
+    }
+
+    Ok(())
+}
+
+fn run_index_stage(
+    receiver: mpsc::Receiver<PooledChunkForIndex>,
+    sender: mpsc::SyncSender<IndexedChunkForMetadata>,
+    index_path: String,
+    config: IndexConfig,
+    update_config: UpdateConfig,
+    initial_kmeans_sample_docs: usize,
+) -> Result<()> {
+    let initial_create = !Path::new(&index_path).join("metadata.json").exists();
+
+    if initial_create {
+        let first_chunk = match receiver.recv() {
+            Ok(chunk) => chunk,
+            Err(_) => return Ok(()),
+        };
+
+        let mut next_doc_id = 0i64;
+        let mut initial_create_config = config.clone();
+        if initial_create_config.n_samples_kmeans.is_none() {
+            initial_create_config.n_samples_kmeans = Some(initial_kmeans_sample_docs.max(1));
+        }
+
+        let sample_embeddings = first_chunk.embeddings.clone();
+        let kmeans_config = initial_create_config.clone();
+        let kmeans_handle = thread::Builder::new()
+            .name("colgrep-kmeans".to_string())
+            .spawn(move || -> Result<_> {
+                let centroids = next_plaid::compute_kmeans(
+                    &sample_embeddings,
+                    &next_plaid::kmeans::ComputeKmeansConfig {
+                        kmeans_niters: kmeans_config.kmeans_niters,
+                        max_points_per_centroid: kmeans_config.max_points_per_centroid,
+                        seed: kmeans_config.seed.unwrap_or(42),
+                        n_samples_kmeans: kmeans_config.n_samples_kmeans,
+                        num_partitions: None,
+                        force_cpu: kmeans_config.force_cpu,
+                    },
+                )?;
+                Ok(prepare_codec_artifacts(
+                    &sample_embeddings,
+                    centroids,
+                    &kmeans_config,
+                )?)
+            })
+            .context("Failed to spawn kmeans stage thread")?;
+
+        let (coding_tx, coding_rx) = mpsc::sync_channel::<ChunkForCoding>(8);
+        let coding_index_path = index_path.clone();
+        let coding_config = initial_create_config.clone();
+        let coding_force_cpu = update_config.force_cpu;
+        let coding_handle = thread::Builder::new()
+            .name("colgrep-coding".to_string())
+            .spawn(move || -> Result<()> {
+                let codec_artifacts = kmeans_handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("K-means stage thread panicked"))??;
+                let mut encoded_chunks: Vec<EncodedIndexChunk> = Vec::new();
+                while let Ok(chunk) = coding_rx.recv() {
+                    let encoded = encode_index_chunk(
+                        &chunk.embeddings,
+                        &codec_artifacts.codec,
+                        coding_force_cpu,
+                    )?;
+                    encoded_chunks.push(encoded);
+                }
+                let _guard = CriticalSectionGuard::new();
+                write_index_from_encoded_chunks(
+                    &encoded_chunks,
+                    &codec_artifacts,
+                    &coding_index_path,
+                    &coding_config,
+                )?;
+                Ok(())
+            })
+            .context("Failed to spawn coding stage thread")?;
+
+        let mut handle_chunk = |chunk: PooledChunkForIndex| -> Result<()> {
+            let doc_count = chunk.embeddings.len();
+            let doc_ids: Vec<i64> = (next_doc_id..next_doc_id + doc_count as i64).collect();
+            next_doc_id += doc_count as i64;
+
+            coding_tx
+                .send(ChunkForCoding {
+                    embeddings: chunk.embeddings,
+                })
+                .context("Failed to send chunk to coding stage")?;
+
+            sender
+                .send(IndexedChunkForMetadata {
+                    units: chunk.units,
+                    doc_ids,
+                })
+                .context("Failed to send indexed chunk to metadata stage")
+        };
+
+        handle_chunk(first_chunk)?;
+        while let Ok(chunk) = receiver.recv() {
+            handle_chunk(chunk)?;
+        }
+        drop(coding_tx);
+        coding_handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("Coding stage thread panicked"))??;
+        return Ok(());
+    }
+
+    while let Ok(chunk) = receiver.recv() {
+        let _guard = CriticalSectionGuard::new();
+        let (_, doc_ids) =
+            MmapIndex::update_or_create(&chunk.embeddings, &index_path, &config, &update_config)?;
+
+        sender
+            .send(IndexedChunkForMetadata {
+                units: chunk.units,
+                doc_ids,
+            })
+            .context("Failed to send indexed chunk to metadata stage")?;
+    }
+
+    Ok(())
+}
+
+fn run_metadata_stage(
+    receiver: mpsc::Receiver<IndexedChunkForMetadata>,
+    index_path: String,
+    pb: Option<ProgressBar>,
+) -> Result<()> {
+    let mut filtering_exists = filtering::exists(&index_path);
+    let mut completed_units = 0u64;
+
+    while let Ok(chunk) = receiver.recv() {
+        let metadata: Vec<serde_json::Value> = chunk
+            .units
+            .iter()
+            .map(|unit| serde_json::to_value(unit.as_ref()).unwrap())
+            .collect();
+        let db_result = if filtering_exists {
+            filtering::update(&index_path, &metadata, &chunk.doc_ids)
+        } else {
+            filtering::create(&index_path, &metadata, &chunk.doc_ids)
+        };
+
+        if let Err(e) = db_result {
+            if let Err(rollback_err) = delete_from_index(&chunk.doc_ids, &index_path) {
+                eprintln!("⚠️  Rollback failed: {}", rollback_err);
             }
+            return Err(e.into());
+        }
+
+        if let Err(e) = next_plaid::text_search::index(
+            &index_path,
+            &metadata,
+            &chunk.doc_ids,
+            &next_plaid::FtsTokenizer::Trigram,
+        ) {
+            eprintln!("⚠️  FTS indexing failed (non-fatal): {}", e);
+        }
+
+        filtering_exists = true;
+        completed_units += chunk.units.len() as u64;
+        if let Some(pb) = pb.as_ref() {
+            pb.set_position(completed_units);
         }
     }
+
     Ok(())
+}
+
+fn run_chunk_pipeline(
+    model: Colbert,
+    sorted_units: &[SortedUnit],
+    pipeline: ChunkPipelineConfig<'_>,
+) -> Result<bool> {
+    let mut was_interrupted = false;
+    let ChunkPipelineConfig {
+        index_chunk_size,
+        effective_pool_factor,
+        index_path,
+        config,
+        update_config,
+        pb,
+    } = pipeline;
+
+    let (tokenize_tx, tokenize_rx) = mpsc::channel::<PreparedChunk>();
+    let (encode_tx, encode_rx) = mpsc::channel::<TokenizedChunk>();
+    let (pool_tx, pool_rx) = mpsc::channel::<RawEncodedChunk>();
+    let (index_tx, index_rx) =
+        mpsc::sync_channel::<PooledChunkForIndex>(POOLED_EMBEDDING_QUEUE_CAPACITY);
+    let (metadata_tx, metadata_rx) =
+        mpsc::sync_channel::<IndexedChunkForMetadata>(METADATA_QUEUE_CAPACITY);
+
+    let tokenize_model = model.clone();
+    let tokenize_handle = thread::Builder::new()
+        .name("colgrep-tokenize".to_string())
+        .spawn(move || run_tokenize_stage(tokenize_rx, encode_tx, tokenize_model))
+        .context("Failed to spawn tokenize stage thread")?;
+    let encode_model = model.clone();
+    let encode_handle = thread::Builder::new()
+        .name("colgrep-encode".to_string())
+        .spawn(move || run_encode_stage(encode_rx, pool_tx, encode_model))
+        .context("Failed to spawn encode stage thread")?;
+    let pool_handle = thread::Builder::new()
+        .name("colgrep-pool".to_string())
+        .spawn(move || run_pool_stage(pool_rx, index_tx, effective_pool_factor))
+        .context("Failed to spawn pool stage thread")?;
+    let index_path_for_index = index_path.to_string();
+    let index_handle = thread::Builder::new()
+        .name("colgrep-index".to_string())
+        .spawn(move || {
+            run_index_stage(
+                index_rx,
+                metadata_tx,
+                index_path_for_index,
+                config,
+                update_config,
+                index_chunk_size,
+            )
+        })
+        .context("Failed to spawn index stage thread")?;
+    let index_path_for_metadata = index_path.to_string();
+    let metadata_pb = pb.cloned();
+    let metadata_handle = thread::Builder::new()
+        .name("colgrep-metadata".to_string())
+        .spawn(move || run_metadata_stage(metadata_rx, index_path_for_metadata, metadata_pb))
+        .context("Failed to spawn metadata stage thread")?;
+
+    for unit_chunk in sorted_units.chunks(index_chunk_size) {
+        if is_interrupted_outside_critical() {
+            was_interrupted = true;
+            break;
+        }
+
+        let prepared = prepare_deduplicated_chunk(unit_chunk);
+
+        tokenize_tx
+            .send(prepared)
+            .context("Failed to send prepared chunk to tokenize stage")?;
+    }
+
+    drop(tokenize_tx);
+
+    tokenize_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Tokenize stage thread panicked"))??;
+    encode_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Encode stage thread panicked"))??;
+    pool_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Pool stage thread panicked"))??;
+    index_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Index stage thread panicked"))??;
+    metadata_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Metadata stage thread panicked"))??;
+
+    Ok(was_interrupted)
+}
+
+fn parse_files_parallel(
+    project_root: &Path,
+    paths: &[PathBuf],
+    pb: Option<&ProgressBar>,
+) -> Vec<ParsedFileResult> {
+    let progress = pb.cloned();
+
+    paths
+        .par_iter()
+        .map(|path| {
+            let full_path = project_root.join(path);
+            let result = match detect_language(&full_path) {
+                Some(lang) => match std::fs::read_to_string(&full_path) {
+                    Ok(source) => {
+                        let units = extract_units(path, &source, lang);
+                        match hash_file(&full_path) {
+                            Ok(content_hash) => match get_mtime(&full_path) {
+                                Ok(mtime) => ParsedFileResult {
+                                    path: path.clone(),
+                                    units,
+                                    file_info: Some(FileInfo {
+                                        content_hash,
+                                        mtime,
+                                    }),
+                                    skip_reason: None,
+                                },
+                                Err(e) => ParsedFileResult {
+                                    path: path.clone(),
+                                    units: Vec::new(),
+                                    file_info: None,
+                                    skip_reason: Some(format!(
+                                        "Skipping {} ({})",
+                                        full_path.display(),
+                                        e
+                                    )),
+                                },
+                            },
+                            Err(e) => ParsedFileResult {
+                                path: path.clone(),
+                                units: Vec::new(),
+                                file_info: None,
+                                skip_reason: Some(format!(
+                                    "Skipping {} ({})",
+                                    full_path.display(),
+                                    e
+                                )),
+                            },
+                        }
+                    }
+                    Err(e) => ParsedFileResult {
+                        path: path.clone(),
+                        units: Vec::new(),
+                        file_info: None,
+                        skip_reason: Some(format!("Skipping {} ({})", full_path.display(), e)),
+                    },
+                },
+                None => ParsedFileResult {
+                    path: path.clone(),
+                    units: Vec::new(),
+                    file_info: None,
+                    skip_reason: None,
+                },
+            };
+
+            if let Some(pb) = &progress {
+                pb.inc(1);
+            }
+
+            result
+        })
+        .collect()
 }
 
 pub struct IndexBuilder {
@@ -184,6 +610,9 @@ pub struct IndexBuilder {
     project_root: PathBuf,
     index_dir: PathBuf,
     pool_factor: Option<usize>,
+    encode_batch_size: Option<usize>,
+    index_chunk_size: Option<usize>,
+    dynamic_batch: bool,
     /// If true, skip user confirmation for large indexes
     auto_confirm: bool,
     /// Model name/id for display (e.g., "lightonai/LateOn-Code-edge")
@@ -219,6 +648,9 @@ impl IndexBuilder {
             project_root: project_root.to_path_buf(),
             index_dir,
             pool_factor,
+            encode_batch_size: None,
+            index_chunk_size: None,
+            dynamic_batch: true,
             auto_confirm: false, // Prompt by default for large indexes
             model_name: None,
         })
@@ -234,6 +666,18 @@ impl IndexBuilder {
         self.model_name = Some(name.to_string());
     }
 
+    pub fn set_encode_batch_size(&mut self, encode_batch_size: usize) {
+        self.encode_batch_size = Some(encode_batch_size.max(1));
+    }
+
+    pub fn set_index_chunk_size(&mut self, index_chunk_size: usize) {
+        self.index_chunk_size = Some(index_chunk_size.max(1));
+    }
+
+    pub fn set_dynamic_batch(&mut self, dynamic_batch: bool) {
+        self.dynamic_batch = dynamic_batch;
+    }
+
     /// Ensure the model is created for encoding.
     /// The model is lazily created on first use to avoid overhead when just scanning files
     /// or when checking for index updates that have no changes.
@@ -244,64 +688,82 @@ impl IndexBuilder {
     ///   available, as GPU initialization overhead outweighs the benefits for small workloads.
     fn ensure_model_created(&mut self, num_units: usize) -> Result<()> {
         if self.model.is_none() {
-            // Use CUDA-optimized settings when CUDA feature is enabled AND cuDNN is available:
-            // - 1 session (GPUs work best with single session)
-            // - 64 batch size (GPUs benefit from larger batches)
-            // - CUDA execution provider for GPU acceleration
-            // Otherwise use CPU-optimized settings:
-            // - min(CPU count, 8) sessions (capped for high-core systems)
-            // - 1 batch size (works better with parallel sessions)
-            // - CPU execution provider
-            //
-            // Special case: For small batches (< SMALL_BATCH_CPU_THRESHOLD), force CPU
-            // even when CUDA is available to avoid GPU initialization overhead.
+            #[cfg(feature = "cuda")]
+            let acceleration_mode = env_acceleration_mode_lossy();
+
             #[cfg(feature = "cuda")]
             let (num_sessions, execution_provider) = {
-                // Force CPU for small batches to avoid GPU initialization overhead
-                // IMPORTANT: Check force_cpu FIRST before any CUDA availability checks
-                // to avoid CUDA driver initialization overhead for small batches.
-                let force_cpu = num_units < SMALL_BATCH_CPU_THRESHOLD;
+                match acceleration_mode {
+                    AccelerationMode::ForceCpu => {
+                        apply_acceleration_mode(AccelerationMode::ForceCpu);
+                        crate::onnx_runtime::ensure_onnx_runtime()
+                            .context("Failed to initialize ONNX Runtime")?;
 
-                // For small batches, set COLGREP_FORCE_CPU="1" to prevent CUDA initialization.
-                // For large batches, remove COLGREP_FORCE_CPU to allow GPU access.
-                // This is much faster than using a separate CPU-only library because the GPU
-                // ONNX Runtime will immediately fall back to CPU when force_cpu is set.
-                if force_cpu {
-                    std::env::set_var("COLGREP_FORCE_CPU", "1");
-                } else {
-                    // Restore CUDA access for large batches
-                    std::env::remove_var("COLGREP_FORCE_CPU");
-                }
+                        (
+                            self.parallel_sessions.unwrap_or_else(|| {
+                                let cpu_count = std::thread::available_parallelism()
+                                    .map(|p| p.get())
+                                    .unwrap_or(8);
+                                cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
+                            }),
+                            ExecutionProvider::Cpu,
+                        )
+                    }
+                    AccelerationMode::ForceGpu => {
+                        apply_acceleration_mode(AccelerationMode::ForceGpu);
+                        crate::onnx_runtime::ensure_onnx_runtime()
+                            .context("Failed to initialize ONNX Runtime")?;
 
-                // Initialize ONNX Runtime
-                crate::onnx_runtime::ensure_onnx_runtime()
-                    .context("Failed to initialize ONNX Runtime")?;
+                        if !crate::onnx_runtime::is_cudnn_available() {
+                            anyhow::bail!("FORCE_GPU is set, but cuDNN was not initialized");
+                        }
 
-                // Only check CUDA availability if we're not forcing CPU
-                // The is_cuda_available() call may trigger CUDA driver init, so skip it for small batches
-                let use_cuda = !force_cpu && {
-                    // Check both cuDNN (for LD_LIBRARY_PATH) and CUDA EP availability
-                    let cudnn_available = crate::onnx_runtime::is_cudnn_available();
-                    let cuda_available = next_plaid_onnx::is_cuda_available();
-                    cudnn_available && cuda_available
-                };
+                        if !next_plaid_onnx::is_cuda_available() {
+                            anyhow::bail!(
+                                "FORCE_GPU is set, but the CUDA execution provider was not initialized"
+                            );
+                        }
 
-                if use_cuda {
-                    (
-                        self.parallel_sessions
-                            .unwrap_or(crate::config::DEFAULT_PARALLEL_SESSIONS_GPU),
-                        ExecutionProvider::Cuda,
-                    )
-                } else {
-                    (
-                        self.parallel_sessions.unwrap_or_else(|| {
-                            let cpu_count = std::thread::available_parallelism()
-                                .map(|p| p.get())
-                                .unwrap_or(8);
-                            cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
-                        }),
-                        ExecutionProvider::Cpu,
-                    )
+                        (
+                            self.parallel_sessions
+                                .unwrap_or(crate::config::DEFAULT_PARALLEL_SESSIONS_GPU),
+                            ExecutionProvider::Cuda,
+                        )
+                    }
+                    AccelerationMode::Auto => {
+                        let force_cpu = num_units < SMALL_BATCH_CPU_THRESHOLD;
+                        if force_cpu {
+                            apply_acceleration_mode(AccelerationMode::ForceCpu);
+                        } else {
+                            apply_acceleration_mode(AccelerationMode::Auto);
+                        }
+
+                        crate::onnx_runtime::ensure_onnx_runtime()
+                            .context("Failed to initialize ONNX Runtime")?;
+
+                        let use_cuda = !force_cpu && {
+                            crate::onnx_runtime::is_cudnn_available()
+                                && next_plaid_onnx::is_cuda_available()
+                        };
+
+                        if use_cuda {
+                            (
+                                self.parallel_sessions
+                                    .unwrap_or(crate::config::DEFAULT_PARALLEL_SESSIONS_GPU),
+                                ExecutionProvider::Cuda,
+                            )
+                        } else {
+                            (
+                                self.parallel_sessions.unwrap_or_else(|| {
+                                    let cpu_count = std::thread::available_parallelism()
+                                        .map(|p| p.get())
+                                        .unwrap_or(8);
+                                    cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
+                                }),
+                                ExecutionProvider::Cpu,
+                            )
+                        }
+                    }
                 }
             };
             #[cfg(not(feature = "cuda"))]
@@ -344,6 +806,7 @@ impl IndexBuilder {
                         .with_quantized(self.quantized)
                         .with_parallel(num_sessions)
                         .with_batch_size(batch)
+                        .with_dynamic_batch(self.dynamic_batch)
                         .with_execution_provider(execution_provider)
                         .build()
                 })
@@ -376,15 +839,11 @@ impl IndexBuilder {
 
     /// Compute the effective pool factor based on the number of units to encode.
     ///
-    /// - For large batches (> 10,000 units): use pool_factor = 3 for faster indexing
-    /// - For small batches (≤ 300 units): use the configured default pool factor
-    /// - Otherwise: use the configured pool factor
+    /// For large runs, forced pooling materially reduces downstream index cost.
     fn effective_pool_factor(&self, num_units: usize) -> Option<usize> {
         if num_units > LARGE_BATCH_THRESHOLD {
-            // Large batch: use higher pool factor for efficiency
             Some(LARGE_BATCH_POOL_FACTOR)
         } else {
-            // Use configured pool factor
             self.pool_factor
         }
     }
@@ -827,44 +1286,17 @@ impl IndexBuilder {
         pb.enable_steady_tick(std::time::Duration::from_millis(100));
         pb.set_message("Parsing files...");
 
-        for path in &files_to_index {
-            let full_path = self.project_root.join(path);
-            let lang = match detect_language(&full_path) {
-                Some(l) => l,
-                None => {
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            let source = match std::fs::read_to_string(&full_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    new_state.ignored_files.insert(path.clone());
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            let units = extract_units(path, &source, lang);
-            new_units.extend(units);
+        for parsed in parse_files_parallel(&self.project_root, &files_to_index, Some(&pb)) {
+            if let Some(reason) = parsed.skip_reason {
+                eprintln!("⚠️  {}", reason);
+                new_state.ignored_files.insert(parsed.path);
+                continue;
+            }
 
-            let content_hash = match hash_file(&full_path) {
-                Ok(h) => h,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    new_state.ignored_files.insert(path.clone());
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            new_state.files.insert(
-                path.clone(),
-                FileInfo {
-                    content_hash,
-                    mtime: get_mtime(&full_path)?,
-                },
-            );
-            pb.inc(1);
+            new_units.extend(parsed.units);
+            if let Some(file_info) = parsed.file_info {
+                new_state.files.insert(parsed.path, file_info);
+            }
         }
         pb.finish_and_clear();
 
@@ -897,11 +1329,7 @@ impl IndexBuilder {
         // Create or update index
         std::fs::create_dir_all(&index_path)?;
 
-        // Force CPU for K-means when batch is small to avoid GPU initialization overhead
-        #[cfg(feature = "cuda")]
-        let force_cpu = new_units.len() < SMALL_BATCH_CPU_THRESHOLD;
-        #[cfg(not(feature = "cuda"))]
-        let force_cpu = false;
+        let force_cpu = next_plaid::is_force_cpu();
 
         let config = IndexConfig {
             force_cpu,
@@ -912,7 +1340,11 @@ impl IndexBuilder {
             ..Default::default()
         };
 
-        let encode_batch_size = 64;
+        let encode_batch_size = self.encode_batch_size.unwrap_or(DEFAULT_ENCODE_BATCH_SIZE);
+        let index_chunk_size = self
+            .index_chunk_size
+            .unwrap_or(INDEX_CHUNK_SIZE)
+            .max(encode_batch_size);
 
         // Compute effective pool factor based on batch size
         let effective_pool_factor = self.effective_pool_factor(new_units.len());
@@ -924,66 +1356,23 @@ impl IndexBuilder {
             self.delete_file_from_index(index_path_str, file_path)?;
         }
 
-        // Track ETA based on character throughput
-        let total_chars: usize = new_units
-            .iter()
-            .map(|u| build_embedding_text(u).len())
-            .sum();
-        let mut eta = EtaEstimator::new(total_chars);
-        let mut was_interrupted = false;
-        let mut pending_update: Option<std::thread::JoinHandle<Result<()>>> = None;
-
-        for (chunk_idx, unit_chunk) in new_units.chunks(PIPELINE_CHUNK_SIZE).enumerate() {
-            let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
-            let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-
-            let mut chunk_embeddings = Vec::new();
-            for batch in text_refs.chunks(encode_batch_size) {
-                // Check for interrupt before each encoding batch (immediate response)
-                if is_interrupted_outside_critical() {
-                    was_interrupted = true;
-                    break;
-                }
-
-                let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
-                let batch_start = std::time::Instant::now();
-                let batch_embeddings = self
-                    .model()
-                    .encode_documents(batch, effective_pool_factor)
-                    .context("Failed to encode documents")?;
-                eta.record_batch(batch_chars, batch_start.elapsed());
-                chunk_embeddings.extend(batch_embeddings);
-
-                let progress = chunk_idx * PIPELINE_CHUNK_SIZE + chunk_embeddings.len();
-                pb.set_position(progress.min(new_units.len()) as u64);
-                pb.set_message(eta.eta_message());
-            }
-
-            // If interrupted during encoding, break out of chunk loop
-            if was_interrupted {
-                break;
-            }
-
-            // Wait for previous index update before starting a new one
-            wait_for_pending_update(pending_update.take())?;
-
-            // Prepare owned data for background thread
-            let metadata: Vec<serde_json::Value> = unit_chunk
-                .iter()
-                .map(|u| serde_json::to_value(u).unwrap())
-                .collect();
-            let idx_path = index_path_str.to_string();
-            let cfg = config.clone();
-            let ucfg = update_config.clone();
-
-            // Spawn background index update — encoding continues on main thread
-            pending_update = Some(std::thread::spawn(move || {
-                commit_chunk_to_index(chunk_embeddings, metadata, idx_path, cfg, ucfg, true)
-            }));
-        }
-
-        // Wait for final index update to complete
-        wait_for_pending_update(pending_update.take())?;
+        let sorted_units = prepare_units_for_encoding(
+            &new_units,
+            index_chunk_size,
+        );
+        self.ensure_model_created(new_units.len())?;
+        let was_interrupted = run_chunk_pipeline(
+            self.model().clone(),
+            &sorted_units,
+            ChunkPipelineConfig {
+                index_chunk_size,
+                effective_pool_factor,
+                index_path: index_path_str,
+                config,
+                update_config,
+                pb: Some(&pb),
+            },
+        )?;
 
         pb.finish_and_clear();
 
@@ -1050,52 +1439,19 @@ impl IndexBuilder {
         pb.set_message("Parsing files...");
 
         // Extract units from all files
-        let mut parsing_interrupted = false;
-        for path in &files {
-            // Check for interrupt during parsing
-            if is_interrupted() {
-                parsing_interrupted = true;
-                break;
+        for parsed in parse_files_parallel(&self.project_root, &files, Some(&pb)) {
+            if let Some(reason) = parsed.skip_reason {
+                eprintln!("⚠️  {}", reason);
+                state.ignored_files.insert(parsed.path);
+                continue;
             }
 
-            let full_path = self.project_root.join(path);
-            let lang = match detect_language(&full_path) {
-                Some(l) => l,
-                None => {
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            let source = match std::fs::read_to_string(&full_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    state.ignored_files.insert(path.clone());
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            let units = extract_units(path, &source, lang);
-            all_units.extend(units);
-
-            let content_hash = match hash_file(&full_path) {
-                Ok(h) => h,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    state.ignored_files.insert(path.clone());
-                    pb.inc(1);
-                    continue;
-                }
-            };
-            state.files.insert(
-                path.clone(),
-                FileInfo {
-                    content_hash,
-                    mtime: get_mtime(&full_path)?,
-                },
-            );
-            pb.inc(1);
+            all_units.extend(parsed.units);
+            if let Some(file_info) = parsed.file_info {
+                state.files.insert(parsed.path, file_info);
+            }
         }
+        let parsing_interrupted = is_interrupted();
         pb.finish_and_clear();
 
         if parsing_interrupted {
@@ -1187,7 +1543,7 @@ impl IndexBuilder {
         let index_path = get_vector_index_path(&self.index_dir);
         let index_path_str = index_path.to_str().unwrap();
 
-        // Repair desync only if last operation was interrupted (dirty flag set)
+        // Repair desync only if the previous run was interrupted mid-write.
         if old_state.dirty {
             if let Err(e) = self.repair_index_db_sync(&index_path) {
                 eprintln!("⚠️  Repair failed: {}, falling back to full rebuild", e);
@@ -1196,15 +1552,8 @@ impl IndexBuilder {
         }
 
         // 0. Clean up orphaned entries (files in index but not on disk)
-        // This is expensive on large repos (fetches all metadata from SQLite),
-        // so only run when deletions were detected or periodically as a safety net.
-        let should_cleanup = !plan.deleted.is_empty()
-            || (old_state.search_count > 0 && old_state.search_count.is_multiple_of(50));
-        let orphaned_deleted = if should_cleanup {
-            self.cleanup_orphaned_entries(index_path_str)?
-        } else {
-            0
-        };
+        // This handles directory deletion/rename and any inconsistencies
+        let orphaned_deleted = self.cleanup_orphaned_entries(index_path_str)?;
 
         // Nothing to do
         if plan.added.is_empty()
@@ -1223,7 +1572,6 @@ impl IndexBuilder {
 
         let mut state = old_state.clone();
 
-        // Mark state as dirty before any index modifications
         if !plan.deleted.is_empty() || !plan.changed.is_empty() || !plan.added.is_empty() {
             state.dirty = true;
             state.save(&self.index_dir)?;
@@ -1278,65 +1626,22 @@ impl IndexBuilder {
             None
         };
 
-        let mut parsing_interrupted = false;
         let mut skipped_files: Vec<PathBuf> = Vec::new();
-        for path in &files_to_index {
-            // Check for interrupt during parsing
-            if is_interrupted() {
-                parsing_interrupted = true;
-                break;
+        for parsed in parse_files_parallel(&self.project_root, &files_to_index, pb.as_ref()) {
+            if let Some(reason) = parsed.skip_reason {
+                eprintln!("⚠️  {}", reason);
+                state.files.remove(&parsed.path);
+                state.ignored_files.insert(parsed.path.clone());
+                skipped_files.push(parsed.path);
+                continue;
             }
 
-            let full_path = self.project_root.join(path);
-            let lang = match detect_language(&full_path) {
-                Some(l) => l,
-                None => {
-                    if let Some(ref pb) = pb {
-                        pb.inc(1);
-                    }
-                    continue;
-                }
-            };
-            let source = match std::fs::read_to_string(&full_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    state.files.remove(path);
-                    state.ignored_files.insert(path.clone());
-                    skipped_files.push(path.clone());
-                    if let Some(ref pb) = pb {
-                        pb.inc(1);
-                    }
-                    continue;
-                }
-            };
-            let units = extract_units(path, &source, lang);
-            new_units.extend(units);
-
-            let content_hash = match hash_file(&full_path) {
-                Ok(h) => h,
-                Err(e) => {
-                    eprintln!("⚠️  Skipping {} ({})", full_path.display(), e);
-                    state.files.remove(path);
-                    state.ignored_files.insert(path.clone());
-                    skipped_files.push(path.clone());
-                    if let Some(ref pb) = pb {
-                        pb.inc(1);
-                    }
-                    continue;
-                }
-            };
-            state.files.insert(
-                path.clone(),
-                FileInfo {
-                    content_hash,
-                    mtime: get_mtime(&full_path)?,
-                },
-            );
-            if let Some(ref pb) = pb {
-                pb.inc(1);
+            new_units.extend(parsed.units);
+            if let Some(file_info) = parsed.file_info {
+                state.files.insert(parsed.path, file_info);
             }
         }
+        let parsing_interrupted = is_interrupted();
         if let Some(pb) = pb {
             pb.finish_and_clear();
         }
@@ -1384,11 +1689,7 @@ impl IndexBuilder {
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
             pb.set_message("Encoding...");
 
-            // Force CPU for K-means when batch is small to avoid GPU initialization overhead
-            #[cfg(feature = "cuda")]
-            let force_cpu = new_units.len() < SMALL_BATCH_CPU_THRESHOLD;
-            #[cfg(not(feature = "cuda"))]
-            let force_cpu = false;
+            let force_cpu = next_plaid::is_force_cpu();
 
             let config = IndexConfig {
                 force_cpu,
@@ -1399,7 +1700,11 @@ impl IndexBuilder {
                 ..Default::default()
             };
 
-            let encode_batch_size = 64;
+            let encode_batch_size = self.encode_batch_size.unwrap_or(DEFAULT_ENCODE_BATCH_SIZE);
+            let index_chunk_size = self
+                .index_chunk_size
+                .unwrap_or(INDEX_CHUNK_SIZE)
+                .max(encode_batch_size);
 
             // Compute effective pool factor based on batch size
             let effective_pool_factor = self.effective_pool_factor(new_units.len());
@@ -1411,66 +1716,24 @@ impl IndexBuilder {
                 self.delete_file_from_index(index_path_str, file_path)?;
             }
 
-            // Track ETA based on character throughput
-            let total_chars: usize = new_units
-                .iter()
-                .map(|u| build_embedding_text(u).len())
-                .sum();
-            let mut eta = EtaEstimator::new(total_chars);
-
-            let mut pending_update: Option<std::thread::JoinHandle<Result<()>>> = None;
-
-            for (chunk_idx, unit_chunk) in new_units.chunks(PIPELINE_CHUNK_SIZE).enumerate() {
-                let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
-                let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-
-                let mut chunk_embeddings = Vec::new();
-                for batch in text_refs.chunks(encode_batch_size) {
-                    // Check for interrupt before each encoding batch (immediate response)
-                    if is_interrupted_outside_critical() {
-                        was_interrupted = true;
-                        break;
-                    }
-
-                    let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
-                    let batch_start = std::time::Instant::now();
-                    let batch_embeddings = self
-                        .model()
-                        .encode_documents(batch, effective_pool_factor)
-                        .context("Failed to encode documents")?;
-                    eta.record_batch(batch_chars, batch_start.elapsed());
-                    chunk_embeddings.extend(batch_embeddings);
-
-                    let progress = chunk_idx * PIPELINE_CHUNK_SIZE + chunk_embeddings.len();
-                    pb.set_position(progress.min(new_units.len()) as u64);
-                    pb.set_message(eta.eta_message());
-                }
-
-                // If interrupted during encoding, break out of chunk loop
-                if was_interrupted {
-                    break;
-                }
-
-                // Wait for previous index update before starting a new one
-                wait_for_pending_update(pending_update.take())?;
-
-                // Prepare owned data for background thread
-                let metadata: Vec<serde_json::Value> = unit_chunk
-                    .iter()
-                    .map(|u| serde_json::to_value(u).unwrap())
-                    .collect();
-                let idx_path = index_path_str.to_string();
-                let cfg = config.clone();
-                let ucfg = update_config.clone();
-
-                // Spawn background index update — encoding continues on main thread
-                pending_update = Some(std::thread::spawn(move || {
-                    commit_chunk_to_index(chunk_embeddings, metadata, idx_path, cfg, ucfg, false)
-                }));
-            }
-
-            // Wait for final index update to complete
-            wait_for_pending_update(pending_update.take())?;
+            let sorted_units = prepare_units_for_encoding(
+                &new_units,
+                index_chunk_size,
+            );
+            self.ensure_model_created(new_units.len())?;
+            let pipeline_interrupted = run_chunk_pipeline(
+                self.model().clone(),
+                &sorted_units,
+                ChunkPipelineConfig {
+                    index_chunk_size,
+                    effective_pool_factor,
+                    index_path: index_path_str,
+                    config,
+                    update_config,
+                    pb: Some(&pb),
+                },
+            )?;
+            was_interrupted |= pipeline_interrupted;
 
             pb.finish_and_clear();
         }
@@ -1478,11 +1741,9 @@ impl IndexBuilder {
         if was_interrupted || is_interrupted() {
             // Don't save state — the index has partial data. Next run will detect
             // the mismatch and re-index the missing files.
-            // dirty flag remains true so next run will repair.
             anyhow::bail!("Indexing interrupted by user");
         }
 
-        // Clear dirty flag — index is consistent
         state.dirty = false;
         state.save(&self.index_dir)?;
 
@@ -1782,17 +2043,6 @@ impl IndexBuilder {
                 continue;
             }
             let full_path = self.project_root.join(path);
-
-            // Fast path: if mtime is unchanged, skip expensive content hashing
-            if let Some(info) = state.files.get(path) {
-                if let Ok(current_mtime) = get_mtime(&full_path) {
-                    if info.mtime == current_mtime {
-                        plan.unchanged += 1;
-                        continue;
-                    }
-                }
-            }
-
             let hash = match hash_file(&full_path) {
                 Ok(h) => h,
                 Err(e) => {
@@ -1906,11 +2156,7 @@ impl IndexBuilder {
             None
         };
 
-        // Force CPU for K-means when batch is small to avoid GPU initialization overhead
-        #[cfg(feature = "cuda")]
-        let force_cpu = units.len() < SMALL_BATCH_CPU_THRESHOLD;
-        #[cfg(not(feature = "cuda"))]
-        let force_cpu = false;
+        let force_cpu = next_plaid::is_force_cpu();
 
         let config = IndexConfig {
             force_cpu,
@@ -1921,73 +2167,32 @@ impl IndexBuilder {
             ..Default::default()
         };
 
-        let encode_batch_size = 64;
+        let encode_batch_size = self.encode_batch_size.unwrap_or(DEFAULT_ENCODE_BATCH_SIZE);
+        let index_chunk_size = self
+            .index_chunk_size
+            .unwrap_or(INDEX_CHUNK_SIZE)
+            .max(encode_batch_size);
 
         // Compute effective pool factor based on batch size
         let effective_pool_factor = self.effective_pool_factor(units.len());
 
-        // Track ETA based on character throughput
-        let total_chars: usize = units.iter().map(|u| build_embedding_text(u).len()).sum();
-        let mut eta = EtaEstimator::new(total_chars);
-        let mut was_interrupted = false;
-
-        let mut pending_update: Option<std::thread::JoinHandle<Result<()>>> = None;
-
-        for (chunk_idx, unit_chunk) in units.chunks(PIPELINE_CHUNK_SIZE).enumerate() {
-            // Build embedding text for this chunk
-            let texts: Vec<String> = unit_chunk.iter().map(build_embedding_text).collect();
-            let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-
-            // Encode in smaller batches within the chunk
-            let mut chunk_embeddings = Vec::new();
-            for batch in text_refs.chunks(encode_batch_size) {
-                // Check for interrupt before each encoding batch (immediate response)
-                if is_interrupted_outside_critical() {
-                    was_interrupted = true;
-                    break;
-                }
-
-                let batch_chars: usize = batch.iter().map(|s| s.len()).sum();
-                let batch_start = std::time::Instant::now();
-                let batch_embeddings = self
-                    .model()
-                    .encode_documents(batch, effective_pool_factor)
-                    .context("Failed to encode documents")?;
-                eta.record_batch(batch_chars, batch_start.elapsed());
-                chunk_embeddings.extend(batch_embeddings);
-
-                if let Some(ref pb) = pb {
-                    let progress = chunk_idx * PIPELINE_CHUNK_SIZE + chunk_embeddings.len();
-                    pb.set_position(progress.min(units.len()) as u64);
-                    pb.set_message(eta.eta_message());
-                }
-            }
-
-            // If interrupted during encoding, break out of chunk loop
-            if was_interrupted {
-                break;
-            }
-
-            // Wait for previous index update before starting a new one
-            wait_for_pending_update(pending_update.take())?;
-
-            // Prepare owned data for background thread
-            let metadata: Vec<serde_json::Value> = unit_chunk
-                .iter()
-                .map(|u| serde_json::to_value(u).unwrap())
-                .collect();
-            let idx_path = index_path_str.to_string();
-            let cfg = config.clone();
-            let ucfg = update_config.clone();
-
-            // Spawn background index update — encoding continues on main thread
-            pending_update = Some(std::thread::spawn(move || {
-                commit_chunk_to_index(chunk_embeddings, metadata, idx_path, cfg, ucfg, true)
-            }));
-        }
-
-        // Wait for final index update to complete
-        wait_for_pending_update(pending_update.take())?;
+        let sorted_units = prepare_units_for_encoding(
+            units,
+            index_chunk_size,
+        );
+        self.ensure_model_created(units.len())?;
+        let was_interrupted = run_chunk_pipeline(
+            self.model().clone(),
+            &sorted_units,
+            ChunkPipelineConfig {
+                index_chunk_size,
+                effective_pool_factor,
+                index_path: index_path_str,
+                config,
+                update_config,
+                pb: pb.as_ref(),
+            },
+        )?;
 
         if let Some(pb) = pb {
             pb.finish_and_clear();
@@ -2488,21 +2693,40 @@ impl Searcher {
         let index_path = get_vector_index_path(&index_dir);
         let index_path_str = index_path.to_str().unwrap().to_string();
 
-        // Load model for search - use CPU or CoreML (not CUDA)
-        // CUDA has too much overhead for single query encoding, CPU/CoreML is faster
-        // Priority: CoreML (if enabled) > CPU
-        let execution_provider = if cfg!(feature = "coreml") {
-            ExecutionProvider::CoreML
-        } else {
-            ExecutionProvider::Cpu
+        let acceleration_mode = env_acceleration_mode_lossy();
+        let execution_provider = match acceleration_mode {
+            AccelerationMode::ForceGpu => ExecutionProvider::Cuda,
+            AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
+            AccelerationMode::Auto => {
+                if cfg!(feature = "coreml") {
+                    ExecutionProvider::CoreML
+                } else {
+                    ExecutionProvider::Cpu
+                }
+            }
         };
 
-        // For search (always small batch - single query), force CPU to avoid
-        // CUDA initialization overhead. The GPU ONNX Runtime will fall back to CPU.
         #[cfg(feature = "cuda")]
-        std::env::set_var("COLGREP_FORCE_CPU", "1");
+        match acceleration_mode {
+            AccelerationMode::ForceGpu => apply_acceleration_mode(AccelerationMode::ForceGpu),
+            AccelerationMode::ForceCpu | AccelerationMode::Auto => {
+                apply_acceleration_mode(AccelerationMode::ForceCpu)
+            }
+        }
 
         crate::onnx_runtime::ensure_onnx_runtime().context("Failed to initialize ONNX Runtime")?;
+
+        #[cfg(feature = "cuda")]
+        if matches!(acceleration_mode, AccelerationMode::ForceGpu) {
+            if !crate::onnx_runtime::is_cudnn_available() {
+                anyhow::bail!("FORCE_GPU is set, but cuDNN was not initialized");
+            }
+            if !next_plaid_onnx::is_cuda_available() {
+                anyhow::bail!(
+                    "FORCE_GPU is set, but the CUDA execution provider was not initialized"
+                );
+            }
+        }
 
         // Cap intra-op threads to avoid overhead on high-core-count systems
         let num_threads = std::thread::available_parallelism()
@@ -2545,21 +2769,40 @@ impl Searcher {
         let index_path = get_vector_index_path(index_dir);
         let index_path_str = index_path.to_str().unwrap().to_string();
 
-        // Load model for search - use CPU or CoreML (not CUDA)
-        // CUDA has too much overhead for single query encoding, CPU/CoreML is faster
-        // Priority: CoreML (if enabled) > CPU
-        let execution_provider = if cfg!(feature = "coreml") {
-            ExecutionProvider::CoreML
-        } else {
-            ExecutionProvider::Cpu
+        let acceleration_mode = env_acceleration_mode_lossy();
+        let execution_provider = match acceleration_mode {
+            AccelerationMode::ForceGpu => ExecutionProvider::Cuda,
+            AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
+            AccelerationMode::Auto => {
+                if cfg!(feature = "coreml") {
+                    ExecutionProvider::CoreML
+                } else {
+                    ExecutionProvider::Cpu
+                }
+            }
         };
 
-        // For search (always small batch - single query), force CPU to avoid
-        // CUDA initialization overhead. The GPU ONNX Runtime will fall back to CPU.
         #[cfg(feature = "cuda")]
-        std::env::set_var("COLGREP_FORCE_CPU", "1");
+        match acceleration_mode {
+            AccelerationMode::ForceGpu => apply_acceleration_mode(AccelerationMode::ForceGpu),
+            AccelerationMode::ForceCpu | AccelerationMode::Auto => {
+                apply_acceleration_mode(AccelerationMode::ForceCpu)
+            }
+        }
 
         crate::onnx_runtime::ensure_onnx_runtime().context("Failed to initialize ONNX Runtime")?;
+
+        #[cfg(feature = "cuda")]
+        if matches!(acceleration_mode, AccelerationMode::ForceGpu) {
+            if !crate::onnx_runtime::is_cudnn_available() {
+                anyhow::bail!("FORCE_GPU is set, but cuDNN was not initialized");
+            }
+            if !next_plaid_onnx::is_cuda_available() {
+                anyhow::bail!(
+                    "FORCE_GPU is set, but the CUDA execution provider was not initialized"
+                );
+            }
+        }
 
         // Cap intra-op threads to avoid overhead on high-core-count systems
         let num_threads = std::thread::available_parallelism()
@@ -2823,7 +3066,7 @@ impl Searcher {
         Ok(metadata)
     }
 
-    /// Encode a query into embeddings (for reuse across multiple searches).
+    /// Encode a query once for reuse across multiple searches.
     pub fn encode_query(&self, query: &str) -> Result<ndarray::Array2<f32>> {
         let query_embeddings =
             crate::stderr::with_suppressed_stderr(|| self.model.encode_queries(&[query]))
@@ -2831,7 +3074,8 @@ impl Searcher {
         Ok(query_embeddings.into_iter().next().unwrap())
     }
 
-    /// Run FTS5 keyword search (returns None if FTS5 is unavailable).
+    /// Run FTS5 keyword search if the text index is available and the query
+    /// remains non-empty after sanitization.
     pub fn fts5_search(
         &self,
         query: &str,
@@ -2860,7 +3104,7 @@ impl Searcher {
         self.search_with_embedding(&query_emb, top_k, subset)
     }
 
-    /// Semantic-only search with pre-computed query embedding.
+    /// Semantic-only search with a pre-computed query embedding.
     pub fn search_with_embedding(
         &self,
         query_emb: &ndarray::Array2<f32>,
@@ -2894,9 +3138,7 @@ impl Searcher {
         Ok(search_results)
     }
 
-    /// Hybrid search: ColBERT semantic + FTS5 keyword search fused with RRF.
-    ///
-    /// Falls back to pure semantic search if FTS5 index is not available.
+    /// Hybrid search: semantic retrieval fused with FTS5 keyword search via RRF.
     pub fn search_hybrid(
         &self,
         query: &str,
@@ -2909,7 +3151,8 @@ impl Searcher {
         self.search_hybrid_with_embedding(&query_emb, query, top_k, subset, alpha, fts5.as_ref())
     }
 
-    /// Hybrid search with pre-computed query embedding and optional pre-computed FTS5 results.
+    /// Hybrid search using a pre-computed query embedding and optional cached
+    /// FTS5 results.
     pub fn search_hybrid_with_embedding(
         &self,
         query_emb: &ndarray::Array2<f32>,
@@ -2920,7 +3163,6 @@ impl Searcher {
         fts5_results: Option<&next_plaid::QueryResult>,
     ) -> Result<Vec<SearchResult>> {
         let fetch_k = top_k * 3;
-
         let params = SearchParameters {
             top_k: fetch_k,
             ..Default::default()
@@ -2930,13 +3172,11 @@ impl Searcher {
             .search(query_emb, &params, subset)
             .context("Semantic search failed")?;
 
-        // Use provided FTS5 results, or run FTS5 search if not provided
         let owned_fts5;
         let keyword = match fts5_results {
             Some(fts5) => {
-                // Filter pre-computed FTS5 results to the current subset if needed
                 if let Some(sub) = subset {
-                    let sub_set: std::collections::HashSet<i64> = sub.iter().copied().collect();
+                    let sub_set: HashSet<i64> = sub.iter().copied().collect();
                     let mut filtered_ids = Vec::new();
                     let mut filtered_scores = Vec::new();
                     for (id, score) in fts5.passage_ids.iter().zip(fts5.scores.iter()) {
@@ -2971,7 +3211,6 @@ impl Searcher {
             }
         };
 
-        // Fuse with RRF (or fall back to pure semantic)
         let (fused_ids, fused_scores) = if let Some(kw) = keyword {
             if kw.passage_ids.is_empty() {
                 (semantic.passage_ids, semantic.scores)
@@ -3009,22 +3248,12 @@ impl Searcher {
     }
 }
 
-/// Fix SQLite type conversions in metadata JSON.
-///
-/// SQLite stores booleans as integers (0/1) and arrays/objects as JSON strings.
-/// This function detects and converts them back using naming conventions:
-/// - Integer fields with a `has_` or `is_` prefix → boolean
-/// - String values that parse as JSON arrays → array
-///
-/// Note: this is more general than the original hardcoded field list — it will
-/// convert *any* `has_`/`is_` integer field to bool, not just known ones.
-/// This is intentional: new metadata fields following the naming convention are
-/// handled automatically without code changes.
+/// SQLite stores booleans as integers and arrays as JSON strings. Normalize
+/// those back to the shapes the rest of colgrep expects.
 fn fix_sqlite_types(meta: &mut serde_json::Value) {
     if let serde_json::Value::Object(ref mut obj) = meta {
         let keys: Vec<String> = obj.keys().cloned().collect();
         for key in keys {
-            // Convert 0/1 integers to booleans for has_*/is_* fields
             if key.starts_with("has_") || key.starts_with("is_") {
                 if let Some(v) = obj.get(&key) {
                     if let Some(n) = v.as_i64() {
@@ -3033,7 +3262,6 @@ fn fix_sqlite_types(meta: &mut serde_json::Value) {
                 }
                 continue;
             }
-            // Convert JSON-encoded strings back to arrays
             if let Some(serde_json::Value::String(s)) = obj.get(&key) {
                 if s.starts_with('[') {
                     if let Ok(arr) = serde_json::from_str::<serde_json::Value>(s) {

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
+use rayon::ThreadPoolBuilder;
 
 use colgrep::{
     acceleration::{apply_acceleration_mode, env_acceleration_mode, AccelerationMode},
@@ -18,13 +19,15 @@ use cli::{Cli, Commands};
 use commands::search::{resolve_pool_factor, resolve_top_k};
 use commands::{
     cmd_clear, cmd_config, cmd_init, cmd_reset_stats, cmd_search, cmd_session_hook, cmd_set_model,
-    cmd_stats, cmd_status, cmd_task_hook, cmd_update,
+    cmd_stats, cmd_status, cmd_task_hook, cmd_update, InitOptions,
 };
 
 fn main() -> Result<()> {
     // Set up Ctrl+C handler for graceful interruption during indexing
     // This is non-fatal if it fails (e.g., in environments without signal support)
     let _ = setup_signal_handler();
+
+    init_global_rayon_pool();
 
     let cli = Cli::parse();
     let env_mode = env_acceleration_mode()?;
@@ -112,6 +115,7 @@ fn main() -> Result<()> {
             no_pool,
             pool_factor,
             auto_confirm,
+            static_batch,
         }) => {
             // If only -e pattern is given without a query, use the pattern as the query too
             let original_query = query.clone();
@@ -201,6 +205,7 @@ fn main() -> Result<()> {
                     alpha,
                     resolve_pool_factor(pool_factor, no_pool),
                     auto_confirm,
+                    static_batch,
                 )
             } else {
                 // No query or text_pattern provided - show help
@@ -215,7 +220,23 @@ fn main() -> Result<()> {
             no_pool,
             pool_factor,
             auto_confirm,
-        }) => cmd_init(&path, model.as_deref(), no_pool, pool_factor, auto_confirm),
+            batch_size,
+            encode_batch_size,
+            index_chunk_size,
+            static_batch,
+        }) => cmd_init(
+            &path,
+            InitOptions {
+                cli_model: model.as_deref(),
+                no_pool,
+                pool_factor,
+                auto_confirm,
+                batch_size,
+                encode_batch_size,
+                index_chunk_size,
+                static_batch,
+            },
+        ),
         Some(Commands::Update) => cmd_update(),
         Some(Commands::Status { path }) => cmd_status(&path),
         Some(Commands::Clear { path, all }) => cmd_clear(&path, all),
@@ -355,6 +376,7 @@ fn main() -> Result<()> {
                     cli.alpha,
                     resolve_pool_factor(cli.pool_factor, cli.no_pool),
                     cli.auto_confirm,
+                    false,
                 )
             } else {
                 // No query provided - show help
@@ -364,4 +386,20 @@ fn main() -> Result<()> {
             }
         }
     }
+}
+
+fn init_global_rayon_pool() {
+    if std::env::var_os("RAYON_NUM_THREADS").is_some() {
+        return;
+    }
+
+    let available = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(4);
+    let configured = available.saturating_sub(4).max(1);
+
+    let _ = ThreadPoolBuilder::new()
+        .num_threads(configured)
+        .thread_name(|idx| format!("next-plaid-rayon-{idx}"))
+        .build_global();
 }

--- a/colgrep/src/parser/call_graph.rs
+++ b/colgrep/src/parser/call_graph.rs
@@ -1,6 +1,7 @@
 //! Call graph construction for code units.
 
 use super::types::CodeUnit;
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 /// Build call graph and populate called_by for all units.
@@ -21,17 +22,40 @@ pub fn build_call_graph(units: &mut [CodeUnit]) {
         .map(|(i, u)| (i, u.calls.clone()))
         .collect();
 
-    // For each unit, find what calls it
-    for (caller_idx, calls) in calls_map {
-        let caller_name = units[caller_idx].name.clone();
-        for callee_name in calls {
-            if let Some(indices) = name_to_indices.get(&callee_name) {
-                for &callee_idx in indices {
-                    if !units[callee_idx].called_by.contains(&caller_name) {
-                        units[callee_idx].called_by.push(caller_name.clone());
-                    }
+    let caller_names: Vec<String> = units.iter().map(|unit| unit.name.clone()).collect();
+
+    let name_to_indices_ref = &name_to_indices;
+    let edges: Vec<(usize, String)> = calls_map
+        .par_iter()
+        .map(|(caller_idx, calls)| {
+            let caller_name = caller_names[*caller_idx].clone();
+            let mut local_edges = Vec::new();
+            for callee_name in calls {
+                if let Some(indices) = name_to_indices_ref.get(callee_name) {
+                    local_edges.extend(
+                        indices
+                            .iter()
+                            .copied()
+                            .map(|callee_idx| (callee_idx, caller_name.clone())),
+                    );
                 }
             }
-        }
+            local_edges
+        })
+        .flatten()
+        .collect();
+
+    let mut called_by_map: HashMap<usize, Vec<String>> = HashMap::new();
+    for (callee_idx, caller_name) in edges {
+        called_by_map
+            .entry(callee_idx)
+            .or_default()
+            .push(caller_name);
+    }
+
+    for (callee_idx, mut callers) in called_by_map {
+        callers.sort_unstable();
+        callers.dedup();
+        units[callee_idx].called_by = callers;
     }
 }

--- a/colgrep/src/parser/tests/test_c.rs
+++ b/colgrep/src/parser/tests/test_c.rs
@@ -17,11 +17,11 @@ fn test_basic_function() {
 Signature: int add(int a, int b) {
 Parameters: a, b
 Returns: int
+File: test test.c
 Code:
 int add(int a, int b) {
     return a + b;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -42,11 +42,11 @@ Signature: int add(int a, int b) {
 Description: Calculates the sum of two integers. Returns the result. /
 Parameters: a, b
 Returns: int
+File: test test.c
 Code:
 int add(int a, int b) {
     return a + b;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -63,11 +63,11 @@ fn test_void_function() {
 Signature: void print_hello(void) {
 Returns: void
 Calls: printf
+File: test test.c
 Code:
 void print_hello(void) {
     printf("Hello, World!\n");
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -87,13 +87,13 @@ Signature: void swap(int *a, int *b) {
 Parameters: a, b
 Returns: void
 Variables: temp
+File: test test.c
 Code:
 void swap(int *a, int *b) {
     int temp = *a;
     *a = *b;
     *b = temp;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -109,12 +109,12 @@ fn test_struct() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: Point
 Signature: struct Point {
+File: test test.c
 Code:
 struct Point {
     int x;
     int y;
-};
-File: test test.c"#;
+};"#;
     assert_eq!(text, expected);
 }
 
@@ -136,12 +136,12 @@ Signature: int main(int argc, char *argv[]) {
 Parameters: argc, argv
 Returns: int
 Calls: printf
+File: test test.c
 Code:
 int main(int argc, char *argv[]) {
     printf("Hello\n");
     return 0;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -158,11 +158,11 @@ fn test_static_function() {
 Signature: static int helper(int x) {
 Parameters: x
 Returns: int
+File: test test.c
 Code:
 static int helper(int x) {
     return x * 2;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -182,13 +182,13 @@ Signature: void process_array(int arr[], int size) {
 Parameters: arr, size
 Returns: void
 Variables: i
+File: test test.c
 Code:
 void process_array(int arr[], int size) {
     for (int i = 0; i < size; i++) {
         arr[i] *= 2;
     }
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -212,12 +212,12 @@ Signature: Point create_point(int x, int y) {
 Parameters: x, y
 Returns: Point
 Variables: p
+File: test test.c
 Code:
 Point create_point(int x, int y) {
     Point p = {x, y};
     return p;
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -238,13 +238,13 @@ Parameters: arr, size, func
 Returns: void
 Calls: func
 Variables: i
+File: test test.c
 Code:
 void apply(int *arr, int size, int (*func)(int)) {
     for (int i = 0; i < size; i++) {
         arr[i] = func(arr[i]);
     }
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -264,11 +264,11 @@ Signature: int max_value(int x, int y) {
 Parameters: x, y
 Returns: int
 Calls: MAX
+File: test test.c
 Code:
 int max_value(int x, int y) {
     return MAX(x, y);
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -295,11 +295,11 @@ Signature: double calculate(double x) {
 Parameters: x
 Returns: double
 Calls: printf, sqrt
+File: test test.c
 Code:
 double calculate(double x) {
     printf("Calculating...\n");
     return sqrt(x);
-}
-File: test test.c"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_cpp.rs
+++ b/colgrep/src/parser/tests/test_cpp.rs
@@ -17,11 +17,11 @@ fn test_basic_function() {
 Signature: int add(int a, int b) {
 Parameters: a, b
 Returns: int
+File: test test.cpp
 Code:
 int add(int a, int b) {
     return a + b;
-}
-File: test test.cpp"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -45,6 +45,7 @@ private:
     let class_text = build_embedding_text(class);
     let expected_class = r#"Class: Calculator
 Signature: class Calculator {
+File: test test.cpp
 Code:
 class Calculator {
 public:
@@ -54,8 +55,7 @@ public:
 
 private:
     int value;
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method unit exists
@@ -88,6 +88,7 @@ public:
     let class_text = build_embedding_text(class_unit);
     let expected = r#"Class: Math
 Signature: class Math {
+File: test test.cpp
 Code:
 class Math {
 public:
@@ -100,8 +101,7 @@ public:
     int add(int a, int b) {
         return a + b;
     }
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(class_text, expected);
 
     // Verify NO separate method unit exists
@@ -125,11 +125,11 @@ T max(T a, T b) {
 Signature: T max(T a, T b) {
 Parameters: a, b
 Returns: T
+File: test test.cpp
 Code:
 T max(T a, T b) {
     return (a > b) ? a : b;
-}
-File: test test.cpp"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -148,11 +148,11 @@ fn test_namespace_function() {
 Signature: int helper(int x) {
 Parameters: x
 Returns: int
+File: test test.cpp
 Code:
     int helper(int x) {
         return x * 2;
-    }
-File: test test.cpp"#;
+    }"#;
     assert_eq!(text, expected);
 }
 
@@ -176,6 +176,7 @@ private:
     let class_text = build_embedding_text(class_unit);
     let expected = r#"Class: Person
 Signature: class Person {
+File: test test.cpp
 Code:
 class Person {
 public:
@@ -185,8 +186,7 @@ public:
 private:
     std::string name_;
     int age_;
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(class_text, expected);
 
     // Verify NO separate constructor unit exists (constructor has same name as class)
@@ -214,13 +214,13 @@ public:
     let class_text = build_embedding_text(class_unit);
     let expected = r#"Class: Shape
 Signature: class Shape {
+File: test test.cpp
 Code:
 class Shape {
 public:
     virtual double area() const = 0;
     virtual ~Shape() = default;
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(class_text, expected);
 
     // Verify NO separate method/destructor units exist
@@ -257,14 +257,14 @@ Parameters: nums
 Returns: std::vector<int>
 Calls: back_inserter, begin, copy_if, end
 Variables: result
+File: test test.cpp
 Code:
 std::vector<int> filter_positive(const std::vector<int>& nums) {
     std::vector<int> result;
     std::copy_if(nums.begin(), nums.end(), std::back_inserter(result),
                  [](int x) { return x > 0; });
     return result;
-}
-File: test test.cpp"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -287,6 +287,7 @@ fn test_struct_with_methods() {
     let expected = r#"Class: Point
 Signature: struct Point {
 Calls: sqrt
+File: test test.cpp
 Code:
 struct Point {
     double x, y;
@@ -294,8 +295,7 @@ struct Point {
     double distance() const {
         return std::sqrt(x*x + y*y);
     }
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(text, expected);
 
     // Verify NO separate method unit exists
@@ -326,6 +326,7 @@ private:
     let expected = r#"Class: Vector
 Signature: class Vector {
 Calls: Vector
+File: test test.cpp
 Code:
 class Vector {
 public:
@@ -335,8 +336,7 @@ public:
 
 private:
     double x, y;
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(class_text, expected);
 
     // Verify NO separate operator method unit exists
@@ -362,11 +362,11 @@ Signature: constexpr int factorial(int n) {
 Parameters: n
 Returns: int
 Calls: factorial
+File: test test.cpp
 Code:
 constexpr int factorial(int n) {
     return n <= 1 ? 1 : n * factorial(n - 1);
-}
-File: test test.cpp"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -394,14 +394,14 @@ public:
     let animal_text = build_embedding_text(animal);
     let expected_animal = r#"Class: Animal
 Signature: class Animal {
+File: test test.cpp
 Code:
 class Animal {
 public:
     virtual void speak() {
         std::cout << "..." << std::endl;
     }
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(animal_text, expected_animal);
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -411,14 +411,14 @@ File: test test.cpp"#;
     let expected_dog = r#"Class: Dog
 Signature: class Dog : public Animal {
 Extends: Animal
+File: test test.cpp
 Code:
 class Dog : public Animal {
 public:
     void speak() override {
         std::cout << "Woof!" << std::endl;
     }
-};
-File: test test.cpp"#;
+};"#;
     assert_eq!(dog_text, expected_dog);
 
     // Verify NO separate method units exist
@@ -451,12 +451,12 @@ void print_values(const std::vector<int>& values) {
 Signature: void print_values(const std::vector<int>& values) {
 Parameters: values
 Returns: void
+File: test test.cpp
 Code:
 void print_values(const std::vector<int>& values) {
     for (int v : values) {
         std::cout << v << std::endl;
     }
-}
-File: test test.cpp"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_csharp.rs
+++ b/colgrep/src/parser/tests/test_csharp.rs
@@ -22,6 +22,7 @@ fn test_basic_method() {
         class_text,
         "Class: Calculator
 Signature: public class Calculator
+File: calculator Calculator.cs
 Code:
 public class Calculator
 {
@@ -29,8 +30,7 @@ public class Calculator
     {
         return a + b;
     }
-}
-File: calculator Calculator.cs"
+}"
     );
 
     // Verify NO separate method unit exists
@@ -64,6 +64,7 @@ fn test_method_with_xml_doc() {
         class_text,
         r#"Class: Math
 Signature: public class Math
+File: math Math.cs
 Code:
 public class Math
 {
@@ -77,8 +78,7 @@ public class Math
     {
         return a + b;
     }
-}
-File: math Math.cs"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -115,6 +115,7 @@ fn test_class_definition() {
         class_text,
         r#"Class: Person
 Signature: public class Person
+File: person Person.cs
 Code:
 public class Person
 {
@@ -131,8 +132,7 @@ public class Person
     {
         return $"Hello, I'm {Name}";
     }
-}
-File: person Person.cs"#
+}"#
     );
 
     // Verify NO separate method/constructor units exist
@@ -170,6 +170,7 @@ fn test_async_method() {
 Signature: public class DataService
 Calls: new
 Variables: client
+File: data service DataService.cs
 Code:
 public class DataService
 {
@@ -178,8 +179,7 @@ public class DataService
         using var client = new HttpClient();
         return await client.GetStringAsync(url);
     }
-}
-File: data service DataService.cs"
+}"
     );
 
     // Verify NO separate method unit exists
@@ -207,6 +207,7 @@ fn test_static_method() {
         class_text,
         "Class: Utils
 Signature: public static class Utils
+File: utils Utils.cs
 Code:
 public static class Utils
 {
@@ -214,8 +215,7 @@ public static class Utils
     {
         return string.Format(template, args);
     }
-}
-File: utils Utils.cs"
+}"
     );
 
     // Verify NO separate method unit exists
@@ -241,13 +241,13 @@ fn test_interface() {
         interface_text,
         "Class: IDrawable
 Signature: public interface IDrawable
+File: idrawable IDrawable.cs
 Code:
 public interface IDrawable
 {
     void Draw();
     Rectangle GetBounds();
-}
-File: idrawable IDrawable.cs"
+}"
     );
 
     // Verify NO separate method units exist
@@ -287,6 +287,7 @@ fn test_generic_method() {
         "Class: Container
 Signature: public class Container<T>
 Variables: _value
+File: container Container.cs
 Code:
 public class Container<T>
 {
@@ -301,8 +302,7 @@ public class Container<T>
     {
         _value = value;
     }
-}
-File: container Container.cs"
+}"
     );
 
     // Verify NO separate method units exist
@@ -334,6 +334,7 @@ fn test_extension_method() {
         class_text,
         r#"Class: StringExtensions
 Signature: public static class StringExtensions
+File: string extensions StringExtensions.cs
 Code:
 public static class StringExtensions
 {
@@ -341,8 +342,7 @@ public static class StringExtensions
     {
         return str + "!";
     }
-}
-File: string extensions StringExtensions.cs"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -376,6 +376,7 @@ fn test_property_accessor() {
         "Class: Circle
 Signature: public class Circle
 Variables: _radius
+File: circle Circle.cs
 Code:
 public class Circle
 {
@@ -388,8 +389,7 @@ public class Circle
     }
 
     public double Area => Math.PI * _radius * _radius;
-}
-File: circle Circle.cs"
+}"
     );
 }
 
@@ -440,6 +440,7 @@ fn test_linq_expression() {
         class_text,
         r#"Class: QueryService
 Signature: public class QueryService
+File: query service QueryService.cs
 Code:
 public class QueryService
 {
@@ -449,8 +450,7 @@ public class QueryService
                     .OrderBy(n => n)
                     .ToList();
     }
-}
-File: query service QueryService.cs"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -486,6 +486,7 @@ public class Dog : Animal
         animal_text,
         r#"Class: Animal
 Signature: public class Animal
+File: animals Animals.cs
 Code:
 public class Animal
 {
@@ -493,8 +494,7 @@ public class Animal
     {
         Console.WriteLine("...");
     }
-}
-File: animals Animals.cs"#
+}"#
     );
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -507,6 +507,7 @@ File: animals Animals.cs"#
         r#"Class: Dog
 Signature: public class Dog : Animal
 Extends: Animal
+File: animals Animals.cs
 Code:
 public class Dog : Animal
 {
@@ -514,8 +515,7 @@ public class Dog : Animal
     {
         Console.WriteLine("Woof!");
     }
-}
-File: animals Animals.cs"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -550,6 +550,7 @@ public class Factory
         r#"Class: Factory
 Signature: public class Factory
 Calls: new
+File: factory Factory.cs
 Code:
 public class Factory
 {
@@ -557,8 +558,7 @@ public class Factory
     {
         return new User();
     }
-}
-File: factory Factory.cs"#
+}"#
     );
 
     // Verify NO separate method unit exists

--- a/colgrep/src/parser/tests/test_elixir.rs
+++ b/colgrep/src/parser/tests/test_elixir.rs
@@ -21,9 +21,9 @@ end
 Signature: def greet(name) do
 Calls: greet
 Uses: greet(name
+File: test test.ex
 Code:
-def greet(name) do
-File: test test.ex"
+def greet(name) do"
     );
 }
 
@@ -47,9 +47,9 @@ end
 Signature: def add(a, b) do
 Calls: add
 Uses: add(a
+File: test test.ex
 Code:
-def add(a, b) do
-File: test test.ex"
+def add(a, b) do"
     );
 }
 
@@ -73,6 +73,7 @@ end
 Signature: defmodule MyModule do
 Calls: def, defmodule
 Uses: def, defmodule
+File: test test.ex
 Code:
 defmodule MyModule do
   def hello do
@@ -82,8 +83,7 @@ defmodule MyModule do
   def goodbye do
     "Goodbye!"
   end
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -104,9 +104,9 @@ end
 Signature: defp helper(x) do
 Calls: helper
 Uses: helper(x
+File: test test.ex
 Code:
-defp helper(x) do
-File: test test.ex"
+defp helper(x) do"
     );
 }
 
@@ -128,11 +128,11 @@ end
 Signature: def abs(x) when x >= 0 do
 Calls: abs, def
 Uses: abs(x, def
+File: test test.ex
 Code:
 def abs(x) when x >= 0 do
   x
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -152,13 +152,13 @@ end
 Signature: defmacro my_macro(arg) do
 Calls: defmacro, my_macro, quote, unquote
 Uses: defmacro, my_macro(arg, quote, unquote(arg
+File: test test.ex
 Code:
 defmacro my_macro(arg) do
   quote do
     unquote(arg)
   end
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -180,11 +180,11 @@ end
 Signature: def handle({:ok, value}) do
 Calls: def, handle
 Uses: def, handle({:error, handle({:ok
+File: test test.ex
 Code:
 def handle({:ok, value}) do
   value
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -206,6 +206,7 @@ end
 Signature: defmodule User do
 Calls: def, defmodule, defstruct, new
 Uses: def, defmodule, defstruct, new(name
+File: test test.ex
 Code:
 defmodule User do
   defstruct [:name, :email, age: 0]
@@ -213,8 +214,7 @@ defmodule User do
   def new(name, email) do
     %User{name: name, email: email}
   end
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -234,13 +234,13 @@ end
 Signature: defimpl String.Chars, for: User do
 Calls: def, defimpl, name, to_string
 Uses: def, defimpl, to_string(user
+File: test test.ex
 Code:
 defimpl String.Chars, for: User do
   def to_string(user) do
     "User: #{user.name}"
   end
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -266,11 +266,11 @@ end
 Signature: defmodule MyBehaviour do
 Calls: callback, defmodule, do_something, t
 Uses: String, callback, def, defmodule, do_something(term, do_something(value
+File: test test.ex
 Code:
 defmodule MyBehaviour do
   @callback do_something(term) :: {:ok, term} | {:error, String.t()}
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -291,13 +291,13 @@ end
 Signature: def process(items) do
 Calls: def, filter, map, process, sort, starts_with?, upcase
 Uses: def, process(items
+File: test test.ex
 Code:
 def process(items) do
   items
   |> Enum.map(&String.upcase/1)
   |> Enum.filter(&String.starts_with?(&1, "A"))
   |> Enum.sort()
-end
-File: test test.ex"#;
+end"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_go.rs
+++ b/colgrep/src/parser/tests/test_go.rs
@@ -20,11 +20,11 @@ func add(a, b int) int {
 Signature: func add(a, b int) int {
 Parameters: a, b
 Returns: int
+File: test test.go
 Code:
 func add(a, b int) int {
     return a + b
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -47,13 +47,13 @@ Signature: func Add(a, b int) int {
 Description: Add calculates the sum of two integers. It returns the result as an integer.
 Parameters: a, b
 Returns: int
+File: test test.go
 Code:
 // Add calculates the sum of two integers.
 // It returns the result as an integer.
 func Add(a, b int) int {
     return a + b
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -77,14 +77,14 @@ Signature: func divide(a, b int) (int, error) {
 Parameters: a, b
 Returns: (int, error)
 Calls: New
+File: test test.go
 Code:
 func divide(a, b int) (int, error) {
     if b == 0 {
         return 0, errors.New("division by zero")
     }
     return a / b, nil
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -110,12 +110,12 @@ Signature: func (c *Calculator) Add(x int) int {
 Class: Calculator
 Parameters: x
 Returns: int
+File: test test.go
 Code:
 func (c *Calculator) Add(x int) int {
     c.value += x
     return c.value
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -142,11 +142,11 @@ Parameters: name
 Returns: string
 Calls: Sprintf, TrimSpace
 Uses: fmt, strings
+File: test test.go
 Code:
 func greet(name string) string {
     return fmt.Sprintf("Hello, %s!", strings.TrimSpace(name))
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -170,6 +170,7 @@ Signature: func sum(numbers ...int) int {
 Parameters: numbers
 Returns: int
 Variables: total
+File: test test.go
 Code:
 func sum(numbers ...int) int {
     total := 0
@@ -177,8 +178,7 @@ func sum(numbers ...int) int {
         total += n
     }
     return total
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -239,12 +239,12 @@ Class: Point
 Description: Distance calculates the distance from origin.
 Returns: float64
 Calls: Sqrt
+File: test test.go
 Code:
 // Distance calculates the distance from origin.
 func (p Point) Distance() float64 {
     return math.Sqrt(p.X*p.X + p.Y*p.Y)
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 
     let scale = get_unit_by_name(&units, "Scale").unwrap();
@@ -254,13 +254,13 @@ Signature: func (p *Point) Scale(factor float64) {
 Class: Point
 Description: Scale multiplies the point by a factor.
 Parameters: factor
+File: test test.go
 Code:
 // Scale multiplies the point by a factor.
 func (p *Point) Scale(factor float64) {
     p.X *= factor
     p.Y *= factor
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -302,21 +302,21 @@ func main() {
     let text = build_embedding_text(init);
     let expected = r#"Function: init
 Signature: func init() {
+File: test test.go
 Code:
 func init() {
     // Initialize package
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 
     let main = get_unit_by_name(&units, "main").unwrap();
     let text = build_embedding_text(main);
     let expected = r#"Function: main
 Signature: func main() {
+File: test test.go
 Code:
 func main() {
     // Main function
-}
-File: test test.go"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_haskell.rs
+++ b/colgrep/src/parser/tests/test_haskell.rs
@@ -16,9 +16,9 @@ greet name = "Hello, " ++ name ++ "!"
 
     let expected = r#"Function: greet
 Signature: greet name = "Hello, " ++ name ++ "!"
+File: test test.hs
 Code:
-greet name = "Hello, " ++ name ++ "!"
-File: test test.hs"#;
+greet name = "Hello, " ++ name ++ "!""#;
     assert_eq!(text, expected);
 }
 
@@ -35,9 +35,9 @@ add a b = a + b
 
     let expected = r#"Function: add
 Signature: add a b = a + b
+File: test test.hs
 Code:
-add a b = a + b
-File: test test.hs"#;
+add a b = a + b"#;
     assert_eq!(text, expected);
 }
 
@@ -87,11 +87,11 @@ abs x
 
     let expected = r#"Function: abs
 Signature: abs x
+File: test test.hs
 Code:
 abs x
   | x >= 0    = x
-  | otherwise = -x
-File: test test.hs"#;
+  | otherwise = -x"#;
     assert_eq!(text, expected);
 }
 
@@ -105,9 +105,9 @@ fn test_newtype() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: UserId
 Signature: newtype UserId = UserId Int
+File: test test.hs
 Code:
-newtype UserId = UserId Int
-File: test test.hs"#;
+newtype UserId = UserId Int"#;
     assert_eq!(text, expected);
 }
 
@@ -124,9 +124,9 @@ length (_:xs) = 1 + length xs
 
     let expected = r#"Function: length
 Signature: length [] = 0
+File: test test.hs
 Code:
-length [] = 0
-File: test test.hs"#;
+length [] = 0"#;
     assert_eq!(text, expected);
 }
 
@@ -144,11 +144,11 @@ quadratic a b c x = a*x^2 + b*x + c
 
     let expected = r#"Function: quadratic
 Signature: quadratic a b c x = a*x^2 + b*x + c
+File: test test.hs
 Code:
 quadratic a b c x = a*x^2 + b*x + c
   where
-    square y = y * y
-File: test test.hs"#;
+    square y = y * y"#;
     assert_eq!(text, expected);
 }
 
@@ -165,9 +165,9 @@ fn test_instance_declaration() {
     let text0 = build_embedding_text(unit0);
     let expected0 = r#"Function: show
 Signature: show (Person name age) = name ++ " (" ++ show age ++ ")"
+File: test test.hs
 Code:
-  show (Person name age) = name ++ " (" ++ show age ++ ")"
-File: test test.hs"#;
+  show (Person name age) = name ++ " (" ++ show age ++ ")""#;
     assert_eq!(text0, expected0);
 
     let unit1 = &units[1];
@@ -206,8 +206,8 @@ map f (x:xs) = f x : map f xs
 
     let expected = r#"Function: map
 Signature: map _ [] = []
+File: test test.hs
 Code:
-map _ [] = []
-File: test test.hs"#;
+map _ [] = []"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_java.rs
+++ b/colgrep/src/parser/tests/test_java.rs
@@ -19,13 +19,13 @@ fn test_basic_method() {
     let class_text = build_embedding_text(class_unit);
     let class_expected = r#"Class: Calculator
 Signature: public class Calculator {
+File: calculator Calculator.java
 Code:
 public class Calculator {
     public int add(int a, int b) {
         return a + b;
     }
-}
-File: calculator Calculator.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists
@@ -55,6 +55,7 @@ fn test_method_with_javadoc() {
     let class_text = build_embedding_text(class_unit);
     let class_expected = r#"Class: Math
 Signature: public class Math {
+File: math Math.java
 Code:
 public class Math {
     /**
@@ -66,8 +67,7 @@ public class Math {
     public int add(int a, int b) {
         return a + b;
     }
-}
-File: math Math.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists
@@ -93,13 +93,13 @@ fn test_static_method() {
 Signature: public class Utils {
 Calls: format
 Variables: args
+File: utils Utils.java
 Code:
 public class Utils {
     public static String format(String template, Object... args) {
         return String.format(template, args);
     }
-}
-File: utils Utils.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists
@@ -131,6 +131,7 @@ fn test_method_with_generics() {
 Signature: public class Container<T> {
 Parameters: T
 Variables: value
+File: container Container.java
 Code:
 public class Container<T> {
     private T value;
@@ -142,8 +143,7 @@ public class Container<T> {
     public void setValue(T value) {
         this.value = value;
     }
-}
-File: container Container.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method units exist
@@ -175,6 +175,7 @@ fn test_constructor() {
     let class_expected = r#"Class: Person
 Signature: public class Person {
 Variables: age, name
+File: person Person.java
 Code:
 public class Person {
     private String name;
@@ -184,8 +185,7 @@ public class Person {
         this.name = name;
         this.age = age;
     }
-}
-File: person Person.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 }
 
@@ -201,12 +201,12 @@ fn test_interface() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: Drawable
 Signature: public interface Drawable {
+File: drawable Drawable.java
 Code:
 public interface Drawable {
     void draw();
     Rectangle getBounds();
-}
-File: drawable Drawable.java"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -225,13 +225,13 @@ fn test_method_throws() {
     let class_expected = r#"Class: FileReader
 Signature: public class FileReader {
 Calls: of, readString
+File: file reader FileReader.java
 Code:
 public class FileReader {
     public String read(String path) throws IOException {
         return Files.readString(Path.of(path));
     }
-}
-File: file reader FileReader.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists
@@ -265,6 +265,7 @@ fn test_enum() {
     let expected = r#"Class: Status
 Signature: public enum Status {
 Variables: value
+File: status Status.java
 Code:
 public enum Status {
     ACTIVE("active"),
@@ -280,8 +281,7 @@ public enum Status {
     public String getValue() {
         return value;
     }
-}
-File: status Status.java"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -302,6 +302,7 @@ fn test_abstract_class() {
     let class_expected = r#"Class: Shape
 Signature: public abstract class Shape {
 Calls: println
+File: shape Shape.java
 Code:
 public abstract class Shape {
     public abstract double area();
@@ -309,8 +310,7 @@ public abstract class Shape {
     public void describe() {
         System.out.println("I am a shape");
     }
-}
-File: shape Shape.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method units exist
@@ -345,6 +345,7 @@ fn test_annotations() {
     let class_text = build_embedding_text(class_unit);
     let class_expected = r#"Class: Service
 Signature: public class Service {
+File: service Service.java
 Code:
 public class Service {
     @Override
@@ -357,8 +358,7 @@ public class Service {
     public void init() {
         // Initialize
     }
-}
-File: service Service.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method units exist
@@ -389,6 +389,7 @@ fn test_lambda_expression() {
     let class_expected = r#"Class: StreamExample
 Signature: public class StreamExample {
 Calls: collect, filter, startsWith, stream, toList
+File: stream example StreamExample.java
 Code:
 public class StreamExample {
     public List<String> filter(List<String> items) {
@@ -396,8 +397,7 @@ public class StreamExample {
             .filter(s -> s.startsWith("a"))
             .collect(Collectors.toList());
     }
-}
-File: stream example StreamExample.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists
@@ -434,14 +434,14 @@ public class Dog extends Animal {
 Signature: public class Dog extends Animal {
 Extends: Animal
 Calls: println
+File: animals Animals.java
 Code:
 public class Dog extends Animal {
     @Override
     public void speak() {
         System.out.println("Woof!");
     }
-}
-File: animals Animals.java"#;
+}"#;
     assert_eq!(dog_text, expected_dog);
 }
 
@@ -464,13 +464,13 @@ public class ListUtils {
 Signature: public class ListUtils {
 Calls: new
 Uses: ArrayList
+File: list utils ListUtils.java
 Code:
 public class ListUtils {
     public List<String> createList() {
         return new ArrayList<String>();
     }
-}
-File: list utils ListUtils.java"#;
+}"#;
     assert_eq!(class_text, class_expected);
 
     // Verify NO separate method unit exists

--- a/colgrep/src/parser/tests/test_javascript.rs
+++ b/colgrep/src/parser/tests/test_javascript.rs
@@ -16,11 +16,11 @@ fn test_basic_function() {
     let expected = r#"Function: greet
 Signature: function greet(name) {
 Parameters: name
+File: test test.js
 Code:
 function greet(name) {
     return `Hello, ${name}!`;
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -36,11 +36,11 @@ fn test_arrow_function() {
     let expected = r#"Function: add
 Signature: const add = (a, b) => {
 Parameters: a, b
+File: test test.js
 Code:
 const add = (a, b) => {
     return a + b;
-};
-File: test test.js"#;
+};"#;
     assert_eq!(text, expected);
 }
 
@@ -63,6 +63,7 @@ function add(a, b) {
 Signature: function add(a, b) {
 Description: Calculates the sum of two numbers. @param {number} a - First number @param {number} b - Second number @returns {number} Sum of a and b /
 Parameters: a, b
+File: test test.js
 Code:
 /**
  * Calculates the sum of two numbers.
@@ -72,8 +73,7 @@ Code:
  */
 function add(a, b) {
     return a + b;
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -96,6 +96,7 @@ fn test_class_definition() {
     let class_text = build_embedding_text(class);
     let expected_class = r#"Class: Calculator
 Signature: class Calculator {
+File: test test.js
 Code:
 class Calculator {
     constructor(value) {
@@ -106,8 +107,7 @@ class Calculator {
         this.value += x;
         return this.value;
     }
-}
-File: test test.js"#;
+}"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method units exist - methods are inside the class chunk
@@ -136,12 +136,12 @@ Signature: async function fetchData(url) {
 Parameters: url
 Calls: fetch, json
 Variables: const, response
+File: test test.js
 Code:
 async function fetchData(url) {
     const response = await fetch(url);
     return response.json();
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -156,11 +156,11 @@ fn test_function_with_default_params() {
 
     let expected = r#"Function: greet
 Signature: function greet(name = "World", greeting = "Hello") {
+File: test test.js
 Code:
 function greet(name = "World", greeting = "Hello") {
     return `${greeting}, ${name}!`;
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -176,11 +176,11 @@ fn test_function_with_rest_params() {
     let expected = r#"Function: sum
 Signature: function sum(...numbers) {
 Calls: reduce
+File: test test.js
 Code:
 function sum(...numbers) {
     return numbers.reduce((a, b) => a + b, 0);
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -199,22 +199,22 @@ export default function defaultFunc() {
     let public_text = build_embedding_text(public_func);
     let expected_public = r#"Function: publicFunc
 Signature: export function publicFunc() {
+File: test test.js
 Code:
 export function publicFunc() {
     return "public";
-}
-File: test test.js"#;
+}"#;
     assert_eq!(public_text, expected_public);
 
     let default_func = get_unit_by_name(&units, "defaultFunc").unwrap();
     let default_text = build_embedding_text(default_func);
     let expected_default = r#"Function: defaultFunc
 Signature: export default function defaultFunc() {
+File: test test.js
 Code:
 export default function defaultFunc() {
     return "default";
-}
-File: test test.js"#;
+}"#;
     assert_eq!(default_text, expected_default);
 }
 
@@ -294,13 +294,13 @@ class Dog extends Animal {
     let expected_dog = r#"Class: Dog
 Signature: class Dog extends Animal {
 Extends: Animal
+File: test test.js
 Code:
 class Dog extends Animal {
     speak() {
         return "Woof!";
     }
-}
-File: test test.js"#;
+}"#;
     assert_eq!(dog_text, expected_dog);
 }
 
@@ -321,10 +321,10 @@ Signature: function fetchData(url) {
 Parameters: url
 Calls: get
 Uses: axios
+File: test test.js
 Code:
 function fetchData(url) {
     return axios.get(url);
-}
-File: test test.js"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_kotlin.rs
+++ b/colgrep/src/parser/tests/test_kotlin.rs
@@ -17,11 +17,11 @@ fn test_basic_function() {
     let expected = r#"Function: greet
 Signature: fun greet(name: String): String {
 Parameters: name
+File: test test.kt
 Code:
 fun greet(name: String): String {
     return "Hello, $name!"
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -45,11 +45,11 @@ fun add(a: Int, b: Int): Int {
 Signature: fun add(a: Int, b: Int): Int {
 Description: Calculates the sum of two numbers. @param a First number @param b Second number @return Sum of a and b /
 Parameters: a, b
+File: test test.kt
 Code:
 fun add(a: Int, b: Int): Int {
     return a + b
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -66,13 +66,13 @@ fn test_class_definition() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: Person
 Signature: class Person(val name: String, var age: Int) {
+File: test test.kt
 Code:
 class Person(val name: String, var age: Int) {
     fun greet(): String {
         return "Hello, I'm $name"
     }
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -87,11 +87,11 @@ fn test_extension_function() {
     let text = build_embedding_text(unit);
     let expected = r#"Function: addExclamation
 Signature: fun String.addExclamation(): String {
+File: test test.kt
 Code:
 fun String.addExclamation(): String {
     return this + "!"
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -111,13 +111,13 @@ fn test_suspend_function() {
 Signature: suspend fun fetchData(url: String): String {
 Parameters: url
 Calls: Dispatchers, IO), URL, URL(url), readText, withContext
+File: test test.kt
 Code:
 suspend fun fetchData(url: String): String {
     return withContext(Dispatchers.IO) {
         URL(url).readText()
     }
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -130,9 +130,9 @@ fn test_data_class() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: User
 Signature: data class User(val id: Int, val name: String, val email: String)
+File: test test.kt
 Code:
-data class User(val id: Int, val name: String, val email: String)
-File: test test.kt"#;
+data class User(val id: Int, val name: String, val email: String)"#;
     assert_eq!(text, expected);
 }
 
@@ -152,11 +152,11 @@ fun <K, V> createPair(key: K, value: V): Pair<K, V> {
     let expected = r#"Function: identity
 Signature: fun <T> identity(value: T): T {
 Parameters: value
+File: test test.kt
 Code:
 fun <T> identity(value: T): T {
     return value
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 
     let unit = get_unit_by_name(&units, "createPair").unwrap();
@@ -165,11 +165,11 @@ File: test test.kt"#;
 Signature: fun <K, V> createPair(key: K, value: V): Pair<K, V> {
 Parameters: key, value
 Calls: Pair
+File: test test.kt
 Code:
 fun <K, V> createPair(key: K, value: V): Pair<K, V> {
     return Pair(key, value)
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -186,13 +186,13 @@ fn test_object_declaration() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: Singleton
 Signature: object Singleton {
+File: test test.kt
 Code:
 object Singleton {
     fun doSomething(): String {
         return "singleton"
     }
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -212,6 +212,7 @@ fn test_companion_object() {
     let expected = r#"Class: Factory
 Signature: class Factory {
 Calls: Factory
+File: test test.kt
 Code:
 class Factory {
     companion object {
@@ -219,8 +220,7 @@ class Factory {
             return Factory()
         }
     }
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -236,12 +236,12 @@ fn test_sealed_class() {
     let text = build_embedding_text(unit);
     let expected = r#"Class: Result
 Signature: sealed class Result<out T> {
+File: test test.kt
 Code:
 sealed class Result<out T> {
     data class Success<T>(val data: T) : Result<T>()
     data class Error(val message: String) : Result<Nothing>()
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -258,11 +258,11 @@ fn test_inline_function() {
 Signature: inline fun <reified T> parseJson(json: String): T {
 Parameters: json
 Calls: Gson, Gson(), T, class, fromJson
+File: test test.kt
 Code:
 inline fun <reified T> parseJson(json: String): T {
     return Gson().fromJson(json, T::class.java)
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -291,13 +291,13 @@ class Dog : Animal() {
     let expected_dog = r#"Class: Dog
 Signature: class Dog : Animal() {
 Extends: Animal
+File: test test.kt
 Code:
 class Dog : Animal() {
     override fun speak(): String {
         return "Woof!"
     }
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(dog_text, expected_dog);
 }
 
@@ -316,10 +316,10 @@ Signature: fun sortArray(arr: IntArray) {
 Parameters: arr
 Calls: Arrays, sort
 Uses: Arrays
+File: test test.kt
 Code:
 fun sortArray(arr: IntArray) {
     Arrays.sort(arr)
-}
-File: test test.kt"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_lua.rs
+++ b/colgrep/src/parser/tests/test_lua.rs
@@ -16,11 +16,11 @@ end"#;
     let expected = r#"Function: greet
 Signature: function greet(name)
 Parameters: name
+File: test test.lua
 Code:
 function greet(name)
     return "Hello, " .. name .. "!"
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -41,11 +41,11 @@ end"#;
 Signature: function add(a, b)
 Description: Calculates the sum of two numbers. @param a First number @param b Second number @return Sum of a and b
 Parameters: a, b
+File: test test.lua
 Code:
 function add(a, b)
     return a + b
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -61,11 +61,11 @@ end"#;
     let expected = r#"Function: helper
 Signature: local function helper(x)
 Parameters: x
+File: test test.lua
 Code:
 local function helper(x)
     return x * 2
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -81,11 +81,11 @@ end"#;
     let expected = r#"Function: swap
 Signature: function swap(a, b)
 Parameters: a, b
+File: test test.lua
 Code:
 function swap(a, b)
     return b, a
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -109,11 +109,11 @@ return M"#;
     let expected_greet = r#"Function: M.greet
 Signature: function M.greet(name)
 Parameters: name
+File: test test.lua
 Code:
 function M.greet(name)
     return "Hello, " .. name
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(greet_text, expected_greet);
 
     let farewell = get_unit_by_name(&units, "M.farewell").unwrap();
@@ -121,11 +121,11 @@ File: test test.lua"#;
     let expected_farewell = r#"Function: M.farewell
 Signature: function M.farewell(name)
 Parameters: name
+File: test test.lua
 Code:
 function M.farewell(name)
     return "Goodbye, " .. name
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(farewell_text, expected_farewell);
 }
 
@@ -143,13 +143,13 @@ end"#;
     let expected = r#"Function: print_all
 Signature: function print_all(...)
 Calls: ipairs, print
+File: test test.lua
 Code:
 function print_all(...)
     for i, v in ipairs({...}) do
         print(v)
     end
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -167,11 +167,11 @@ end"#;
     let expected = r#"Function: obj:method
 Signature: function obj:method(arg)
 Parameters: arg
+File: test test.lua
 Code:
 function obj:method(arg)
     return self.value + arg
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -196,13 +196,13 @@ end"#;
 Signature: function process(items, callback)
 Parameters: items, callback
 Calls: callback, ipairs
+File: test test.lua
 Code:
 function process(items, callback)
     for _, item in ipairs(items) do
         callback(item)
     end
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -223,6 +223,7 @@ end"#;
 Signature: function factorial(n)
 Parameters: n
 Calls: factorial
+File: test test.lua
 Code:
 function factorial(n)
     if n <= 1 then
@@ -230,8 +231,7 @@ function factorial(n)
     else
         return n * factorial(n - 1)
     end
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -258,24 +258,24 @@ Signature: function class.new(value)
 Parameters: value
 Calls: setmetatable
 Variables: local
+File: test test.lua
 Code:
 function class.new(value)
     local self = setmetatable({}, class)
     self.value = value
     return self
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(new_text, expected_new);
 
     let get_func = get_unit_by_name(&units, "class:getValue").unwrap();
     let get_text = build_embedding_text(get_func);
     let expected_get = r#"Function: class:getValue
 Signature: function class:getValue()
+File: test test.lua
 Code:
 function class:getValue()
     return self.value
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(get_text, expected_get);
 }
 
@@ -296,10 +296,10 @@ Signature: function parseData(str)
 Parameters: str
 Calls: decode
 Uses: json
+File: test test.lua
 Code:
 function parseData(str)
     return json.decode(str)
-end
-File: test test.lua"#;
+end"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_ocaml.rs
+++ b/colgrep/src/parser/tests/test_ocaml.rs
@@ -17,10 +17,10 @@ fn test_basic_function() {
     let expected = r#"Function: greet
 Signature: let greet name =
 Parameters: name
+File: test test.ml
 Code:
 let greet name =
-  "Hello, " ^ name ^ "!"
-File: test test.ml"#;
+  "Hello, " ^ name ^ "!""#;
     assert_eq!(text, expected);
 }
 
@@ -38,9 +38,9 @@ let add a b = a + b
 Signature: let add a b = a + b
 Description: Calculates the sum of two numbers.
 Parameters: a, b
+File: test test.ml
 Code:
-let add a b = a + b
-File: test test.ml"#;
+let add a b = a + b"#;
     assert_eq!(text, expected);
 }
 
@@ -59,11 +59,11 @@ fn test_recursive_function() {
 Signature: let rec factorial n =
 Parameters: n
 Calls: factorial
+File: test test.ml
 Code:
 let rec factorial n =
   if n <= 1 then 1
-  else n * factorial (n - 1)
-File: test test.ml";
+  else n * factorial (n - 1)";
     assert_eq!(text, expected);
 }
 
@@ -93,9 +93,9 @@ end
     let helper_expected = "Function: helper
 Signature: let helper x = x * 2
 Parameters: x
+File: test test.ml
 Code:
-  let helper x = x * 2
-File: test test.ml";
+  let helper x = x * 2";
     assert_eq!(helper_text, helper_expected);
 
     let another_func = get_unit_by_name(&units, "another").unwrap();
@@ -104,9 +104,9 @@ File: test test.ml";
     let another_expected = "Function: another
 Signature: let another y = y + 1
 Parameters: y
+File: test test.ml
 Code:
-  let another y = y + 1
-File: test test.ml";
+  let another y = y + 1";
     assert_eq!(another_text, another_expected);
 }
 
@@ -122,9 +122,9 @@ fn test_function_with_type_annotation() {
     let expected = "Function: add
 Signature: let add (a : int) (b : int) : int = a + b
 Parameters: a, b
+File: test test.ml
 Code:
-let add (a : int) (b : int) : int = a + b
-File: test test.ml";
+let add (a : int) (b : int) : int = a + b";
     assert_eq!(text, expected);
 }
 
@@ -142,11 +142,11 @@ fn test_pattern_matching() {
     let expected = "Function: length
 Signature: let rec length = function
 Calls: length
+File: test test.ml
 Code:
 let rec length = function
   | [] -> 0
-  | _ :: xs -> 1 + length xs
-File: test test.ml";
+  | _ :: xs -> 1 + length xs";
     assert_eq!(text, expected);
 }
 
@@ -197,11 +197,11 @@ fn test_let_binding_with_match() {
     let expected = "Function: first_or_default
 Signature: let first_or_default default = function
 Parameters: default
+File: test test.ml
 Code:
 let first_or_default default = function
   | [] -> default
-  | x :: _ -> x
-File: test test.ml";
+  | x :: _ -> x";
     assert_eq!(text, expected);
 }
 
@@ -221,10 +221,10 @@ and odd n =
 Signature: let rec even n =
 Parameters: n
 Calls: odd
+File: test test.ml
 Code:
 let rec even n =
-  if n = 0 then true else odd (n - 1)
-File: test test.ml";
+  if n = 0 then true else odd (n - 1)";
     assert_eq!(even_text, even_expected);
 
     let odd_func = get_unit_by_name(&units, "odd").unwrap();
@@ -234,10 +234,10 @@ File: test test.ml";
 Signature: and odd n =
 Parameters: n
 Calls: even
+File: test test.ml
 Code:
 and odd n =
-  if n = 0 then false else even (n - 1)
-File: test test.ml";
+  if n = 0 then false else even (n - 1)";
     assert_eq!(odd_text, odd_expected);
 }
 
@@ -258,9 +258,9 @@ Signature: let greet name =
 Parameters: name
 Calls: printf
 Uses: Printf
+File: test test.ml
 Code:
 let greet name =
-  Printf.printf "Hello, %s!\n" name
-File: test test.ml"#;
+  Printf.printf "Hello, %s!\n" name"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_php.rs
+++ b/colgrep/src/parser/tests/test_php.rs
@@ -19,11 +19,11 @@ function greet($name) {
     let expected = "Function: greet
 Signature: function greet($name) {
 Parameters: $name
+File: test test.php
 Code:
 function greet($name) {
     return \"Hello, \" . $name . \"!\";
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -50,11 +50,11 @@ function add($a, $b) {
 Signature: function add($a, $b) {
 Description: Calculates the sum of two numbers. @param int $a First number @param int $b Second number @return int Sum of a and b /
 Parameters: $a, $b
+File: test test.php
 Code:
 function add($a, $b) {
     return $a + $b;
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -86,6 +86,7 @@ class Person {
         class_text,
         "Class: Person
 Signature: class Person {
+File: test test.php
 Code:
 class Person {
     private $name;
@@ -99,8 +100,7 @@ class Person {
     public function greet() {
         return \"Hello, I'm \" . $this->name;
     }
-}
-File: test test.php"
+}"
     );
 
     // Verify NO separate method units exist
@@ -129,11 +129,11 @@ function add(int $a, int $b): int {
     let expected = "Function: add
 Signature: function add(int $a, int $b): int {
 Parameters: $a, $b
+File: test test.php
 Code:
 function add(int $a, int $b): int {
     return $a + $b;
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -157,13 +157,13 @@ class Utils {
         class_text,
         "Class: Utils
 Signature: class Utils {
+File: test test.php
 Code:
 class Utils {
     public static function helper(): string {
         return \"help\";
     }
-}
-File: test test.php"
+}"
     );
 
     // Verify NO separate method unit exists
@@ -191,12 +191,12 @@ interface Drawable {
         text,
         "Class: Drawable
 Signature: interface Drawable {
+File: test test.php
 Code:
 interface Drawable {
     public function draw(): void;
     public function getBounds(): array;
-}
-File: test test.php"
+}"
     );
 
     // Verify NO separate method units exist
@@ -226,11 +226,11 @@ function helper(): int {
 
     let expected = "Function: helper
 Signature: function helper(): int {
+File: test test.php
 Code:
 function helper(): int {
     return 42;
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -254,13 +254,13 @@ trait Loggable {
         text,
         "Class: Loggable
 Signature: trait Loggable {
+File: test test.php
 Code:
 trait Loggable {
     public function log(string $message): void {
         echo $message;
     }
-}
-File: test test.php"
+}"
     );
 
     // Verify NO separate method unit exists
@@ -291,6 +291,7 @@ abstract class Shape {
         class_text,
         "Class: Shape
 Signature: abstract class Shape {
+File: test test.php
 Code:
 abstract class Shape {
     abstract public function area(): float;
@@ -298,8 +299,7 @@ abstract class Shape {
     public function describe(): string {
         return \"I am a shape\";
     }
-}
-File: test test.php"
+}"
     );
 
     // Verify NO separate method units exist
@@ -330,13 +330,13 @@ function getMultiplier(int $factor): callable {
     let expected = "Function: getMultiplier
 Signature: function getMultiplier(int $factor): callable {
 Parameters: $factor
+File: test test.php
 Code:
 function getMultiplier(int $factor): callable {
     return function(int $x) use ($factor): int {
         return $x * $factor;
     };
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -359,11 +359,11 @@ function process(array $items): array {
 Signature: function process(array $items): array {
 Parameters: $items
 Calls: array_map
+File: test test.php
 Code:
 function process(array $items): array {
     return array_map(fn($x) => $x * 2, $items);
-}
-File: test test.php";
+}";
 
     assert_eq!(text, expected);
 }
@@ -392,13 +392,13 @@ class Dog extends Animal {
         animal_text,
         r#"Class: Animal
 Signature: class Animal {
+File: test test.php
 Code:
 class Animal {
     public function speak() {
         return "...";
     }
-}
-File: test test.php"#
+}"#
     );
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -411,13 +411,13 @@ File: test test.php"#
         r#"Class: Dog
 Signature: class Dog extends Animal {
 Extends: Animal
+File: test test.php
 Code:
 class Dog extends Animal {
     public function speak() {
         return "Woof!";
     }
-}
-File: test test.php"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -445,11 +445,11 @@ function getToday(): string {
     let expected = r#"Function: getToday
 Signature: function getToday(): string {
 Uses: DateTime
+File: test test.php
 Code:
 function getToday(): string {
     $dt = new DateTime();
     return $dt->format('Y-m-d');
-}
-File: test test.php"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_python.rs
+++ b/colgrep/src/parser/tests/test_python.rs
@@ -18,11 +18,11 @@ Signature: def greet(name: str) -> str:
 Description: """Say hello to someone.
 Parameters: name
 Returns: str
+File: test test.py
 Code:
 def greet(name: str) -> str:
     """Say hello to someone."""
-    return f"Hello, {name}!"
-File: test test.py"#;
+    return f"Hello, {name}!""#;
     assert_eq!(text, expected);
 }
 
@@ -45,11 +45,11 @@ Parameters: url
 Returns: dict
 Calls: loads
 Uses: json
+File: test test.py
 Code:
 def fetch_data(url: str) -> dict:
     """Fetch JSON data from URL."""
-    return json.loads("{}")
-File: test test.py"#;
+    return json.loads("{}")"#;
     assert_eq!(text, expected);
 }
 
@@ -74,6 +74,7 @@ fn test_class_definition() {
 Signature: class Calculator:
 Description: """A simple calculator class.
 Variables: self.value
+File: test test.py
 Code:
 class Calculator:
     """A simple calculator class."""
@@ -84,8 +85,7 @@ class Calculator:
     def add(self, x: int) -> int:
         """Add x to the current value."""
         self.value += x
-        return self.value
-File: test test.py"#;
+        return self.value"#;
     assert_eq!(class_text, expected_class);
 
     // Methods should NOT be extracted separately - they are part of the class chunk
@@ -117,13 +117,13 @@ def decorated_func():
     let expected = r#"Function: decorated_func
 Signature: def decorated_func():
 Description: """A decorated function.
+File: test test.py
 Code:
 @staticmethod
 @decorator_with_args(arg=1)
 def decorated_func():
     """A decorated function."""
-    pass
-File: test test.py"#;
+    pass"#;
     assert_eq!(text, expected);
 }
 
@@ -141,11 +141,11 @@ Signature: async def fetch_async(url: str) -> bytes:
 Description: """Fetch data asynchronously.
 Parameters: url
 Returns: bytes
+File: test test.py
 Code:
 async def fetch_async(url: str) -> bytes:
     """Fetch data asynchronously."""
-    return b"data"
-File: test test.py"#;
+    return b"data""#;
     assert_eq!(text, expected);
 }
 
@@ -162,11 +162,11 @@ fn test_function_with_args_kwargs() {
 Signature: def variadic_func(*args, **kwargs):
 Description: """Function with variadic arguments.
 Parameters: args, kwargs
+File: test test.py
 Code:
 def variadic_func(*args, **kwargs):
     """Function with variadic arguments."""
-    return args, kwargs
-File: test test.py"#;
+    return args, kwargs"#;
     assert_eq!(text, expected);
 }
 
@@ -205,6 +205,7 @@ Description: """
         The processed result
 Parameters: x, y
 Returns: int
+File: test test.py
 Code:
 def complex_function(x: int, y: int) -> int:
     """
@@ -219,8 +220,7 @@ def complex_function(x: int, y: int) -> int:
     Returns:
         The processed result
     """
-    return x + y
-File: test test.py"##;
+    return x + y"##;
     assert_eq!(text, expected);
 }
 
@@ -265,6 +265,7 @@ fn test_nested_class() {
     let expected_outer = r#"Class: Outer
 Signature: class Outer:
 Description: """Outer class.
+File: test test.py
 Code:
 class Outer:
     """Outer class."""
@@ -273,8 +274,7 @@ class Outer:
         """Inner class."""
 
         def inner_method(self):
-            pass
-File: test test.py"#;
+            pass"#;
     assert_eq!(outer_text, expected_outer);
 }
 
@@ -308,12 +308,12 @@ class Cat(Animal):
 Signature: class Dog(Animal):
 Extends: Animal
 Description: """A dog that barks.
+File: test test.py
 Code:
 class Dog(Animal):
     """A dog that barks."""
     def speak(self):
-        return "Woof!"
-File: test test.py"#;
+        return "Woof!""#;
     assert_eq!(dog_text, expected_dog);
 
     let cat = get_unit_by_name(&units, "Cat").unwrap();
@@ -322,12 +322,12 @@ File: test test.py"#;
 Signature: class Cat(Animal):
 Extends: Animal
 Description: """A cat that meows.
+File: test test.py
 Code:
 class Cat(Animal):
     """A cat that meows."""
     def speak(self):
-        return "Meow!"
-File: test test.py"#;
+        return "Meow!""#;
     assert_eq!(cat_text, expected_cat);
 }
 
@@ -344,10 +344,10 @@ def real_function():
     let expected = r#"Function: real_function
 Signature: def real_function():
 Calls: square
+File: test test.py
 Code:
 def real_function():
-    return square(5)
-File: test test.py"#;
+    return square(5)"#;
     assert_eq!(text, expected);
 
     // Lambda should not be extracted as a separate function

--- a/colgrep/src/parser/tests/test_ruby.rs
+++ b/colgrep/src/parser/tests/test_ruby.rs
@@ -18,11 +18,11 @@ end
     let expected = r#"Function: greet
 Signature: def greet(name)
 Parameters: name
+File: test test.rb
 Code:
 def greet(name)
   "Hello, #{name}!"
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -45,11 +45,11 @@ end
 Signature: def add(a, b)
 Description: Calculates the sum of two numbers. @param a [Integer] First number @param b [Integer] Second number @return [Integer] Sum of a and b
 Parameters: a, b
+File: test test.rb
 Code:
 def add(a, b)
   a + b
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -72,6 +72,7 @@ end
     let class_text = build_embedding_text(class_unit);
     let expected_class = r#"Class: Calculator
 Signature: class Calculator
+File: test test.rb
 Code:
 class Calculator
   def initialize(value = 0)
@@ -81,8 +82,7 @@ class Calculator
   def add(x)
     @value += x
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method units exist
@@ -110,11 +110,11 @@ end
     let expected = r#"Function: greet
 Signature: def greet(name = "World", greeting = "Hello")
 Parameters: name, greeting
+File: test test.rb
 Code:
 def greet(name = "World", greeting = "Hello")
   greeting + ", " + name + "!"
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -132,11 +132,11 @@ end
     let expected = r#"Function: create_user
 Signature: def create_user(name:, email:, age: nil)
 Parameters: name, email, age
+File: test test.rb
 Code:
 def create_user(name:, email:, age: nil)
   { name: name, email: email, age: age }
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -159,6 +159,7 @@ end
     let module_text = build_embedding_text(module_unit);
     let expected_module = r#"Class: Utils
 Signature: module Utils
+File: test test.rb
 Code:
 module Utils
   def self.helper(x)
@@ -168,8 +169,7 @@ module Utils
   def instance_helper(x)
     x + 1
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(module_text, expected_module);
 
     // Verify NO separate method units exist
@@ -201,14 +201,14 @@ end
 Signature: def with_logging
 Calls: puts
 Variables: result
+File: test test.rb
 Code:
 def with_logging
   puts "Starting..."
   result = yield
   puts "Done!"
   result
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }
 
@@ -231,6 +231,7 @@ end
     let expected_class = r#"Class: Factory
 Signature: class Factory
 Calls: new
+File: test test.rb
 Code:
 class Factory
   def self.create(type)
@@ -239,8 +240,7 @@ class Factory
     when :gadget then Gadget.new
     end
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method unit exists
@@ -268,11 +268,11 @@ end
 Signature: def sum(*numbers)
 Parameters: numbers
 Calls: reduce
+File: test test.rb
 Code:
 def sum(*numbers)
   numbers.reduce(0, :+)
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(sum_text, expected_sum);
 
     let merge_unit = get_unit_by_name(&units, "merge").unwrap();
@@ -281,11 +281,11 @@ File: test test.rb"#;
 Signature: def merge(**options)
 Parameters: options
 Calls: merge
+File: test test.rb
 Code:
 def merge(**options)
   { default: true }.merge(options)
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(merge_text, expected_merge);
 }
 
@@ -309,6 +309,7 @@ end
     let expected_class = r#"Class: Person
 Signature: class Person
 Calls: attr_accessor, attr_reader
+File: test test.rb
 Code:
 class Person
   attr_reader :name
@@ -318,8 +319,7 @@ class Person
     @name = name
     @age = age
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method unit exists
@@ -350,6 +350,7 @@ end
     let class_text = build_embedding_text(class_unit);
     let expected_class = r#"Class: Service
 Signature: class Service
+File: test test.rb
 Code:
 class Service
   def public_method
@@ -361,8 +362,7 @@ class Service
   def helper
     "secret"
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(class_text, expected_class);
 
     // Verify NO separate method units exist
@@ -397,13 +397,13 @@ end
     let animal_text = build_embedding_text(animal);
     let expected_animal = r#"Class: Animal
 Signature: class Animal
+File: test test.rb
 Code:
 class Animal
   def speak
     "..."
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(animal_text, expected_animal);
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -414,13 +414,13 @@ File: test test.rb"#;
     let expected_dog = r#"Class: Dog
 Signature: class Dog < Animal
 Extends: Animal
+File: test test.rb
 Code:
 class Dog < Animal
   def speak
     "Woof!"
   end
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(dog_text, expected_dog);
 
     // Verify NO separate method units exist
@@ -447,10 +447,10 @@ Signature: def parse_data(str)
 Parameters: str
 Calls: parse
 Uses: json
+File: test test.rb
 Code:
 def parse_data(str)
   JSON.parse(str)
-end
-File: test test.rb"#;
+end"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_rust.rs
+++ b/colgrep/src/parser/tests/test_rust.rs
@@ -18,11 +18,11 @@ fn test_basic_function() {
 Signature: fn add(a: i32, b: i32) -> i32 {
 Parameters: a, b
 Returns: i32
+File: test test.rs
 Code:
 fn add(a: i32, b: i32) -> i32 {
     a + b
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -46,6 +46,7 @@ Signature: fn add(a: i32, b: i32) -> i32 {
 Description: Calculates the sum of two numbers.  # Arguments * `a` - First number * `b` - Second number
 Parameters: a, b
 Returns: i32
+File: test test.rs
 Code:
 /// Calculates the sum of two numbers.
 ///
@@ -54,8 +55,7 @@ Code:
 /// * `b` - Second number
 fn add(a: i32, b: i32) -> i32 {
     a + b
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -73,11 +73,11 @@ fn test_public_function() {
 Signature: pub fn public_func() -> String {
 Returns: String
 Calls: from
+File: test test.rs
 Code:
 pub fn public_func() -> String {
     String::from("public")
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -98,11 +98,11 @@ Signature: fn read_file(path: &str) -> Result<String, io::Error> {
 Parameters: path
 Returns: Result<String, io::Error>
 Calls: read_to_string
+File: test test.rs
 Code:
 fn read_file(path: &str) -> Result<String, io::Error> {
     std::fs::read_to_string(path)
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -122,12 +122,12 @@ Parameters: url
 Returns: Result<String, Error>
 Calls: get, text
 Variables: response
+File: test test.rs
 Code:
 async fn fetch_data(url: &str) -> Result<String, Error> {
     let response = reqwest::get(url).await?;
     response.text().await
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -145,13 +145,13 @@ pub struct Point {
     let expected = r#"Class: Point
 Signature: pub struct Point {
 Description: A 2D point.
+File: test test.rs
 Code:
 /// A 2D point.
 pub struct Point {
     pub x: f64,
     pub y: f64,
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -177,11 +177,11 @@ impl Calculator {
     let class_text = build_embedding_text(class);
     let expected_class = r#"Class: Calculator
 Signature: struct Calculator {
+File: test test.rs
 Code:
 struct Calculator {
     value: i32,
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(class_text, expected_class);
 
     let new_method = get_unit_by_name(&units, "new").unwrap();
@@ -191,11 +191,11 @@ Signature: pub fn new(initial: i32) -> Self {
 Class: Calculator
 Parameters: initial
 Returns: Self
+File: test test.rs
 Code:
     pub fn new(initial: i32) -> Self {
         Self { value: initial }
-    }
-File: test test.rs"#;
+    }"#;
     assert_eq!(new_text, expected_new);
 
     let add_method = get_unit_by_name(&units, "add").unwrap();
@@ -205,12 +205,12 @@ Signature: pub fn add(&mut self, x: i32) -> i32 {
 Class: Calculator
 Parameters: x
 Returns: i32
+File: test test.rs
 Code:
     pub fn add(&mut self, x: i32) -> i32 {
         self.value += x;
         self.value
-    }
-File: test test.rs"#;
+    }"#;
     assert_eq!(add_text, expected_add);
 }
 
@@ -231,11 +231,11 @@ fn swap<T, U>(a: T, b: U) -> (U, T) {
 Signature: fn identity<T>(value: T) -> T {
 Parameters: value
 Returns: T
+File: test test.rs
 Code:
 fn identity<T>(value: T) -> T {
     value
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(identity_text, expected_identity);
 
     let swap = get_unit_by_name(&units, "swap").unwrap();
@@ -244,11 +244,11 @@ File: test test.rs"#;
 Signature: fn swap<T, U>(a: T, b: U) -> (U, T) {
 Parameters: a, b
 Returns: (U, T)
+File: test test.rs
 Code:
 fn swap<T, U>(a: T, b: U) -> (U, T) {
     (b, a)
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(swap_text, expected_swap);
 }
 
@@ -266,13 +266,13 @@ fn test_macro_calls() {
     let expected = r#"Function: main
 Signature: fn main() {
 Calls: assert, println, vec
+File: test test.rs
 Code:
 fn main() {
     println!("Hello, world!");
     vec![1, 2, 3];
     assert!(true);
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -307,12 +307,12 @@ fn test_trait_definition() {
 
     let expected = r#"Class: Drawable
 Signature: pub trait Drawable {
+File: test test.rs
 Code:
 pub trait Drawable {
     fn draw(&self);
     fn bounds(&self) -> Rectangle;
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -329,13 +329,13 @@ fn test_enum_definition() {
 
     let expected = r#"Class: Status
 Signature: pub enum Status {
+File: test test.rs
 Code:
 pub enum Status {
     Active,
     Inactive,
     Pending(String),
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -358,13 +358,13 @@ struct MyStruct {
     let expected = r#"Function: test_something
 Signature: fn test_something() {
 Calls: assert
+File: test test.rs
 Code:
 #[test]
 #[ignore]
 fn test_something() {
     assert!(true);
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -392,11 +392,11 @@ Parameters: path
 Returns: io::Result<String>
 Calls: open, read_to_string
 Variables: file
+File: test test.rs
 Code:
 fn read_config(path: &str) -> io::Result<String> {
     let file = File::open(path)?;
     std::io::read_to_string(file)
-}
-File: test test.rs"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_scala.rs
+++ b/colgrep/src/parser/tests/test_scala.rs
@@ -17,11 +17,11 @@ fn test_basic_function() {
     let expected = r#"Function: greet
 Signature: def greet(name: String): String = {
 Parameters: name
+File: test test.scala
 Code:
 def greet(name: String): String = {
   s"Hello, $name!"
-}
-File: test test.scala"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -43,9 +43,9 @@ def add(a: Int, b: Int): Int = a + b"#;
 Signature: def add(a: Int, b: Int): Int = a + b
 Description: Calculates the sum of two numbers. @param a First number @param b Second number @return Sum of a and b /
 Parameters: a, b
+File: test test.scala
 Code:
-def add(a: Int, b: Int): Int = a + b
-File: test test.scala";
+def add(a: Int, b: Int): Int = a + b";
     assert_eq!(text, expected);
 }
 
@@ -63,11 +63,11 @@ fn test_class_definition() {
         text,
         r#"Class: Person
 Signature: class Person(val name: String, var age: Int) {
+File: test test.scala
 Code:
 class Person(val name: String, var age: Int) {
   def greet(): String = s"Hello, I'm $name"
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -86,9 +86,9 @@ fn test_case_class() {
     let text = build_embedding_text(class);
     let expected = r#"Class: User
 Signature: case class User(id: Int, name: String, email: String)
+File: test test.scala
 Code:
-case class User(id: Int, name: String, email: String)
-File: test test.scala"#;
+case class User(id: Int, name: String, email: String)"#;
     assert_eq!(text, expected);
 }
 
@@ -109,13 +109,13 @@ fn test_object_definition() {
         r#"Class: Utils
 Signature: object Utils {
 Variables: constant
+File: test test.scala
 Code:
 object Utils {
   def helper(x: Int): Int = x * 2
 
   val constant: String = "value"
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -140,12 +140,12 @@ fn test_trait_definition() {
         text,
         r#"Class: Drawable
 Signature: trait Drawable {
+File: test test.scala
 Code:
 trait Drawable {
   def draw(): Unit
   def bounds: Rectangle
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -171,9 +171,9 @@ def swap[A, B](pair: (A, B)): (B, A) = (pair._2, pair._1)"#;
     let expected = r#"Function: identity
 Signature: def identity[T](value: T): T = value
 Parameters: value
+File: test test.scala
 Code:
-def identity[T](value: T): T = value
-File: test test.scala"#;
+def identity[T](value: T): T = value"#;
     assert_eq!(text, expected);
 
     let func = get_unit_by_name(&units, "swap").unwrap();
@@ -181,9 +181,9 @@ File: test test.scala"#;
     let expected = r#"Function: swap
 Signature: def swap[A, B](pair: (A, B)): (B, A) = (pair._2, pair._1)
 Parameters: pair
+File: test test.scala
 Code:
-def swap[A, B](pair: (A, B)): (B, A) = (pair._2, pair._1)
-File: test test.scala"#;
+def swap[A, B](pair: (A, B)): (B, A) = (pair._2, pair._1)"#;
     assert_eq!(text, expected);
 }
 
@@ -202,11 +202,11 @@ fn test_implicit_class() {
         r#"Class: StringOps
 Signature: implicit class StringOps(val s: String) extends AnyVal {
 Extends: AnyVal
+File: test test.scala
 Code:
 implicit class StringOps(val s: String) extends AnyVal {
   def addExclamation: String = s + "!"
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -228,9 +228,9 @@ case class Failure(message: String) extends Result[Nothing]"#;
     let expected = r#"Class: Result
 Signature: sealed trait Result[+T]
 Parameters: T
+File: test test.scala
 Code:
-sealed trait Result[+T]
-File: test test.scala"#;
+sealed trait Result[+T]"#;
     assert_eq!(text, expected);
 
     let class = get_unit_by_name(&units, "Success").unwrap();
@@ -239,9 +239,9 @@ File: test test.scala"#;
 Signature: case class Success[T](value: T) extends Result[T]
 Extends: Result
 Parameters: T
+File: test test.scala
 Code:
-case class Success[T](value: T) extends Result[T]
-File: test test.scala"#;
+case class Success[T](value: T) extends Result[T]"#;
     assert_eq!(text, expected);
 
     let class = get_unit_by_name(&units, "Failure").unwrap();
@@ -249,9 +249,9 @@ File: test test.scala"#;
     let expected = r#"Class: Failure
 Signature: case class Failure(message: String) extends Result[Nothing]
 Extends: Result
+File: test test.scala
 Code:
-case class Failure(message: String) extends Result[Nothing]
-File: test test.scala"#;
+case class Failure(message: String) extends Result[Nothing]"#;
     assert_eq!(text, expected);
 }
 
@@ -276,9 +276,9 @@ object Circle {
         text,
         r#"Class: Circle
 Signature: class Circle(val radius: Double)
+File: test test.scala
 Code:
-class Circle(val radius: Double)
-File: test test.scala"#
+class Circle(val radius: Double)"#
     );
 
     // Companion object is extracted as a single chunk with methods inside
@@ -288,12 +288,12 @@ File: test test.scala"#
         text,
         r#"Class: Circle
 Signature: object Circle {
+File: test test.scala
 Code:
 object Circle {
   def apply(radius: Double): Circle = new Circle(radius)
   def unit: Circle = new Circle(1.0)
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -320,11 +320,11 @@ fn test_higher_order_function() {
 Signature: def map[A, B](list: List[A])(f: A => B): List[B] = {
 Parameters: list
 Calls: map
+File: test test.scala
 Code:
 def map[A, B](list: List[A])(f: A => B): List[B] = {
   list.map(f)
-}
-File: test test.scala"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -346,11 +346,11 @@ class Dog extends Animal {
         animal_text,
         r#"Class: Animal
 Signature: class Animal {
+File: test test.scala
 Code:
 class Animal {
   def speak(): String = "..."
-}
-File: test test.scala"#
+}"#
     );
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -363,11 +363,11 @@ File: test test.scala"#
         r#"Class: Dog
 Signature: class Dog extends Animal {
 Extends: Animal
+File: test test.scala
 Code:
 class Dog extends Animal {
   override def speak(): String = "Woof!"
-}
-File: test test.scala"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -396,12 +396,12 @@ Parameters: items
 Calls: foreach
 Variables: buffer
 Uses: ArrayBuffer
+File: test test.scala
 Code:
 def processBuffer(items: List[String]): ArrayBuffer[String] = {
   val buffer = ArrayBuffer.empty[String]
   items.foreach(item => buffer += item)
   buffer
-}
-File: test test.scala"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_svelte.rs
+++ b/colgrep/src/parser/tests/test_svelte.rs
@@ -29,11 +29,11 @@ fn test_basic_component() {
         text,
         "Function: increment
 Signature: function increment() {
+File: test test.svelte
 Code:
     function increment() {
         count += 1;
-    }
-File: test test.svelte"
+    }"
     );
 
     let text = build_embedding_text(&units[2]);
@@ -68,11 +68,11 @@ fn test_reactive_declarations() {
         text,
         "Function: increment
 Signature: function increment() {
+File: test test.svelte
 Code:
     function increment() {
         count += 1;
-    }
-File: test test.svelte"
+    }"
     );
 }
 
@@ -97,11 +97,11 @@ fn test_props() {
     let greet_text = build_embedding_text(greet_unit);
     let expected_greet = r#"Function: greet
 Signature: function greet() {
+File: test test.svelte
 Code:
     function greet() {
         return `${greeting}, ${name}!`;
-    }
-File: test test.svelte"#;
+    }"#;
     assert_eq!(greet_text, expected_greet);
 }
 
@@ -280,11 +280,11 @@ Signature: async function fetchUsers() {
 Calls: get
 Variables: const, response
 Uses: axios
+File: test test.svelte
 Code:
 async function fetchUsers() {
     const response = await axios.get('/api/users');
     return response.data;
-}
-File: test test.svelte"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_swift.rs
+++ b/colgrep/src/parser/tests/test_swift.rs
@@ -17,11 +17,11 @@ fn test_basic_function() {
     let expected = r#"Function: greet
 Signature: func greet(name: String) -> String {
 Parameters: name
+File: test test.swift
 Code:
 func greet(name: String) -> String {
     return "Hello, \(name)!"
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -44,11 +44,11 @@ func add(a: Int, b: Int) -> Int {
 Signature: func add(a: Int, b: Int) -> Int {
 Description: Calculates the sum of two numbers. - Parameters: - a: First number - b: Second number - Returns: Sum of a and b
 Parameters: a, b
+File: test test.swift
 Code:
 func add(a: Int, b: Int) -> Int {
     return a + b
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -75,6 +75,7 @@ fn test_class_definition() {
     let expected = r#"Class: Person
 Signature: class Person {
 Variables: age, name
+File: test test.swift
 Code:
 class Person {
     var name: String
@@ -88,8 +89,7 @@ class Person {
     func greet() -> String {
         return "Hello, I'm \(name)"
     }
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 
     // Verify NO separate method unit exists
@@ -118,6 +118,7 @@ fn test_struct_definition() {
 Signature: struct Point {
 Calls: sqrt
 Variables: x, y
+File: test test.swift
 Code:
 struct Point {
     var x: Double
@@ -126,8 +127,7 @@ struct Point {
     func distance() -> Double {
         return sqrt(x*x + y*y)
     }
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 
     // Verify NO separate method unit exists
@@ -152,12 +152,12 @@ fn test_async_function() {
 Signature: func fetchData(url: URL) async throws -> Data {
 Parameters: url
 Calls: data
+File: test test.swift
 Code:
 func fetchData(url: URL) async throws -> Data {
     let (data, _) = try await URLSession.shared.data(from: url)
     return data
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -178,14 +178,14 @@ fn test_function_with_throws() {
 Signature: func parse(data: String) throws -> Int {
 Parameters: data
 Calls: Int
+File: test test.swift
 Code:
 func parse(data: String) throws -> Int {
     guard let result = Int(data) else {
         throw ParseError.invalidFormat
     }
     return result
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -201,12 +201,12 @@ fn test_protocol_definition() {
     let text = build_embedding_text(protocol);
     let expected = r#"Class: Drawable
 Signature: protocol Drawable {
+File: test test.swift
 Code:
 protocol Drawable {
     func draw()
     var bounds: CGRect { get }
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -232,6 +232,7 @@ fn test_enum_definition() {
     let expected = r#"Class: Status
 Signature: enum Status {
 Variables: description
+File: test test.swift
 Code:
 enum Status {
     case active
@@ -245,8 +246,7 @@ enum Status {
         case .pending(let reason): return "Pending: \(reason)"
         }
     }
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -264,13 +264,13 @@ fn test_extension() {
     let text = build_embedding_text(ext);
     let expected = r#"Class: String
 Signature: extension String {
+File: test test.swift
 Code:
 extension String {
     func addExclamation() -> String {
         return self + "!"
     }
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 
     // Verify NO separate method unit exists
@@ -295,13 +295,13 @@ fn test_generic_function() {
 Signature: func swap<T>(a: inout T, b: inout T) {
 Parameters: a, b
 Variables: temp
+File: test test.swift
 Code:
 func swap<T>(a: inout T, b: inout T) {
     let temp = a
     a = b
     b = temp
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -322,6 +322,7 @@ struct Clamped<Value: Comparable> {
 Signature: @propertyWrapper
 Calls: max, min
 Variables: range, wrappedValue
+File: test test.swift
 Code:
 @propertyWrapper
 struct Clamped<Value: Comparable> {
@@ -329,8 +330,7 @@ struct Clamped<Value: Comparable> {
         didSet { wrappedValue = min(max(wrappedValue, range.lowerBound), range.upperBound) }
     }
     let range: ClosedRange<Value>
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -356,13 +356,13 @@ class Dog: Animal {
         animal_text,
         r#"Class: Animal
 Signature: class Animal {
+File: test test.swift
 Code:
 class Animal {
     func speak() -> String {
         return "..."
     }
-}
-File: test test.swift"#
+}"#
     );
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -375,13 +375,13 @@ File: test test.swift"#
         r#"Class: Dog
 Signature: class Dog: Animal {
 Extends: Animal
+File: test test.swift
 Code:
 class Dog: Animal {
     override func speak() -> String {
         return "Woof!"
     }
-}
-File: test test.swift"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -414,12 +414,12 @@ Signature: func formatDate(_ date: Date) -> String {
 Parameters: date
 Calls: DateFormatter, string
 Variables: formatter
+File: test test.swift
 Code:
 func formatDate(_ date: Date) -> String {
     let formatter = DateFormatter()
     formatter.dateStyle = .medium
     return formatter.string(from: date)
-}
-File: test test.swift"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_typescript.rs
+++ b/colgrep/src/parser/tests/test_typescript.rs
@@ -17,11 +17,11 @@ fn test_basic_function_with_types() {
 Signature: function add(a: number, b: number): number {
 Parameters: a, b
 Returns: : number
+File: test test.ts
 Code:
 function add(a: number, b: number): number {
     return a + b;
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -43,11 +43,11 @@ function getUser(id: number): User {
 Signature: function getUser(id: number): User {
 Parameters: id
 Returns: : User
+File: test test.ts
 Code:
 function getUser(id: number): User {
     return { id, name: "John" };
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -64,11 +64,11 @@ fn test_generic_function() {
 Signature: function identity<T>(value: T): T {
 Parameters: value
 Returns: : T
+File: test test.ts
 Code:
 function identity<T>(value: T): T {
     return value;
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -88,12 +88,12 @@ Parameters: id
 Returns: : Promise<User>
 Calls: fetch, json
 Variables: const, response
+File: test test.ts
 Code:
 async function fetchUser(id: number): Promise<User> {
     const response = await fetch(`/users/${id}`);
     return response.json();
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -120,6 +120,7 @@ fn test_class_with_types() {
         class_text,
         r#"Class: Calculator
 Signature: class Calculator {
+File: test test.ts
 Code:
 class Calculator {
     private value: number;
@@ -132,8 +133,7 @@ class Calculator {
         this.value += x;
         return this.value;
     }
-}
-File: test test.ts"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -156,11 +156,11 @@ fn test_function_with_optional_params() {
 Signature: function greet(name: string, greeting?: string): string {
 Parameters: name, greeting
 Returns: : string
+File: test test.ts
 Code:
 function greet(name: string, greeting?: string): string {
     return `${greeting || "Hello"}, ${name}!`;
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -179,11 +179,11 @@ function getUsers(): UserMap {
     let expected = r#"Function: getUsers
 Signature: function getUsers(): UserMap {
 Returns: : UserMap
+File: test test.ts
 Code:
 function getUsers(): UserMap {
     return new Map();
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -205,11 +205,11 @@ function getStatus(): Status {
     let expected = r#"Function: getStatus
 Signature: function getStatus(): Status {
 Returns: : Status
+File: test test.ts
 Code:
 function getStatus(): Status {
     return Status.Active;
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }
 
@@ -224,9 +224,9 @@ fn test_arrow_function_with_types() {
 Signature: const multiply = (a: number, b: number): number => a * b;
 Parameters: a, b
 Returns: : number
+File: test test.ts
 Code:
-const multiply = (a: number, b: number): number => a * b;
-File: test test.ts"#;
+const multiply = (a: number, b: number): number => a * b;"#;
     assert_eq!(text, expected);
 }
 
@@ -252,11 +252,11 @@ class Service {
 Signature: function Log(target: any, key: string) {
 Parameters: target, key
 Calls: log
+File: test test.ts
 Code:
 function Log(target: any, key: string) {
     console.log(`Called ${key}`);
-}
-File: test test.ts"#
+}"#
     );
 
     // Class is extracted as a single chunk with decorated method inside
@@ -267,14 +267,14 @@ File: test test.ts"#
         r#"Class: Service
 Signature: class Service {
 Calls: log
+File: test test.ts
 Code:
 class Service {
     @Log
     doSomething(): void {
         console.log("doing something");
     }
-}
-File: test test.ts"#
+}"#
     );
 
     // Verify NO separate method unit exists
@@ -324,13 +324,13 @@ class Dog extends Animal {
         animal_text,
         r#"Class: Animal
 Signature: class Animal {
+File: test test.ts
 Code:
 class Animal {
     speak(): string {
         return "...";
     }
-}
-File: test test.ts"#
+}"#
     );
     // Animal has no parent
     assert!(!animal_text.contains("Extends:"));
@@ -343,13 +343,13 @@ File: test test.ts"#
         r#"Class: Dog
 Signature: class Dog extends Animal {
 Extends: Animal
+File: test test.ts
 Code:
 class Dog extends Animal {
     speak(): string {
         return "Woof!";
     }
-}
-File: test test.ts"#
+}"#
     );
 
     // Verify NO separate method units exist
@@ -377,10 +377,10 @@ Parameters: url
 Returns: : Promise<any>
 Calls: get
 Uses: axios
+File: test test.ts
 Code:
 function fetchData(url: string): Promise<any> {
     return axios.get(url);
-}
-File: test test.ts"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/colgrep/src/parser/tests/test_vue.rs
+++ b/colgrep/src/parser/tests/test_vue.rs
@@ -29,10 +29,10 @@ export default {
     assert_eq!(units.len(), 3);
 
     let text = build_embedding_text(&units[0]);
-    assert_eq!(text, "Function: data\nSignature: data() {\nCode:\n    data() {\n        return { count: 0 }\n    },\nFile: test test.vue");
+    assert_eq!(text, "Function: data\nSignature: data() {\nFile: test test.vue\nCode:\n    data() {\n        return { count: 0 }\n    },");
 
     let text = build_embedding_text(&units[1]);
-    assert_eq!(text, "Function: increment\nSignature: increment() {\nCode:\n        increment() {\n            this.count++\n        }\nFile: test test.vue");
+    assert_eq!(text, "Function: increment\nSignature: increment() {\nFile: test test.vue\nCode:\n        increment() {\n            this.count++\n        }");
 
     let text = build_embedding_text(&units[2]);
     assert_eq!(
@@ -65,7 +65,7 @@ function increment() {
     assert_eq!(text, "const count = ref(0)");
 
     let text = build_embedding_text(&units[1]);
-    assert_eq!(text, "Function: increment\nSignature: function increment() {\nCode:\nfunction increment() {\n    count.value++\n}\nFile: test test.vue");
+    assert_eq!(text, "Function: increment\nSignature: function increment() {\nFile: test test.vue\nCode:\nfunction increment() {\n    count.value++\n}");
 
     let text = build_embedding_text(&units[2]);
     assert_eq!(
@@ -97,10 +97,10 @@ export default defineComponent({
     assert_eq!(units.len(), 3);
 
     let text = build_embedding_text(&units[0]);
-    assert_eq!(text, "Class: User\nSignature: interface User {\nCode:\ninterface User {\n    name: string\n    age: number\n}\nFile: test test.vue");
+    assert_eq!(text, "Class: User\nSignature: interface User {\nFile: test test.vue\nCode:\ninterface User {\n    name: string\n    age: number\n}");
 
     let text = build_embedding_text(&units[1]);
-    assert_eq!(text, "Function: setup\nSignature: setup() {\nCalls: ref\nVariables: const, user\nCode:\n    setup() {\n        const user = ref<User>({ name: 'John', age: 30 })\n        return { user }\n    }\nFile: test test.vue");
+    assert_eq!(text, "Function: setup\nSignature: setup() {\nCalls: ref\nVariables: const, user\nFile: test test.vue\nCode:\n    setup() {\n        const user = ref<User>({ name: 'John', age: 30 })\n        return { user }\n    }");
 
     let text = build_embedding_text(&units[2]);
     assert_eq!(
@@ -272,11 +272,11 @@ Parameters: url
 Calls: get
 Variables: const, response
 Uses: axios
+File: test test.vue
 Code:
 async function fetchData(url) {
     const response = await axios.get(url)
     data.value = response.data
-}
-File: test test.vue"#;
+}"#;
     assert_eq!(text, expected);
 }

--- a/next-plaid-onnx/src/lib.rs
+++ b/next-plaid-onnx/src/lib.rs
@@ -53,17 +53,23 @@ use ndarray::Array2;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
 use ort::value::Tensor;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::{ThreadPool, ThreadPoolBuilder};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::sync::Once;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
+use tokenizers::Encoding;
 use tokenizers::Tokenizer;
 
 // Conditional imports for execution providers
 #[cfg(feature = "cuda")]
-use ort::ep::ExecutionProvider as ExecutionProviderTrait;
+use ort::ep::ExecutionProvider as _;
 #[cfg(feature = "cuda")]
 use ort::execution_providers::CUDAExecutionProvider;
 
@@ -218,6 +224,13 @@ fn get_cuda_device_id() -> i32 {
     0
 }
 
+#[cfg(feature = "cuda")]
+fn configured_cuda_execution_provider() -> CUDAExecutionProvider {
+    CUDAExecutionProvider::default()
+        .with_device_id(get_cuda_device_id())
+        .with_tf32(true)
+}
+
 /// Check if CPU-only mode is forced via environment variable.
 /// Only checks the canonical `NEXT_PLAID_FORCE_CPU` env var.
 /// The higher-level `colgrep` crate's `apply_acceleration_mode()` propagates
@@ -310,13 +323,9 @@ fn configure_auto_provider(builder: SessionBuilder) -> Result<SessionBuilder> {
         // Wrap CUDA initialization in catch_cuda_panic to handle panics from stub libraries
         // without printing the default panic message to stderr
         let cuda_result = catch_cuda_panic(std::panic::AssertUnwindSafe(|| {
-            let device_id = get_cuda_device_id();
             builder
                 .clone()
-                .with_execution_providers([CUDAExecutionProvider::default()
-                    .with_device_id(device_id)
-                    .with_tf32(true)
-                    .build()])
+                .with_execution_providers([configured_cuda_execution_provider().build()])
         }));
         match cuda_result {
             Ok(Ok(b)) => return Ok(b),
@@ -380,13 +389,9 @@ fn configure_cuda(builder: SessionBuilder) -> Result<SessionBuilder> {
     // Wrap CUDA initialization in catch_cuda_panic to handle panics from stub/invalid libraries
     // without printing the default panic message to stderr
     let cuda_result = catch_cuda_panic(std::panic::AssertUnwindSafe(|| {
-        let device_id = get_cuda_device_id();
         builder
             .clone()
-            .with_execution_providers([CUDAExecutionProvider::default()
-                .with_device_id(device_id)
-                .with_tf32(true)
-                .build()])
+            .with_execution_providers([configured_cuda_execution_provider().build()])
     }));
 
     match cuda_result {
@@ -617,8 +622,6 @@ const DEFAULT_CPU_BATCH_SIZE: usize = 32;
 const DEFAULT_GPU_BATCH_SIZE: usize = 64;
 
 /// Type alias for batch encoding data: (input_ids, attention_mask, token_type_ids, token_ids)
-type BatchEncoding = (Vec<i64>, Vec<i64>, Vec<i64>, Vec<u32>);
-
 /// ColBERT model for encoding documents and queries into multi-vector embeddings.
 ///
 /// Supports both single-session and parallel multi-session encoding.
@@ -639,12 +642,109 @@ type BatchEncoding = (Vec<i64>, Vec<i64>, Vec<i64>, Vec<u32>);
 ///     .with_parallel(25)
 ///     .build()?;
 /// ```
+#[derive(Clone)]
 pub struct Colbert {
-    sessions: Vec<Mutex<Session>>,
+    sessions: Vec<Arc<Mutex<Session>>>,
     tokenizer: Arc<Tokenizer>,
-    config: ColbertConfig,
-    skiplist_ids: HashSet<u32>,
+    config: Arc<ColbertConfig>,
+    skiplist_ids: Arc<HashSet<u32>>,
+    next_session_idx: Arc<AtomicUsize>,
+    requested_execution_provider: ExecutionProvider,
     batch_size: usize,
+    dynamic_batch: bool,
+}
+
+pub struct PreparedDocumentBatch {
+    batch_size: usize,
+    batch_max_len: usize,
+    all_input_ids: Vec<i64>,
+    all_attention_mask: Vec<i64>,
+    all_token_type_ids: Option<Vec<i64>>,
+    all_token_ids: Vec<Vec<u32>>,
+    original_lengths: Vec<usize>,
+    is_query: bool,
+    filter_skiplist: bool,
+}
+
+struct TokenizedDocument {
+    ids: Vec<u32>,
+    type_ids: Vec<u32>,
+}
+
+struct DocumentEmbeddingChunk {
+    start_offset: usize,
+    embeddings: Vec<Array2<f32>>,
+}
+
+struct RawDocumentEmbeddingChunk {
+    start_offset: usize,
+    embeddings: Vec<Array2<f32>>,
+}
+
+struct RawDocumentEmbeddingStream {
+    receiver: mpsc::Receiver<Result<RawDocumentEmbeddingChunk>>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl Iterator for RawDocumentEmbeddingStream {
+    type Item = Result<RawDocumentEmbeddingChunk>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.receiver.recv() {
+            Ok(item) => Some(item),
+            Err(_) => {
+                self.join_workers();
+                None
+            }
+        }
+    }
+}
+
+impl Drop for RawDocumentEmbeddingStream {
+    fn drop(&mut self) {
+        self.join_workers();
+    }
+}
+
+impl RawDocumentEmbeddingStream {
+    fn join_workers(&mut self) {
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}
+
+struct DocumentEmbeddingStream {
+    receiver: mpsc::Receiver<Result<DocumentEmbeddingChunk>>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl Iterator for DocumentEmbeddingStream {
+    type Item = Result<DocumentEmbeddingChunk>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.receiver.recv() {
+            Ok(item) => Some(item),
+            Err(_) => {
+                self.join_workers();
+                None
+            }
+        }
+    }
+}
+
+impl Drop for DocumentEmbeddingStream {
+    fn drop(&mut self) {
+        self.join_workers();
+    }
+}
+
+impl DocumentEmbeddingStream {
+    fn join_workers(&mut self) {
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
+        }
+    }
 }
 
 /// Builder for configuring [`Colbert`].
@@ -672,6 +772,7 @@ pub struct ColbertBuilder {
     batch_size: Option<usize>,
     execution_provider: ExecutionProvider,
     quantized: bool,
+    dynamic_batch: bool,
     query_length: Option<usize>,
     document_length: Option<usize>,
 }
@@ -694,6 +795,7 @@ impl ColbertBuilder {
             batch_size: None,
             execution_provider: ExecutionProvider::Auto,
             quantized: false,
+            dynamic_batch: true,
             query_length: None,
             document_length: None,
         }
@@ -705,9 +807,23 @@ impl ColbertBuilder {
     /// When enabled, uses 1 thread per session (optimal for parallel execution).
     ///
     /// Recommended: 25 for large models, 8 for small models.
+    /// This code is called with `num_sessions` set to 1 when intention
+    /// is clearly to run one session with many parallel threads.
     pub fn with_parallel(mut self, num_sessions: usize) -> Self {
-        self.num_sessions = num_sessions.max(1);
-        self.threads_per_session = 1; // Optimal for parallel sessions
+        match num_sessions {
+            0 | 1 => {
+                // Single session with auto-detected threads (default)
+                self.threads_per_session = std::thread::available_parallelism()
+                    .map(|p| p.get())
+                    .unwrap_or(4);
+                self.num_sessions = 1;
+            }
+            _ => {
+                // Parallel sessions with 1 thread each
+                self.num_sessions = num_sessions;
+                self.threads_per_session = 1; // Optimal for parallel sessions
+            }
+        };
         self
     }
 
@@ -738,6 +854,11 @@ impl ColbertBuilder {
     /// Quantization provides ~2x speedup with minimal quality loss (>99% cosine similarity).
     pub fn with_quantized(mut self, quantized: bool) -> Self {
         self.quantized = quantized;
+        self
+    }
+
+    pub fn with_dynamic_batch(mut self, dynamic_batch: bool) -> Self {
+        self.dynamic_batch = dynamic_batch;
         self
     }
 
@@ -796,11 +917,15 @@ impl ColbertBuilder {
                 .map_err(|e| anyhow::anyhow!("Failed to set ONNX intra-op threads: {e:?}"))?
                 .with_inter_threads(if self.num_sessions > 1 { 1 } else { 2 })
                 .map_err(|e| anyhow::anyhow!("Failed to set ONNX inter-op threads: {e:?}"))?;
-            // Disable memory pattern optimization for ~7% speedup on CPU
-            // (based on benchmarking - helps with variable-length sequences)
-            let builder = builder
-                .with_memory_pattern(false)
-                .map_err(|e| anyhow::anyhow!("Failed to configure ONNX memory pattern: {e:?}"))?;
+            // Keep the CPU-specific variable-shape tuning on CPU, but don't
+            // disable ORT memory patterns on GPU/Auto where it may reduce throughput.
+            let builder = if matches!(self.execution_provider, ExecutionProvider::Cpu) {
+                builder.with_memory_pattern(false).map_err(|e| {
+                    anyhow::anyhow!("Failed to configure ONNX memory pattern: {e:?}")
+                })?
+            } else {
+                builder
+            };
 
             let builder = configure_execution_provider(builder, self.execution_provider)?;
 
@@ -808,7 +933,7 @@ impl ColbertBuilder {
                 .commit_from_file(&onnx_path)
                 .context("Failed to load ONNX model")?;
 
-            sessions.push(Mutex::new(session));
+            sessions.push(Arc::new(Mutex::new(session)));
         }
 
         // Determine batch size
@@ -824,9 +949,12 @@ impl ColbertBuilder {
         Ok(Colbert {
             sessions,
             tokenizer: Arc::new(tokenizer),
-            config,
-            skiplist_ids,
+            config: Arc::new(config),
+            skiplist_ids: Arc::new(skiplist_ids),
+            next_session_idx: Arc::new(AtomicUsize::new(0)),
+            requested_execution_provider: self.execution_provider,
             batch_size,
+            dynamic_batch: self.dynamic_batch,
         })
     }
 }
@@ -888,24 +1016,274 @@ impl Colbert {
         if documents.is_empty() {
             return Ok(Vec::new());
         }
+        let owned_documents: Vec<String> = documents.iter().map(|doc| (*doc).to_string()).collect();
+        let mut stream = self.encode_documents_stream(owned_documents, pool_factor)?;
+        let mut ordered_embeddings: Vec<Option<Array2<f32>>> = vec![None; documents.len()];
 
-        let embeddings = if self.sessions.len() == 1 {
-            self.encode_single_session(documents, false, true)?
-        } else {
-            self.encode_parallel(documents, false, true)?
-        };
-
-        // Apply pooling if requested
-        match pool_factor {
-            Some(pf) if pf > 1 => {
-                let pooled: Vec<Array2<f32>> = embeddings
-                    .into_iter()
-                    .map(|emb| pool_embeddings_hierarchical(emb, pf, 1))
-                    .collect();
-                Ok(pooled)
+        for chunk in &mut stream {
+            let chunk = chunk?;
+            for (offset, embedding) in chunk.embeddings.into_iter().enumerate() {
+                ordered_embeddings[chunk.start_offset + offset] = Some(embedding);
             }
-            _ => Ok(embeddings),
         }
+
+        Ok(ordered_embeddings
+            .into_iter()
+            .map(|embedding| embedding.expect("Missing embedding from document stream"))
+            .collect())
+    }
+
+    pub fn tokenize_documents_in_batches(
+        &self,
+        documents: &[&str],
+    ) -> Result<Vec<PreparedDocumentBatch>> {
+        if documents.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let processed_texts = preprocess_texts(&self.config, documents);
+        let tokenized = tokenize_processed_texts_individually(&self.tokenizer, &processed_texts)?;
+        let truncate_limit = self.config.document_length - 1;
+        let use_gpu_batch_modes =
+            !matches!(self.requested_execution_provider, ExecutionProvider::Cpu);
+        let use_dynamic_batch = self.dynamic_batch && use_gpu_batch_modes;
+
+        let prepared_lengths: Vec<usize> = tokenized
+            .iter()
+            .map(|doc| doc.ids.len().min(truncate_limit) + 1)
+            .collect();
+        if !use_dynamic_batch {
+            let batch_docs = self.batch_size.max(1);
+            let mut batches = Vec::new();
+
+            let mut tokenized_iter = tokenized.into_iter();
+            while let Some(first) = tokenized_iter.next() {
+                let mut piece_encodings = Vec::with_capacity(batch_docs);
+                piece_encodings.push(first);
+                for encoding in tokenized_iter.by_ref().take(batch_docs - 1) {
+                    piece_encodings.push(encoding);
+                }
+
+                batches.push(prepare_batch_from_tokenized_documents(
+                    &self.tokenizer,
+                    &self.config,
+                    piece_encodings,
+                    false,
+                    true,
+                )?);
+            }
+
+            return Ok(batches);
+        }
+
+        let mut items: Vec<(usize, TokenizedDocument)> =
+            prepared_lengths.into_iter().zip(tokenized).collect();
+        items.sort_by_key(|(prepared_len, _)| *prepared_len);
+
+        let shapes =
+            build_fixed_dynamic_shapes(self.batch_size.max(1), self.config.document_length);
+        let mut buckets: Vec<Vec<TokenizedDocument>> =
+            (0..shapes.len()).map(|_| Vec::new()).collect();
+
+        for (prepared_len, encoding) in items {
+            let bucket_idx = shapes
+                .iter()
+                .position(|shape| prepared_len <= shape.planned_len)
+                .unwrap_or(shapes.len().saturating_sub(1));
+            buckets[bucket_idx].push(encoding);
+        }
+
+        let mut batches = Vec::new();
+        for (shape, bucket_docs) in shapes.iter().zip(buckets) {
+            let docs_per_batch = shape.docs.max(1);
+            let mut bucket_iter = bucket_docs.into_iter();
+            while let Some(first) = bucket_iter.next() {
+                let mut piece_encodings = Vec::with_capacity(docs_per_batch);
+                piece_encodings.push(first);
+                for encoding in bucket_iter.by_ref().take(docs_per_batch - 1) {
+                    piece_encodings.push(encoding);
+                }
+                batches.push(prepare_batch_from_tokenized_documents(
+                    &self.tokenizer,
+                    &self.config,
+                    piece_encodings,
+                    false,
+                    true,
+                )?);
+            }
+        }
+
+        Ok(batches)
+    }
+
+    fn encode_prepared_documents(
+        &self,
+        prepared: PreparedDocumentBatch,
+    ) -> Result<Vec<Array2<f32>>> {
+        let session_idx =
+            self.next_session_idx.fetch_add(1, Ordering::Relaxed) % self.sessions.len().max(1);
+        let mut session = self.sessions[session_idx].lock().unwrap();
+        encode_prepared_batch_with_session(&mut session, &self.config, &self.skiplist_ids, prepared)
+    }
+
+    pub fn encode_prepared_document_batches(
+        &self,
+        prepared_batches: Vec<PreparedDocumentBatch>,
+    ) -> Result<Vec<Array2<f32>>> {
+        if prepared_batches.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if self.sessions.len() <= 1 || prepared_batches.len() == 1 {
+            let mut all_embeddings = Vec::new();
+            for prepared_batch in prepared_batches {
+                all_embeddings.extend(self.encode_prepared_documents(prepared_batch)?);
+            }
+            return Ok(all_embeddings);
+        }
+
+        let results: Vec<Result<Vec<Array2<f32>>>> = std::thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(prepared_batches.len());
+
+            for (i, prepared_batch) in prepared_batches.into_iter().enumerate() {
+                let session_idx = i % self.sessions.len();
+                let session_mutex = &self.sessions[session_idx];
+                let config = &self.config;
+                let skiplist_ids = &self.skiplist_ids;
+
+                handles.push(scope.spawn(move || {
+                    let mut session = session_mutex.lock().unwrap();
+                    encode_prepared_batch_with_session(
+                        &mut session,
+                        config,
+                        skiplist_ids,
+                        prepared_batch,
+                    )
+                }));
+            }
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect()
+        });
+
+        let mut all_embeddings = Vec::new();
+        for result in results {
+            all_embeddings.extend(result?);
+        }
+
+        Ok(all_embeddings)
+    }
+
+    /// Stream document embeddings chunk-by-chunk.
+    ///
+    /// The returned stream owns the worker threads. Dropping it early will stop
+    /// receiving new chunks and join the workers.
+    fn encode_documents_stream(
+        &self,
+        documents: Vec<String>,
+        pool_factor: Option<usize>,
+    ) -> Result<DocumentEmbeddingStream> {
+        let mut raw_stream = self.encode_documents_raw_stream(documents)?;
+        let (pooled_tx, pooled_rx) = mpsc::channel::<Result<DocumentEmbeddingChunk>>();
+        let handle = std::thread::Builder::new()
+            .name("next-plaid-stream-pool".to_string())
+            .spawn(move || {
+                for result in &mut raw_stream {
+                    let pooled = result.map(|chunk| DocumentEmbeddingChunk {
+                        start_offset: chunk.start_offset,
+                        embeddings: pool_document_embeddings(chunk.embeddings, pool_factor),
+                    });
+
+                    if pooled_tx.send(pooled).is_err() {
+                        break;
+                    }
+                }
+            })
+            .expect("failed to spawn next-plaid stream pool thread");
+
+        Ok(DocumentEmbeddingStream {
+            receiver: pooled_rx,
+            handles: vec![handle],
+        })
+    }
+
+    /// Stream raw document embeddings chunk-by-chunk before pooling.
+    ///
+    /// This is the low-level stage boundary for callers that want to build
+    /// their own pipelines and run pooling separately.
+    fn encode_documents_raw_stream(
+        &self,
+        documents: Vec<String>,
+    ) -> Result<RawDocumentEmbeddingStream> {
+        if documents.is_empty() {
+            let (_tx, rx) = mpsc::channel();
+            return Ok(RawDocumentEmbeddingStream {
+                receiver: rx,
+                handles: Vec::new(),
+            });
+        }
+
+        let chunk_queue = Arc::new(Mutex::new(self.build_document_work_queue(documents)));
+        let (raw_tx, raw_rx) = mpsc::channel::<Result<RawDocumentEmbeddingChunk>>();
+
+        let mut handles = Vec::new();
+        for (session_idx, session_mutex) in self.sessions.iter().enumerate() {
+            let queue = Arc::clone(&chunk_queue);
+            let raw_sender = raw_tx.clone();
+            let session_mutex = Arc::clone(session_mutex);
+            let tokenizer = Arc::clone(&self.tokenizer);
+            let config = Arc::clone(&self.config);
+            let skiplist_ids = Arc::clone(&self.skiplist_ids);
+
+            handles.push(
+                std::thread::Builder::new()
+                    .name(format!("next-plaid-session-{session_idx}"))
+                    .spawn(move || loop {
+                        let work = {
+                            let mut guard = queue.lock().unwrap();
+                            guard.pop_front()
+                        };
+
+                        let Some((_chunk_index, start_offset, chunk_texts)) = work else {
+                            break;
+                        };
+
+                        let text_refs: Vec<&str> =
+                            chunk_texts.iter().map(|text| text.as_str()).collect();
+                        let result = {
+                            let mut session = session_mutex.lock().unwrap();
+                            encode_batch_with_session(
+                                &mut session,
+                                &tokenizer,
+                                &config,
+                                &skiplist_ids,
+                                &text_refs,
+                                false,
+                                true,
+                            )
+                            .map(|embeddings| {
+                                RawDocumentEmbeddingChunk {
+                                    start_offset,
+                                    embeddings,
+                                }
+                            })
+                        };
+
+                        if raw_sender.send(result).is_err() {
+                            break;
+                        }
+                    })
+                    .expect("failed to spawn next-plaid session worker"),
+            );
+        }
+        drop(raw_tx);
+
+        Ok(RawDocumentEmbeddingStream {
+            receiver: raw_rx,
+            handles,
+        })
     }
 
     /// Encode queries into ColBERT embeddings.
@@ -1028,6 +1406,57 @@ impl Colbert {
 
         Ok(all_embeddings)
     }
+
+    fn build_document_work_queue(
+        &self,
+        documents: Vec<String>,
+    ) -> VecDeque<(usize, usize, Vec<String>)> {
+        let mut queue = VecDeque::new();
+        let batch_size = self.batch_size.max(1);
+
+        for (chunk_index, chunk) in documents.chunks(batch_size).enumerate() {
+            queue.push_back((chunk_index, chunk_index * batch_size, chunk.to_vec()));
+        }
+
+        queue
+    }
+}
+
+/// Pool a batch of per-document embeddings.
+///
+/// This is exposed so callers can build explicit pipelines with separate
+/// encode and pool stages while keeping `encode_documents(...)` as a
+/// compatibility wrapper.
+pub fn pool_document_embeddings(
+    embeddings: Vec<Array2<f32>>,
+    pool_factor: Option<usize>,
+) -> Vec<Array2<f32>> {
+    match pool_factor {
+        Some(pf) if pf > 1 => embeddings
+            .into_par_iter()
+            .map(|emb| pool_embeddings_hierarchical(emb, pf, 1))
+            .collect(),
+        _ => embeddings,
+    }
+}
+
+fn tokenizer_thread_pool() -> &'static ThreadPool {
+    static POOL: OnceLock<ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        let available = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(4);
+        let threads = std::env::var("NEXT_PLAID_TOKENIZER_THREADS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|v| v.max(1))
+            .unwrap_or_else(|| available.clamp(1, 4));
+        ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .thread_name(|idx| format!("next-plaid-tokenizer-{idx}"))
+            .build()
+            .expect("failed to build tokenizer thread pool")
+    })
 }
 
 // =============================================================================
@@ -1061,6 +1490,96 @@ fn select_onnx_file<P: AsRef<Path>>(model_dir: P, quantized: bool) -> Result<std
             )
         }
     }
+}
+
+fn preprocess_texts(config: &ColbertConfig, texts: &[&str]) -> Vec<String> {
+    if config.do_lower_case {
+        texts.iter().map(|t| t.trim().to_lowercase()).collect()
+    } else {
+        texts.iter().map(|t| t.trim().to_string()).collect()
+    }
+}
+
+fn tokenize_processed_texts(
+    tokenizer: &Tokenizer,
+    processed_texts: &[String],
+) -> Result<Vec<Encoding>> {
+    let texts_to_encode: Vec<&str> = processed_texts.iter().map(|s| s.as_str()).collect();
+    tokenizer_thread_pool()
+        .install(|| tokenizer.encode_batch(texts_to_encode, true))
+        .map_err(|e| anyhow::anyhow!("Tokenization error: {}", e))
+}
+
+fn tokenize_processed_texts_individually(
+    tokenizer: &Tokenizer,
+    processed_texts: &[String],
+) -> Result<Vec<TokenizedDocument>> {
+    let results = tokenizer_thread_pool().install(|| {
+        processed_texts
+            .into_par_iter()
+            .map(|text| {
+                let encoding = tokenizer
+                    .encode(text.as_str(), true)
+                    .map_err(|e| anyhow::anyhow!("Tokenization error: {}", e))?;
+                let real_len = encoding
+                    .get_attention_mask()
+                    .iter()
+                    .take_while(|&&v| v != 0)
+                    .count()
+                    .max(1);
+                Ok(TokenizedDocument {
+                    ids: encoding.get_ids()[..real_len].to_vec(),
+                    type_ids: encoding.get_type_ids()[..real_len].to_vec(),
+                })
+            })
+            .collect::<Vec<_>>()
+    });
+    results.into_iter().collect()
+}
+
+fn round_up_len_for_planning(len: usize) -> usize {
+    if len <= 8 {
+        return len.max(1);
+    }
+    let quantum = 32;
+    len.div_ceil(quantum) * quantum
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FixedDynamicShape {
+    docs: usize,
+    planned_len: usize,
+}
+
+fn build_fixed_dynamic_shapes(batch_size: usize, document_length: usize) -> Vec<FixedDynamicShape> {
+    let total_budget = batch_size.max(1).saturating_mul(document_length.max(1));
+    let mut shapes = Vec::new();
+    let mut planned_len = round_up_len_for_planning(document_length.max(1));
+    let min_planned_len = 128.min(planned_len.max(1));
+
+    loop {
+        let docs = total_budget.checked_div(planned_len).unwrap_or(0).max(1);
+        if shapes
+            .last()
+            .map(|shape: &FixedDynamicShape| shape.planned_len != planned_len)
+            .unwrap_or(true)
+        {
+            shapes.push(FixedDynamicShape { docs, planned_len });
+        }
+
+        if planned_len <= min_planned_len {
+            break;
+        }
+
+        let next_len = round_up_len_for_planning((planned_len / 2).max(min_planned_len));
+        if next_len == planned_len {
+            break;
+        }
+        planned_len = next_len;
+    }
+
+    shapes.sort_by_key(|shape| shape.planned_len);
+    shapes
 }
 
 fn update_token_ids(config: &mut ColbertConfig, tokenizer: &Tokenizer) {
@@ -1111,6 +1630,54 @@ fn encode_batch_with_session(
         return Ok(Vec::new());
     }
 
+    let prepared = prepare_batch_for_session(tokenizer, config, texts, is_query, filter_skiplist)?;
+    encode_prepared_batch_with_session(session, config, skiplist_ids, prepared)
+}
+
+fn prepare_batch_for_session(
+    tokenizer: &Tokenizer,
+    config: &ColbertConfig,
+    texts: &[&str],
+    is_query: bool,
+    filter_skiplist: bool,
+) -> Result<PreparedDocumentBatch> {
+    if texts.is_empty() {
+        return Ok(PreparedDocumentBatch {
+            batch_size: 0,
+            batch_max_len: 0,
+            all_input_ids: Vec::new(),
+            all_attention_mask: Vec::new(),
+            all_token_type_ids: if config.uses_token_type_ids {
+                Some(Vec::new())
+            } else {
+                None
+            },
+            all_token_ids: Vec::new(),
+            original_lengths: Vec::new(),
+            is_query,
+            filter_skiplist,
+        });
+    }
+
+    let processed_texts = preprocess_texts(config, texts);
+    let batch_encodings = tokenize_processed_texts(tokenizer, &processed_texts)?;
+
+    prepare_batch_from_tokenizer_encodings(
+        tokenizer,
+        config,
+        batch_encodings,
+        is_query,
+        filter_skiplist,
+    )
+}
+
+fn prepare_batch_from_tokenized_documents(
+    tokenizer: &Tokenizer,
+    config: &ColbertConfig,
+    batch_docs: Vec<TokenizedDocument>,
+    is_query: bool,
+    filter_skiplist: bool,
+) -> Result<PreparedDocumentBatch> {
     let (prefix_str, prefix_token_id_opt, max_length) = if is_query {
         (
             &config.query_prefix,
@@ -1125,7 +1692,6 @@ fn encode_batch_with_session(
         )
     };
 
-    // Get the prefix token ID, either from config or by looking it up in the tokenizer
     let prefix_token_id: u32 = match prefix_token_id_opt {
         Some(id) => id,
         None => tokenizer.token_to_id(prefix_str).ok_or_else(|| {
@@ -1136,144 +1702,298 @@ fn encode_batch_with_session(
         })?,
     };
 
-    // Apply text preprocessing to match sentence-transformers behavior:
-    // 1. Strip leading/trailing whitespace
-    // 2. Lowercase if configured
-    let processed_texts: Vec<String> = if config.do_lower_case {
-        texts.iter().map(|t| t.trim().to_lowercase()).collect()
-    } else {
-        texts.iter().map(|t| t.trim().to_string()).collect()
-    };
-    let texts_to_encode: Vec<&str> = processed_texts.iter().map(|s| s.as_str()).collect();
-
-    // Tokenize texts WITHOUT the prefix first (matching PyLate's approach)
-    // PyLate tokenizes with max_length - 1 to reserve space for the prefix token
-    let batch_encodings = tokenizer
-        .encode_batch(texts_to_encode, true)
-        .map_err(|e| anyhow::anyhow!("Tokenization error: {}", e))?;
-
-    let mut encodings: Vec<BatchEncoding> = Vec::with_capacity(texts.len());
+    let truncate_limit = max_length.saturating_sub(1);
     let mut batch_max_len = 0usize;
+    for doc in &batch_docs {
+        let effective_len = if doc.ids.len() > truncate_limit {
+            max_length
+        } else {
+            doc.ids.len() + 1
+        };
+        batch_max_len = batch_max_len.max(effective_len);
+    }
+    if is_query && config.do_query_expansion {
+        batch_max_len = max_length;
+    }
 
-    // Truncate limit is max_length - 1 to leave room for prefix token insertion
-    let truncate_limit = max_length - 1;
+    let batch_size = batch_docs.len();
+    let default_input_id = if is_query && config.do_query_expansion {
+        config.mask_token_id as i64
+    } else {
+        config.pad_token_id as i64
+    };
+    let default_attention = if is_query && config.do_query_expansion {
+        1i64
+    } else {
+        0i64
+    };
+    let mut all_input_ids: Vec<i64> = vec![default_input_id; batch_size * batch_max_len];
+    let mut all_attention_mask: Vec<i64> = vec![default_attention; batch_size * batch_max_len];
+    let mut all_token_type_ids: Vec<i64> = vec![0; batch_size * batch_max_len];
+    let mut all_token_ids: Vec<Vec<u32>> = Vec::with_capacity(batch_size);
+    let mut original_lengths: Vec<usize> = Vec::with_capacity(batch_size);
 
-    for encoding in batch_encodings {
-        let token_ids: Vec<u32> = encoding.get_ids().to_vec();
-        let mut input_ids: Vec<i64> = token_ids.iter().map(|&x| x as i64).collect();
-        let mut attention_mask: Vec<i64> = encoding
-            .get_attention_mask()
-            .iter()
-            .map(|&x| x as i64)
-            .collect();
-        let mut token_type_ids: Vec<i64> =
-            encoding.get_type_ids().iter().map(|&x| x as i64).collect();
-        let mut token_ids_vec = token_ids;
+    for (row_idx, doc) in batch_docs.into_iter().enumerate() {
+        let row_start = row_idx * batch_max_len;
+        let real_len = doc.ids.len().max(1);
+        let (content_prefix_len, keep_sep) = if real_len > truncate_limit {
+            (truncate_limit.saturating_sub(1), true)
+        } else {
+            (real_len, false)
+        };
+        let final_len = if keep_sep { max_length } else { real_len + 1 };
+        original_lengths.push(final_len);
 
-        // Truncate to max_length - 1 to leave room for prefix token
-        // IMPORTANT: Preserve [SEP] token at the end when truncating
-        // PyLate truncates content but keeps [CLS] at start and [SEP] at end
-        if input_ids.len() > truncate_limit {
-            // Save the [SEP] token (last token)
-            let sep_token = input_ids[input_ids.len() - 1];
-            let sep_mask = attention_mask[attention_mask.len() - 1];
-            let sep_type = token_type_ids[token_type_ids.len() - 1];
-            let sep_token_id = token_ids_vec[token_ids_vec.len() - 1];
+        all_input_ids[row_start] = doc.ids[0] as i64;
+        all_attention_mask[row_start] = 1;
+        all_token_type_ids[row_start] = doc.type_ids[0] as i64;
 
-            // Truncate content (keeping room for [SEP])
-            input_ids.truncate(truncate_limit - 1);
-            attention_mask.truncate(truncate_limit - 1);
-            token_type_ids.truncate(truncate_limit - 1);
-            token_ids_vec.truncate(truncate_limit - 1);
+        all_input_ids[row_start + 1] = prefix_token_id as i64;
+        all_attention_mask[row_start + 1] = 1;
+        all_token_type_ids[row_start + 1] = 0;
 
-            // Re-add [SEP] at the end
-            input_ids.push(sep_token);
-            attention_mask.push(sep_mask);
-            token_type_ids.push(sep_type);
-            token_ids_vec.push(sep_token_id);
+        let mut token_ids_vec: Vec<u32> = Vec::with_capacity(final_len);
+        token_ids_vec.push(doc.ids[0]);
+        token_ids_vec.push(prefix_token_id);
+
+        let mut write_pos = row_start + 2;
+        for src_idx in 1..content_prefix_len {
+            all_input_ids[write_pos] = doc.ids[src_idx] as i64;
+            all_attention_mask[write_pos] = 1;
+            all_token_type_ids[write_pos] = doc.type_ids[src_idx] as i64;
+            token_ids_vec.push(doc.ids[src_idx]);
+            write_pos += 1;
         }
 
-        // Insert prefix token after [CLS] (position 1), matching PyLate's insert_prefix_token
-        // PyLate does: torch.cat([input_ids[:, :1], prefix_tensor, input_ids[:, 1:]], dim=1)
-        input_ids.insert(1, prefix_token_id as i64);
-        attention_mask.insert(1, 1);
-        token_type_ids.insert(1, 0);
-        token_ids_vec.insert(1, prefix_token_id);
+        if keep_sep {
+            let sep_idx = real_len - 1;
+            all_input_ids[write_pos] = doc.ids[sep_idx] as i64;
+            all_attention_mask[write_pos] = 1;
+            all_token_type_ids[write_pos] = doc.type_ids[sep_idx] as i64;
+            token_ids_vec.push(doc.ids[sep_idx]);
+        }
 
-        batch_max_len = batch_max_len.max(input_ids.len());
-        encodings.push((input_ids, attention_mask, token_type_ids, token_ids_vec));
+        all_token_ids.push(token_ids_vec);
+    }
+
+    Ok(PreparedDocumentBatch {
+        batch_size,
+        batch_max_len,
+        all_input_ids,
+        all_attention_mask,
+        all_token_type_ids: if config.uses_token_type_ids {
+            Some(all_token_type_ids)
+        } else {
+            None
+        },
+        all_token_ids,
+        original_lengths,
+        is_query,
+        filter_skiplist,
+    })
+}
+
+fn prepare_batch_from_tokenizer_encodings(
+    tokenizer: &Tokenizer,
+    config: &ColbertConfig,
+    batch_encodings: Vec<Encoding>,
+    is_query: bool,
+    filter_skiplist: bool,
+) -> Result<PreparedDocumentBatch> {
+    let (prefix_str, prefix_token_id_opt, max_length) = if is_query {
+        (
+            &config.query_prefix,
+            config.query_prefix_id,
+            config.query_length,
+        )
+    } else {
+        (
+            &config.document_prefix,
+            config.document_prefix_id,
+            config.document_length,
+        )
+    };
+
+    let prefix_token_id: u32 = match prefix_token_id_opt {
+        Some(id) => id,
+        None => tokenizer.token_to_id(prefix_str).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Prefix token '{}' not found in tokenizer vocabulary",
+                prefix_str
+            )
+        })?,
+    };
+
+    let mut batch_max_len = 0usize;
+
+    // Truncate limit is max_length - 1 to leave room for prefix token insertion.
+    // Keep this saturating so tiny synthetic probe lengths like 1 do not underflow.
+    let truncate_limit = max_length.saturating_sub(1);
+    let real_lengths: Vec<usize> = batch_encodings
+        .iter()
+        .map(|encoding| {
+            encoding
+                .get_attention_mask()
+                .iter()
+                .take_while(|&&v| v != 0)
+                .count()
+                .max(1)
+        })
+        .collect();
+
+    for &real_len in &real_lengths {
+        let effective_len = if real_len > truncate_limit {
+            max_length
+        } else {
+            real_len + 1
+        };
+        batch_max_len = batch_max_len.max(effective_len);
     }
 
     if is_query && config.do_query_expansion {
         batch_max_len = max_length;
     }
 
-    let batch_size = texts.len();
-    let mut all_input_ids: Vec<i64> = Vec::with_capacity(batch_size * batch_max_len);
-    let mut all_attention_mask: Vec<i64> = Vec::with_capacity(batch_size * batch_max_len);
-    let mut all_token_type_ids: Vec<i64> = Vec::with_capacity(batch_size * batch_max_len);
+    let batch_size = batch_encodings.len();
+    let default_input_id = if is_query && config.do_query_expansion {
+        config.mask_token_id as i64
+    } else {
+        config.pad_token_id as i64
+    };
+    let default_attention = if is_query && config.do_query_expansion {
+        1i64
+    } else {
+        0i64
+    };
+    let mut all_input_ids: Vec<i64> = vec![default_input_id; batch_size * batch_max_len];
+    let mut all_attention_mask: Vec<i64> = vec![default_attention; batch_size * batch_max_len];
+    let mut all_token_type_ids: Vec<i64> = vec![0; batch_size * batch_max_len];
     let mut all_token_ids: Vec<Vec<u32>> = Vec::with_capacity(batch_size);
     let mut original_lengths: Vec<usize> = Vec::with_capacity(batch_size);
 
-    for (mut input_ids, mut attention_mask, mut token_type_ids, mut token_ids) in encodings {
-        original_lengths.push(input_ids.len());
+    for (row_idx, (encoding, &real_len)) in
+        batch_encodings.into_iter().zip(&real_lengths).enumerate()
+    {
+        let row_start = row_idx * batch_max_len;
+        let ids = encoding.get_ids();
+        let masks = encoding.get_attention_mask();
+        let type_ids = encoding.get_type_ids();
 
-        while input_ids.len() < batch_max_len {
-            if is_query && config.do_query_expansion {
-                input_ids.push(config.mask_token_id as i64);
-                attention_mask.push(1);
-                token_ids.push(config.mask_token_id);
-            } else {
-                input_ids.push(config.pad_token_id as i64);
-                attention_mask.push(0);
-                token_ids.push(config.pad_token_id);
-            }
-            token_type_ids.push(0);
+        let (content_prefix_len, keep_sep) = if real_len > truncate_limit {
+            (truncate_limit.saturating_sub(1), true)
+        } else {
+            (real_len, false)
+        };
+        let final_len = if keep_sep { max_length } else { real_len + 1 };
+        original_lengths.push(final_len);
+
+        all_input_ids[row_start] = ids[0] as i64;
+        all_attention_mask[row_start] = masks[0] as i64;
+        all_token_type_ids[row_start] = type_ids[0] as i64;
+
+        all_input_ids[row_start + 1] = prefix_token_id as i64;
+        all_attention_mask[row_start + 1] = 1;
+        all_token_type_ids[row_start + 1] = 0;
+
+        let mut token_ids_vec: Vec<u32> = Vec::with_capacity(final_len);
+        token_ids_vec.push(ids[0]);
+        token_ids_vec.push(prefix_token_id);
+
+        let mut write_pos = row_start + 2;
+        for src_idx in 1..content_prefix_len {
+            all_input_ids[write_pos] = ids[src_idx] as i64;
+            all_attention_mask[write_pos] = masks[src_idx] as i64;
+            all_token_type_ids[write_pos] = type_ids[src_idx] as i64;
+            token_ids_vec.push(ids[src_idx]);
+            write_pos += 1;
         }
 
-        all_input_ids.extend(input_ids);
-        all_attention_mask.extend(attention_mask);
-        all_token_type_ids.extend(token_type_ids);
-        all_token_ids.push(token_ids);
+        if keep_sep {
+            let sep_idx = real_len - 1;
+            all_input_ids[write_pos] = ids[sep_idx] as i64;
+            all_attention_mask[write_pos] = masks[sep_idx] as i64;
+            all_token_type_ids[write_pos] = type_ids[sep_idx] as i64;
+            token_ids_vec.push(ids[sep_idx]);
+        }
+
+        all_token_ids.push(token_ids_vec);
+    }
+
+    Ok(PreparedDocumentBatch {
+        batch_size,
+        batch_max_len,
+        all_input_ids,
+        all_attention_mask,
+        all_token_type_ids: if config.uses_token_type_ids {
+            Some(all_token_type_ids)
+        } else {
+            None
+        },
+        all_token_ids,
+        original_lengths,
+        is_query,
+        filter_skiplist,
+    })
+}
+
+fn encode_prepared_batch_with_session(
+    session: &mut Session,
+    config: &ColbertConfig,
+    skiplist_ids: &HashSet<u32>,
+    prepared: PreparedDocumentBatch,
+) -> Result<Vec<Array2<f32>>> {
+    let PreparedDocumentBatch {
+        batch_size,
+        batch_max_len,
+        all_input_ids,
+        all_attention_mask,
+        all_token_type_ids,
+        all_token_ids,
+        original_lengths,
+        is_query,
+        filter_skiplist,
+    } = prepared;
+
+    if batch_size == 0 {
+        return Ok(Vec::new());
     }
 
     let input_ids_tensor = Tensor::from_array(([batch_size, batch_max_len], all_input_ids))?;
     let attention_mask_tensor =
-        Tensor::from_array(([batch_size, batch_max_len], all_attention_mask.clone()))?;
+        Tensor::from_array(([batch_size, batch_max_len], all_attention_mask))?;
 
-    let token_type_ids_tensor = if config.uses_token_type_ids {
-        Some(Tensor::from_array((
-            [batch_size, batch_max_len],
-            all_token_type_ids,
-        ))?)
-    } else {
-        None
-    };
+    let token_type_ids_tensor = all_token_type_ids
+        .map(|ids| Tensor::from_array(([batch_size, batch_max_len], ids)))
+        .transpose()?;
 
-    let outputs = if let Some(token_type_ids_tensor) = token_type_ids_tensor {
-        session.run(ort::inputs![
-            "input_ids" => input_ids_tensor,
-            "attention_mask" => attention_mask_tensor,
-            "token_type_ids" => token_type_ids_tensor,
-        ])?
-    } else {
-        session.run(ort::inputs![
-            "input_ids" => input_ids_tensor,
-            "attention_mask" => attention_mask_tensor,
-        ])?
-    };
+    let (shape_slice, output_owned): (Vec<i64>, Vec<f32>) =
+        if let Some(token_type_ids_tensor) = token_type_ids_tensor {
+            let outputs = session.run(ort::inputs![
+                "input_ids" => input_ids_tensor,
+                "attention_mask" => attention_mask_tensor,
+                "token_type_ids" => token_type_ids_tensor,
+            ])?;
+            let (output_shape, output_data) = outputs["output"]
+                .try_extract_tensor::<f32>()
+                .context("Failed to extract output tensor")?;
+            (output_shape.to_vec(), output_data.to_vec())
+        } else {
+            let outputs = session.run(ort::inputs![
+                "input_ids" => input_ids_tensor,
+                "attention_mask" => attention_mask_tensor,
+            ])?;
+            let (output_shape, output_data) = outputs["output"]
+                .try_extract_tensor::<f32>()
+                .context("Failed to extract output tensor")?;
+            (output_shape.to_vec(), output_data.to_vec())
+        };
 
-    let (output_shape, output_data) = outputs["output"]
-        .try_extract_tensor::<f32>()
-        .context("Failed to extract output tensor")?;
-
-    let shape_slice: Vec<i64> = output_shape.iter().copied().collect();
     let embedding_dim = shape_slice[2] as usize;
+    let output_data = &output_owned;
 
     let mut all_embeddings = Vec::with_capacity(batch_size);
     for i in 0..batch_size {
         let batch_offset = i * batch_max_len * embedding_dim;
-        let attention_offset = i * batch_max_len;
 
         if is_query && config.do_query_expansion {
             let end = batch_offset + batch_max_len * embedding_dim;
@@ -1286,20 +2006,13 @@ fn encode_batch_with_session(
 
             let valid_count = (0..orig_len)
                 .filter(|&j| {
-                    let mask = all_attention_mask[attention_offset + j];
                     let token_id = token_ids[j];
-                    mask != 0 && !(filter_skiplist && skiplist_ids.contains(&token_id))
+                    !(filter_skiplist && skiplist_ids.contains(&token_id))
                 })
                 .count();
 
             let mut flat: Vec<f32> = Vec::with_capacity(valid_count * embedding_dim);
-            for j in 0..orig_len {
-                let mask = all_attention_mask[attention_offset + j];
-                let token_id = token_ids[j];
-
-                if mask == 0 {
-                    continue;
-                }
+            for (j, &token_id) in token_ids.iter().enumerate().take(orig_len) {
                 if filter_skiplist && skiplist_ids.contains(&token_id) {
                     continue;
                 }
@@ -1354,38 +2067,37 @@ fn pool_embeddings_hierarchical(
         num_clusters as f64,
     );
 
-    let mut pooled_rows: Vec<Vec<f32>> = Vec::with_capacity(num_clusters + protected_tokens);
+    let mut cluster_sums = vec![vec![0.0f32; n_features]; num_clusters];
+    let mut cluster_counts = vec![0usize; num_clusters];
+
+    for (idx, &label) in labels.iter().enumerate() {
+        let cluster_idx = label.saturating_sub(1);
+        if cluster_idx >= num_clusters {
+            continue;
+        }
+
+        let row = to_pool.row(idx);
+        for (sum, &value) in cluster_sums[cluster_idx].iter_mut().zip(row.iter()) {
+            *sum += value;
+        }
+        cluster_counts[cluster_idx] += 1;
+    }
+
+    let mut output = Array2::<f32>::zeros((protected_tokens + num_clusters, n_features));
 
     for i in 0..protected_tokens {
-        pooled_rows.push(embeddings.row(i).to_vec());
+        output.row_mut(i).assign(&embeddings.row(i));
     }
 
-    for cluster_id in 1..=num_clusters {
-        let mut sum = vec![0.0f32; n_features];
-        let mut count = 0usize;
-
-        for (idx, &label) in labels.iter().enumerate() {
-            if label == cluster_id {
-                let row = to_pool.row(idx);
-                for (s, &v) in sum.iter_mut().zip(row.iter()) {
-                    *s += v;
-                }
-                count += 1;
-            }
-        }
-
-        if count > 0 {
-            for s in &mut sum {
-                *s /= count as f32;
-            }
-            pooled_rows.push(sum);
+    for cluster_idx in 0..num_clusters {
+        let count = cluster_counts[cluster_idx].max(1) as f32;
+        let mut row = output.row_mut(protected_tokens + cluster_idx);
+        for (dst, sum) in row.iter_mut().zip(cluster_sums[cluster_idx].iter()) {
+            *dst = *sum / count;
         }
     }
 
-    let n_pooled = pooled_rows.len();
-    let flat: Vec<f32> = pooled_rows.into_iter().flatten().collect();
-    Array2::from_shape_vec((n_pooled, n_features), flat)
-        .expect("Shape mismatch in pooled embeddings")
+    output
 }
 
 #[cfg(test)]

--- a/next-plaid/src/codec.rs
+++ b/next-plaid/src/codec.rs
@@ -4,10 +4,20 @@ use ndarray::{s, Array1, Array2, ArrayView1, ArrayView2, Axis};
 
 use crate::error::{Error, Result};
 
-/// Maximum memory (bytes) to allocate for nearest centroid computation in `compress_into_codes`.
-/// This limits the size of the [batch_size, num_centroids] scores matrix to prevent OOM errors
-/// with large centroid counts (e.g., 2.5M centroids).
-const MAX_NEAREST_CENTROID_MEMORY: usize = 4 * 1024 * 1024 * 1024; // 4GB
+/// Default maximum memory (bytes) to allocate for nearest centroid computation in
+/// `compress_into_codes`. This limits the size of the `[batch_size, num_centroids]`
+/// scores matrix. Keeping this lower reduces page-fault and zero-fill overhead
+/// from giant temporary score buffers.
+const DEFAULT_MAX_NEAREST_CENTROID_MEMORY: usize = 1024 * 1024 * 1024; // 1GB
+
+fn max_nearest_centroid_memory() -> usize {
+    std::env::var("NEXT_PLAID_MAX_NEAREST_CENTROID_MEMORY_MB")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&mb| mb > 0)
+        .map(|mb| mb.saturating_mul(1024 * 1024))
+        .unwrap_or(DEFAULT_MAX_NEAREST_CENTROID_MEMORY)
+}
 
 /// Storage backend for centroids, supporting both owned arrays and memory-mapped files.
 ///
@@ -241,6 +251,7 @@ impl ResidualCodec {
         // Try CUDA acceleration if available
         #[cfg(feature = "cuda")]
         {
+            let force_gpu = crate::is_force_gpu();
             if let Some(ctx) = crate::cuda::get_global_context() {
                 let centroids = self.centroids_view();
                 match crate::cuda::compress_into_codes_cuda_batched(
@@ -251,12 +262,20 @@ impl ResidualCodec {
                 ) {
                     Ok(codes) => return codes,
                     Err(e) => {
+                        if force_gpu {
+                            panic!(
+                                "FORCE_GPU is set but CUDA compress_into_codes failed: {}",
+                                e
+                            );
+                        }
                         eprintln!(
                             "[next-plaid] CUDA compression error: {}. Falling back to CPU.",
                             e
                         );
                     }
                 }
+            } else if force_gpu {
+                panic!("FORCE_GPU is set but CUDA context is unavailable");
             }
         }
 
@@ -281,35 +300,36 @@ impl ResidualCodec {
         // The scores matrix has shape [batch_size, num_centroids] with f32 elements.
         // With 2.5M centroids and 4GB budget: batch_size = 4GB / (2.5M * 4) = 400
         let max_batch_by_memory =
-            MAX_NEAREST_CENTROID_MEMORY / (num_centroids * std::mem::size_of::<f32>());
-        let batch_size = max_batch_by_memory.clamp(1, 2048);
+            max_nearest_centroid_memory() / (num_centroids * std::mem::size_of::<f32>());
+        let batch_size = max_batch_by_memory.clamp(1, 1024);
+        let batch_ranges: Vec<(usize, usize)> = (0..n)
+            .step_by(batch_size)
+            .map(|start| (start, (start + batch_size).min(n)))
+            .collect();
 
-        let mut all_codes = Vec::with_capacity(n);
+        let chunked_codes: Vec<Vec<usize>> = batch_ranges
+            .into_par_iter()
+            .map(|(start, end)| {
+                let batch = embeddings.slice(ndarray::s![start..end, ..]);
 
-        for start in (0..n).step_by(batch_size) {
-            let end = (start + batch_size).min(n);
-            let batch = embeddings.slice(ndarray::s![start..end, ..]);
+                // Batch matrix multiplication: [batch, dim] @ [dim, K] -> [batch, K]
+                let scores = batch.dot(&centroids.t());
 
-            // Batch matrix multiplication: [batch, dim] @ [dim, K] -> [batch, K]
-            let scores = batch.dot(&centroids.t());
+                // Keep the per-row scan local to avoid nested parallelism.
+                scores
+                    .axis_iter(Axis(0))
+                    .map(|row| {
+                        row.iter()
+                            .enumerate()
+                            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+                            .map(|(idx, _)| idx)
+                            .unwrap_or(0)
+                    })
+                    .collect()
+            })
+            .collect();
 
-            // Parallel argmax over each row
-            let batch_codes: Vec<usize> = scores
-                .axis_iter(Axis(0))
-                .into_par_iter()
-                .map(|row| {
-                    row.iter()
-                        .enumerate()
-                        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(0)
-                })
-                .collect();
-
-            all_codes.extend(batch_codes);
-        }
-
-        Array1::from_vec(all_codes)
+        Array1::from_vec(chunked_codes.into_iter().flatten().collect())
     }
 
     /// Quantize residuals into packed bytes.

--- a/next-plaid/src/cuda.rs
+++ b/next-plaid/src/cuda.rs
@@ -145,7 +145,7 @@ pub fn is_initialized() -> bool {
     GLOBAL_CUDA_CONTEXT
         .get()
         .and_then(|m| m.lock().ok())
-        .map_or(false, |guard| guard.is_some())
+        .is_some_and(|guard| guard.is_some())
 }
 
 /// Check if CUDA has been determined to be broken/unavailable.

--- a/next-plaid/src/filtering.rs
+++ b/next-plaid/src/filtering.rs
@@ -595,22 +595,185 @@ pub(crate) fn get_db_path(index_path: &str) -> std::path::PathBuf {
     Path::new(index_path).join(METADATA_DB_NAME)
 }
 
-/// Open a SQLite connection with WAL mode and busy timeout.
+/// Open a SQLite connection with the metadata DB defaults we want everywhere.
 ///
-/// WAL mode allows concurrent readers during writes. The busy timeout
-/// makes writers retry for up to 5 seconds instead of failing immediately.
+/// WAL keeps readers unblocked during writes, the busy timeout makes transient
+/// lock contention survivable, and the extra pragmas keep write-heavy metadata
+/// updates closer to the previous tuned behavior.
 pub(crate) fn open_db(db_path: &std::path::Path) -> Result<Connection> {
     let conn = Connection::open(db_path)?;
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(|e| Error::Filtering(format!("Failed to set WAL mode: {}", e)))?;
-    conn.pragma_update(None, "busy_timeout", 5000)
-        .map_err(|e| Error::Filtering(format!("Failed to set busy_timeout: {}", e)))?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
+         PRAGMA temp_store=MEMORY;
+         PRAGMA busy_timeout=5000;",
+    )?;
     Ok(conn)
+}
+
+fn validate_fixed_columns(columns: &[(&str, &str)]) -> Result<()> {
+    for (name, _) in columns {
+        if !is_valid_column_name(name) {
+            return Err(Error::Filtering(format!(
+                "Invalid column name '{}'. Column names must start with a letter or \
+                 underscore, followed by letters, digits, or underscores.",
+                name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn create_fixed_metadata_table(conn: &Connection, columns: &[(&str, &str)]) -> Result<()> {
+    // The caller has already committed to a stable schema, so we can skip the
+    // generic "discover columns as we go" logic and create the table directly.
+    let mut col_defs = vec![format!("\"{}\" INTEGER PRIMARY KEY", SUBSET_COLUMN)];
+    for (name, sql_type) in columns {
+        col_defs.push(format!("\"{}\" {}", name, sql_type));
+    }
+    let create_sql = format!("CREATE TABLE METADATA ({})", col_defs.join(", "));
+    conn.execute(&create_sql, [])?;
+    Ok(())
+}
+
+fn insert_fixed_metadata_rows(
+    conn: &mut Connection,
+    columns: &[(&str, &str)],
+    metadata: &[Value],
+    doc_ids: &[i64],
+) -> Result<usize> {
+    let tx = conn.transaction()?;
+    let mut column_names = vec![format!("\"{}\"", SUBSET_COLUMN)];
+    column_names.extend(columns.iter().map(|(name, _)| format!("\"{}\"", name)));
+    let placeholders: Vec<&str> = std::iter::repeat_n("?", columns.len() + 1).collect();
+    let insert_sql = format!(
+        "INSERT INTO METADATA ({}) VALUES ({})",
+        column_names.join(", "),
+        placeholders.join(", ")
+    );
+    {
+        let mut stmt = tx.prepare_cached(&insert_sql)?;
+        for (i, item) in metadata.iter().enumerate() {
+            let obj = item.as_object().ok_or_else(|| {
+                Error::Filtering("Expected metadata rows to be JSON objects".into())
+            })?;
+            let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(doc_ids[i])];
+            for (column_name, _) in columns {
+                // Reuse the generic JSON-to-SQL coercion so the fast path stores
+                // values exactly like the slower schema-discovery path.
+                let value = obj.get(*column_name).unwrap_or(&Value::Null);
+                values.push(json_to_sql(value));
+            }
+            let params: Vec<&dyn ToSql> = values.iter().map(|value| value.as_ref()).collect();
+            stmt.execute(params_from_iter(params))?;
+        }
+    }
+    tx.commit()?;
+    Ok(metadata.len())
+}
+
+fn try_fixed_schema_from_first_row(
+    metadata: &[Value],
+) -> Result<Option<Vec<(&str, &'static str)>>> {
+    let Some(Value::Object(first_obj)) = metadata.first() else {
+        return Ok(None);
+    };
+
+    let mut columns = Vec::with_capacity(first_obj.len());
+    let mut seen = HashSet::with_capacity(first_obj.len());
+    for (key, value) in first_obj {
+        if !is_valid_column_name(key) {
+            return Err(Error::Filtering(format!(
+                "Invalid column name '{}'. Column names must start with a letter or \
+                 underscore, followed by letters, digits, or underscores.",
+                key
+            )));
+        }
+        seen.insert(key.as_str());
+        columns.push((key.as_str(), infer_sql_type(value)));
+    }
+
+    // If every later row is a subset of the first row's keys, the batch is
+    // effectively fixed-schema and we can stay on the cheaper insert path.
+    for item in &metadata[1..] {
+        if let Value::Object(obj) = item {
+            for key in obj.keys() {
+                if !seen.contains(key.as_str()) {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    Ok(Some(columns))
 }
 
 /// Check if a metadata database exists for the given index.
 pub fn exists(index_path: &str) -> bool {
     get_db_path(index_path).exists()
+}
+
+fn create_with_fixed_columns(
+    index_path: &str,
+    columns: &[(&str, &str)],
+    metadata: &[Value],
+    doc_ids: &[i64],
+) -> Result<usize> {
+    if metadata.len() != doc_ids.len() {
+        return Err(Error::Filtering(format!(
+            "Metadata length ({}) must match doc_ids length ({})",
+            metadata.len(),
+            doc_ids.len()
+        )));
+    }
+    validate_fixed_columns(columns)?;
+
+    let index_dir = Path::new(index_path);
+    if !index_dir.exists() {
+        fs::create_dir_all(index_dir)?;
+    }
+
+    let db_path = get_db_path(index_path);
+    if db_path.exists() {
+        fs::remove_file(&db_path)?;
+    }
+
+    if metadata.is_empty() {
+        return Ok(0);
+    }
+
+    let mut conn = open_db(&db_path)?;
+    create_fixed_metadata_table(&conn, columns)?;
+    insert_fixed_metadata_rows(&mut conn, columns, metadata, doc_ids)
+}
+
+fn update_with_fixed_columns(
+    index_path: &str,
+    columns: &[(&str, &str)],
+    metadata: &[Value],
+    doc_ids: &[i64],
+) -> Result<usize> {
+    if metadata.is_empty() {
+        return Ok(0);
+    }
+    if metadata.len() != doc_ids.len() {
+        return Err(Error::Filtering(format!(
+            "Metadata length ({}) must match doc_ids length ({})",
+            metadata.len(),
+            doc_ids.len()
+        )));
+    }
+    validate_fixed_columns(columns)?;
+
+    let db_path = get_db_path(index_path);
+    if !db_path.exists() {
+        return Err(Error::Filtering(
+            "Metadata database does not exist. Use create() first.".into(),
+        ));
+    }
+
+    let mut conn = open_db(&db_path)?;
+    insert_fixed_metadata_rows(&mut conn, columns, metadata, doc_ids)
 }
 
 /// Create a new SQLite metadata database, replacing any existing one.
@@ -674,6 +837,13 @@ pub fn create(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         return Ok(0);
     }
 
+    // Most colgrep metadata batches are fixed-shape JSON objects. Detect that
+    // early so creation does one direct CREATE TABLE + INSERT pass instead of
+    // paying for generic column discovery on every batch.
+    if let Some(columns) = try_fixed_schema_from_first_row(metadata)? {
+        return create_with_fixed_columns(index_path, &columns, metadata, doc_ids);
+    }
+
     // Collect all unique column names and infer types
     let mut columns: Vec<String> = Vec::new();
     let mut column_types: HashMap<String, &'static str> = HashMap::new();
@@ -701,7 +871,7 @@ pub fn create(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
     }
 
     // Create connection
-    let conn = open_db(&db_path)?;
+    let mut conn = open_db(&db_path)?;
 
     // Build CREATE TABLE statement
     let mut col_defs = vec![format!("\"{}\" INTEGER PRIMARY KEY", SUBSET_COLUMN)];
@@ -710,8 +880,9 @@ pub fn create(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         col_defs.push(format!("\"{}\" {}", col, sql_type));
     }
 
+    let tx = conn.transaction()?;
     let create_sql = format!("CREATE TABLE METADATA ({})", col_defs.join(", "));
-    conn.execute(&create_sql, [])?;
+    tx.execute(&create_sql, [])?;
 
     // Prepare INSERT statement
     let placeholders: Vec<&str> = std::iter::repeat_n("?", columns.len() + 1).collect();
@@ -727,27 +898,26 @@ pub fn create(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         )
     };
 
-    // Insert rows (in a transaction for performance — single fsync)
-    conn.execute_batch("BEGIN")?;
-    let mut stmt = conn.prepare(&insert_sql)?;
-    for (i, item) in metadata.iter().enumerate() {
-        let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(doc_ids[i])];
-        if let Value::Object(obj) = item {
-            for col in &columns {
-                let value = obj.get(col).unwrap_or(&Value::Null);
-                values.push(json_to_sql(value));
+    {
+        let mut stmt = tx.prepare(&insert_sql)?;
+        for (i, item) in metadata.iter().enumerate() {
+            let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(doc_ids[i])];
+            if let Value::Object(obj) = item {
+                for col in &columns {
+                    let value = obj.get(col).unwrap_or(&Value::Null);
+                    values.push(json_to_sql(value));
+                }
+            } else {
+                // If not an object, insert nulls
+                for _ in &columns {
+                    values.push(Box::new(None::<String>));
+                }
             }
-        } else {
-            // If not an object, insert nulls
-            for _ in &columns {
-                values.push(Box::new(None::<String>));
-            }
+            let params: Vec<&dyn ToSql> = values.iter().map(|v| v.as_ref()).collect();
+            stmt.execute(params_from_iter(params))?;
         }
-        let params: Vec<&dyn ToSql> = values.iter().map(|v| v.as_ref()).collect();
-        stmt.execute(params_from_iter(params))?;
     }
-    drop(stmt);
-    conn.execute_batch("COMMIT")?;
+    tx.commit()?;
 
     Ok(metadata.len())
 }
@@ -795,7 +965,7 @@ pub fn update(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         ));
     }
 
-    let conn = open_db(&db_path)?;
+    let mut conn = open_db(&db_path)?;
 
     // Get existing columns
     let mut existing_columns: Vec<String> = Vec::new();
@@ -808,6 +978,27 @@ pub fn update(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
                 existing_columns.push(col);
             }
         }
+    }
+
+    let existing_column_set: HashSet<&str> = existing_columns
+        .iter()
+        .map(|column| column.as_str())
+        .collect();
+    let has_new_columns = metadata.iter().any(|item| {
+        item.as_object().is_some_and(|obj| {
+            obj.keys()
+                .any(|key| !existing_column_set.contains(key.as_str()))
+        })
+    });
+    if !has_new_columns {
+        // Common case: callers keep sending the same schema that already exists
+        // in SQLite. Skip PRAGMA-driven schema mutation work and append rows
+        // directly using the current column order.
+        let fixed_columns: Vec<(&str, &str)> = existing_columns
+            .iter()
+            .map(|column| (column.as_str(), "TEXT"))
+            .collect();
+        return update_with_fixed_columns(index_path, &fixed_columns, metadata, doc_ids);
     }
 
     // Find new columns and add them
@@ -834,11 +1025,12 @@ pub fn update(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         }
     }
 
+    let tx = conn.transaction()?;
     // Add new columns to table
     for col in &new_columns {
         let sql_type = column_types.get(col).copied().unwrap_or("TEXT");
         let alter_sql = format!("ALTER TABLE METADATA ADD COLUMN \"{}\" {}", col, sql_type);
-        conn.execute(&alter_sql, [])?;
+        tx.execute(&alter_sql, [])?;
     }
 
     // Get all columns (existing + new)
@@ -858,26 +1050,25 @@ pub fn update(index_path: &str, metadata: &[Value], doc_ids: &[i64]) -> Result<u
         )
     };
 
-    // Insert rows (in a transaction for performance — single fsync)
-    conn.execute_batch("BEGIN")?;
-    let mut stmt = conn.prepare(&insert_sql)?;
-    for (i, item) in metadata.iter().enumerate() {
-        let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(doc_ids[i])];
-        if let Value::Object(obj) = item {
-            for col in &all_columns {
-                let value = obj.get(col).unwrap_or(&Value::Null);
-                values.push(json_to_sql(value));
+    {
+        let mut stmt = tx.prepare(&insert_sql)?;
+        for (i, item) in metadata.iter().enumerate() {
+            let mut values: Vec<Box<dyn ToSql>> = vec![Box::new(doc_ids[i])];
+            if let Value::Object(obj) = item {
+                for col in &all_columns {
+                    let value = obj.get(col).unwrap_or(&Value::Null);
+                    values.push(json_to_sql(value));
+                }
+            } else {
+                for _ in &all_columns {
+                    values.push(Box::new(None::<String>));
+                }
             }
-        } else {
-            for _ in &all_columns {
-                values.push(Box::new(None::<String>));
-            }
+            let params: Vec<&dyn ToSql> = values.iter().map(|v| v.as_ref()).collect();
+            stmt.execute(params_from_iter(params))?;
         }
-        let params: Vec<&dyn ToSql> = values.iter().map(|v| v.as_ref()).collect();
-        stmt.execute(params_from_iter(params))?;
     }
-    drop(stmt);
-    conn.execute_batch("COMMIT")?;
+    tx.commit()?;
 
     Ok(metadata.len())
 }
@@ -1381,7 +1572,9 @@ pub fn update_where(
         }
     }
 
-    // Find which _subset_ IDs will be affected (before the UPDATE)
+    // Keep the FTS mirror in sync with metadata updates by recording affected rows
+    // before executing the UPDATE. This stays on the generic path so any caller that
+    // updates searchable fields gets consistent search results.
     let affected_ids: Vec<i64> = {
         let affected_query = format!(
             "SELECT \"{}\" FROM METADATA WHERE {}",
@@ -1394,8 +1587,7 @@ pub fn update_where(
         let rows = affected_stmt.query_map(params_from_iter(cond_param_refs), |row| {
             row.get::<_, i64>(0)
         })?;
-        let ids: Vec<i64> = rows.filter_map(|r| r.ok()).collect();
-        ids
+        rows.filter_map(|row| row.ok()).collect()
     };
 
     // Build SET clause
@@ -1416,8 +1608,6 @@ pub fn update_where(
 
     let updated = conn.execute(&query, params_from_iter(param_refs))?;
 
-    // Sync FTS5 index for affected rows.
-    // With WAL mode, the existing conn (reader) coexists with update_rows' writer.
     if updated > 0 && !affected_ids.is_empty() {
         crate::text_search::update_rows(index_path, &affected_ids)?;
     }

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -164,6 +164,337 @@ pub struct ChunkMetadata {
     pub embedding_offset: usize,
 }
 
+#[derive(Debug, Clone)]
+pub struct EncodedIndexChunk {
+    pub codes: Array1<i64>,
+    pub residuals: Array2<u8>,
+    pub doclens: Vec<i64>,
+}
+
+pub struct PreparedCodecArtifacts {
+    pub codec: ResidualCodec,
+    pub cluster_threshold: f32,
+    pub bucket_cutoffs: Array1<f32>,
+    pub bucket_weights: Array1<f32>,
+    pub avg_res_per_dim: Array1<f32>,
+}
+
+pub fn prepare_codec_artifacts(
+    embeddings: &[Array2<f32>],
+    centroids: Array2<f32>,
+    config: &IndexConfig,
+) -> Result<PreparedCodecArtifacts> {
+    let embedding_dim = centroids.ncols();
+    let total_embeddings: usize = embeddings.iter().map(|e| e.nrows()).sum();
+    let num_documents = embeddings.len();
+
+    if num_documents == 0 {
+        return Err(Error::IndexCreation("No documents provided".into()));
+    }
+
+    let sample_count = ((16.0 * (120.0 * num_documents as f64).sqrt()) as usize)
+        .min(num_documents)
+        .max(1);
+
+    let mut rng = if let Some(seed) = config.seed {
+        use rand::SeedableRng;
+        rand_chacha::ChaCha8Rng::seed_from_u64(seed)
+    } else {
+        use rand::SeedableRng;
+        rand_chacha::ChaCha8Rng::from_entropy()
+    };
+
+    use rand::seq::SliceRandom;
+    let mut indices: Vec<usize> = (0..num_documents).collect();
+    indices.shuffle(&mut rng);
+    let sample_indices: Vec<usize> = indices.into_iter().take(sample_count).collect();
+
+    let heldout_size = (0.05 * total_embeddings as f64).min(50000.0) as usize;
+    let mut heldout_embeddings: Vec<f32> = Vec::with_capacity(heldout_size * embedding_dim);
+    let mut collected = 0;
+
+    for &idx in sample_indices.iter().rev() {
+        if collected >= heldout_size {
+            break;
+        }
+        let emb = &embeddings[idx];
+        let take = (heldout_size - collected).min(emb.nrows());
+        for row in emb.axis_iter(Axis(0)).take(take) {
+            heldout_embeddings.extend(row.iter());
+        }
+        collected += take;
+    }
+
+    let heldout = Array2::from_shape_vec((collected, embedding_dim), heldout_embeddings)
+        .map_err(|e| Error::IndexCreation(format!("Failed to create heldout array: {}", e)))?;
+
+    let avg_residual = Array1::zeros(embedding_dim);
+    let initial_codec =
+        ResidualCodec::new(config.nbits, centroids.clone(), avg_residual, None, None)?;
+
+    let heldout_codes = if config.force_cpu {
+        initial_codec.compress_into_codes_cpu(&heldout)
+    } else {
+        initial_codec.compress_into_codes(&heldout)
+    };
+
+    let mut residuals = heldout.clone();
+    for i in 0..heldout.nrows() {
+        let centroid = initial_codec.centroids.row(heldout_codes[i]);
+        for j in 0..embedding_dim {
+            residuals[[i, j]] -= centroid[j];
+        }
+    }
+
+    let distances: Array1<f32> = residuals
+        .axis_iter(Axis(0))
+        .map(|row| row.dot(&row).sqrt())
+        .collect();
+    let cluster_threshold = quantile(&distances, 0.75);
+
+    let avg_res_per_dim: Array1<f32> = residuals
+        .axis_iter(Axis(1))
+        .map(|col| col.iter().map(|x| x.abs()).sum::<f32>() / col.len() as f32)
+        .collect();
+
+    let n_options = 1 << config.nbits;
+    let quantile_values: Vec<f64> = (1..n_options)
+        .map(|i| i as f64 / n_options as f64)
+        .collect();
+    let weight_quantile_values: Vec<f64> = (0..n_options)
+        .map(|i| (i as f64 + 0.5) / n_options as f64)
+        .collect();
+
+    let flat_residuals: Array1<f32> = residuals.iter().copied().collect();
+    let bucket_cutoffs = Array1::from_vec(quantiles(&flat_residuals, &quantile_values));
+    let bucket_weights = Array1::from_vec(quantiles(&flat_residuals, &weight_quantile_values));
+
+    let codec = ResidualCodec::new(
+        config.nbits,
+        centroids,
+        avg_res_per_dim.clone(),
+        Some(bucket_cutoffs.clone()),
+        Some(bucket_weights.clone()),
+    )?;
+
+    Ok(PreparedCodecArtifacts {
+        codec,
+        cluster_threshold,
+        bucket_cutoffs,
+        bucket_weights,
+        avg_res_per_dim,
+    })
+}
+
+pub fn encode_index_chunk(
+    embeddings: &[Array2<f32>],
+    codec: &ResidualCodec,
+    force_cpu: bool,
+) -> Result<EncodedIndexChunk> {
+    let embedding_dim = codec.embedding_dim();
+    let packed_dim = embedding_dim * codec.nbits / 8;
+    let doclens: Vec<i64> = embeddings.iter().map(|d| d.nrows() as i64).collect();
+    let total_tokens: usize = doclens.iter().sum::<i64>() as usize;
+
+    #[cfg(not(feature = "cuda"))]
+    let _ = force_cpu;
+
+    let mut batch_embeddings = Array2::<f32>::zeros((total_tokens, embedding_dim));
+    let mut offset = 0;
+    for doc in embeddings {
+        let n = doc.nrows();
+        batch_embeddings
+            .slice_mut(s![offset..offset + n, ..])
+            .assign(doc);
+        offset += n;
+    }
+
+    let (batch_codes, batch_residuals) = {
+        #[cfg(feature = "cuda")]
+        {
+            let force_gpu = crate::is_force_gpu();
+            if !force_cpu {
+                if let Some(ctx) = crate::cuda::get_global_context() {
+                    match crate::cuda::compress_and_residuals_cuda_batched(
+                        &ctx,
+                        &batch_embeddings.view(),
+                        &codec.centroids_view(),
+                        None,
+                    ) {
+                        Ok(result) => result,
+                        Err(e) => {
+                            if force_gpu {
+                                panic!(
+                                    "FORCE_GPU is set but CUDA compress_and_residuals failed: {}",
+                                    e
+                                );
+                            }
+                            println!(
+                                "[next-plaid] CUDA compress_and_residuals failed: {}, falling back to CPU",
+                                e
+                            );
+                            compress_and_residuals_cpu(&batch_embeddings, codec)
+                        }
+                    }
+                } else if force_gpu {
+                    panic!("FORCE_GPU is set but CUDA context is unavailable");
+                } else {
+                    compress_and_residuals_cpu(&batch_embeddings, codec)
+                }
+            } else {
+                compress_and_residuals_cpu(&batch_embeddings, codec)
+            }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            compress_and_residuals_cpu(&batch_embeddings, codec)
+        }
+    };
+
+    let batch_packed = codec.quantize_residuals(&batch_residuals)?;
+    let (raw_residuals, residuals_offset) = batch_packed.into_raw_vec_and_offset();
+    if residuals_offset != Some(0) {
+        return Err(Error::Shape(format!(
+            "Unexpected residual packing offset: {:?}",
+            residuals_offset
+        )));
+    }
+    let residuals = Array2::from_shape_vec((batch_codes.len(), packed_dim), raw_residuals)
+        .map_err(|e| Error::Shape(format!("Failed to reshape residuals: {}", e)))?;
+    let codes: Array1<i64> = batch_codes.iter().map(|&x| x as i64).collect();
+
+    Ok(EncodedIndexChunk {
+        codes,
+        residuals,
+        doclens,
+    })
+}
+
+pub fn write_index_from_encoded_chunks(
+    chunks: &[EncodedIndexChunk],
+    codec_artifacts: &PreparedCodecArtifacts,
+    index_path: &str,
+    config: &IndexConfig,
+) -> Result<Metadata> {
+    use ndarray_npy::WriteNpyExt;
+
+    let index_dir = Path::new(index_path);
+    fs::create_dir_all(index_dir)?;
+
+    let embedding_dim = codec_artifacts.codec.embedding_dim();
+    let num_centroids = codec_artifacts.codec.num_centroids();
+    let total_embeddings: usize = chunks.iter().map(|c| c.codes.len()).sum();
+    let num_documents: usize = chunks.iter().map(|c| c.doclens.len()).sum();
+    let avg_doclen = if num_documents > 0 {
+        total_embeddings as f64 / num_documents as f64
+    } else {
+        0.0
+    };
+
+    let centroids_path = index_dir.join("centroids.npy");
+    codec_artifacts
+        .codec
+        .centroids_view()
+        .to_owned()
+        .write_npy(File::create(&centroids_path)?)?;
+    codec_artifacts
+        .bucket_cutoffs
+        .write_npy(File::create(index_dir.join("bucket_cutoffs.npy"))?)?;
+    codec_artifacts
+        .bucket_weights
+        .write_npy(File::create(index_dir.join("bucket_weights.npy"))?)?;
+    codec_artifacts
+        .avg_res_per_dim
+        .write_npy(File::create(index_dir.join("avg_residual.npy"))?)?;
+    Array1::from_vec(vec![codec_artifacts.cluster_threshold])
+        .write_npy(File::create(index_dir.join("cluster_threshold.npy"))?)?;
+
+    let n_chunks = chunks.len();
+    let plan = serde_json::json!({
+        "nbits": config.nbits,
+        "num_chunks": n_chunks,
+    });
+    let mut plan_file = File::create(index_dir.join("plan.json"))?;
+    writeln!(plan_file, "{}", serde_json::to_string_pretty(&plan)?)?;
+
+    let mut all_codes: Vec<usize> = Vec::with_capacity(total_embeddings);
+    let mut doc_lengths: Vec<i64> = Vec::with_capacity(num_documents);
+    let mut current_offset = 0usize;
+
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
+        let chunk_meta = ChunkMetadata {
+            num_documents: chunk.doclens.len(),
+            num_embeddings: chunk.codes.len(),
+            embedding_offset: current_offset,
+        };
+        current_offset += chunk.codes.len();
+
+        serde_json::to_writer_pretty(
+            BufWriter::new(File::create(
+                index_dir.join(format!("{}.metadata.json", chunk_idx)),
+            )?),
+            &chunk_meta,
+        )?;
+        serde_json::to_writer(
+            BufWriter::new(File::create(
+                index_dir.join(format!("doclens.{}.json", chunk_idx)),
+            )?),
+            &chunk.doclens,
+        )?;
+        chunk.codes.write_npy(File::create(
+            index_dir.join(format!("{}.codes.npy", chunk_idx)),
+        )?)?;
+        chunk.residuals.write_npy(File::create(
+            index_dir.join(format!("{}.residuals.npy", chunk_idx)),
+        )?)?;
+
+        doc_lengths.extend_from_slice(&chunk.doclens);
+        all_codes.extend(chunk.codes.iter().map(|&x| x as usize));
+    }
+
+    let mut code_to_docs: BTreeMap<usize, Vec<i64>> = BTreeMap::new();
+    let mut emb_idx = 0;
+    for (doc_id, &len) in doc_lengths.iter().enumerate() {
+        for _ in 0..len {
+            let code = all_codes[emb_idx];
+            code_to_docs.entry(code).or_default().push(doc_id as i64);
+            emb_idx += 1;
+        }
+    }
+
+    let mut ivf_data: Vec<i64> = Vec::new();
+    let mut ivf_lengths: Vec<i32> = vec![0; num_centroids];
+    for (centroid_id, ivf_len) in ivf_lengths.iter_mut().enumerate() {
+        if let Some(docs) = code_to_docs.get(&centroid_id) {
+            let mut unique_docs = docs.clone();
+            unique_docs.sort_unstable();
+            unique_docs.dedup();
+            *ivf_len = unique_docs.len() as i32;
+            ivf_data.extend(unique_docs);
+        }
+    }
+
+    Array1::from_vec(ivf_data).write_npy(File::create(index_dir.join("ivf.npy"))?)?;
+    Array1::from_vec(ivf_lengths).write_npy(File::create(index_dir.join("ivf_lengths.npy"))?)?;
+
+    let metadata = Metadata {
+        num_chunks: n_chunks,
+        nbits: config.nbits,
+        num_partitions: num_centroids,
+        num_embeddings: total_embeddings,
+        avg_doclen,
+        num_documents,
+        embedding_dim,
+        next_plaid_compatible: true,
+    };
+    serde_json::to_writer_pretty(
+        BufWriter::new(File::create(index_dir.join("metadata.json"))?),
+        &metadata,
+    )?;
+
+    Ok(metadata)
+}
+
 // ============================================================================
 // Standalone Index Creation Functions
 // ============================================================================
@@ -363,6 +694,7 @@ pub fn create_index_files(
         let (batch_codes, batch_residuals) = {
             #[cfg(feature = "cuda")]
             {
+                let force_gpu = crate::is_force_gpu();
                 if !config.force_cpu {
                     if let Some(ctx) = crate::cuda::get_global_context() {
                         match crate::cuda::compress_and_residuals_cuda_batched(
@@ -373,6 +705,9 @@ pub fn create_index_files(
                         ) {
                             Ok(result) => result,
                             Err(e) => {
+                                if force_gpu {
+                                    panic!("FORCE_GPU is set but CUDA compress_and_residuals failed: {}", e);
+                                }
                                 eprintln!(
                                     "[next-plaid] CUDA compress_and_residuals failed: {}, falling back to CPU",
                                     e
@@ -380,6 +715,8 @@ pub fn create_index_files(
                                 compress_and_residuals_cpu(&batch_embeddings, &codec)
                             }
                         }
+                    } else if force_gpu {
+                        panic!("FORCE_GPU is set but CUDA context is unavailable");
                     } else {
                         compress_and_residuals_cpu(&batch_embeddings, &codec)
                     }
@@ -522,7 +859,12 @@ pub fn create_index_with_kmeans_files(
     // Skip if force_cpu is set to avoid unnecessary initialization overhead
     #[cfg(feature = "cuda")]
     if !config.force_cpu {
-        let _ = crate::cuda::get_global_context();
+        if crate::is_force_gpu() {
+            crate::cuda::get_global_context()
+                .expect("FORCE_GPU is set but CUDA context failed to initialize");
+        } else {
+            let _ = crate::cuda::get_global_context();
+        }
     }
 
     // Build K-means configuration from IndexConfig
@@ -690,15 +1032,15 @@ impl MmapIndex {
         let last_len = *doc_lengths.last().unwrap_or(&0) as usize;
         let padding_needed = max_len.saturating_sub(last_len);
 
-        // Create merged files if needed
         let merged_codes_path =
             crate::mmap::merge_codes_chunks(index_dir, metadata.num_chunks, padding_needed)?;
         let merged_residuals_path =
             crate::mmap::merge_residuals_chunks(index_dir, metadata.num_chunks, padding_needed)?;
 
-        // Memory-map the merged files
-        let mmap_codes = crate::mmap::MmapNpyArray1I64::from_npy_file(&merged_codes_path)?;
-        let mmap_residuals = crate::mmap::MmapNpyArray2U8::from_npy_file(&merged_residuals_path)?;
+        let (mmap_codes, mmap_residuals) = (
+            crate::mmap::MmapNpyArray1I64::from_npy_file(&merged_codes_path)?,
+            crate::mmap::MmapNpyArray2U8::from_npy_file(&merged_residuals_path)?,
+        );
 
         Ok(Self {
             path: index_path.to_string(),

--- a/next-plaid/src/kmeans.rs
+++ b/next-plaid/src/kmeans.rs
@@ -275,11 +275,11 @@ pub fn compute_kmeans(
     });
     let n_samples_kmeans = n_samples_kmeans.min(num_documents);
 
-    // Sample random documents
     let mut rng = ChaCha8Rng::seed_from_u64(config.seed);
-    let mut sampled_indices: Vec<usize> = (0..num_documents).collect();
-    sampled_indices.shuffle(&mut rng);
-    sampled_indices.truncate(n_samples_kmeans);
+    let mut indices: Vec<usize> = (0..num_documents).collect();
+    indices.shuffle(&mut rng);
+    indices.truncate(n_samples_kmeans);
+    let sampled_indices = indices;
 
     // Calculate total tokens in sampled documents
     let total_sample_tokens: usize = sampled_indices

--- a/next-plaid/src/lib.rs
+++ b/next-plaid/src/lib.rs
@@ -30,7 +30,10 @@ pub use codec::ResidualCodec;
 pub use delete::delete_from_index;
 pub use error::{Error, Result};
 pub use index::MmapIndex;
-pub use index::{IndexConfig, Metadata};
+pub use index::{
+    encode_index_chunk, prepare_codec_artifacts, write_index_from_encoded_chunks,
+    EncodedIndexChunk, IndexConfig, Metadata, PreparedCodecArtifacts,
+};
 pub use kmeans::{
     compute_centroids, compute_centroids_from_documents, compute_kmeans, estimate_num_partitions,
     ComputeKmeansConfig, FastKMeans, KMeansConfig,

--- a/next-plaid/src/update.rs
+++ b/next-plaid/src/update.rs
@@ -357,67 +357,185 @@ pub fn update_cluster_threshold(
 ///
 /// Returns indices of embeddings where min L2² distance > threshold².
 ///
-/// Uses batch matrix multiplication for efficiency:
-/// ||a - b||² = ||a||² + ||b||² - 2*a·b
-fn find_outliers(
+const OUTLIER_CENTROID_TILE: usize = 8;
+const OUTLIER_EMBEDDING_TILE: usize = 64;
+const OUTLIER_BLOCKS_MIN_LEN: usize = 4;
+const OUTLIER_THRESHOLD_RECHECK_REL_EPS: f32 = 1e-5;
+
+#[inline]
+fn squared_norm(row: &[f32]) -> f32 {
+    let mut sum0 = 0.0f32;
+    let mut sum1 = 0.0f32;
+    let mut sum2 = 0.0f32;
+    let mut sum3 = 0.0f32;
+
+    let mut i = 0;
+    while i + 4 <= row.len() {
+        sum0 += row[i] * row[i];
+        sum1 += row[i + 1] * row[i + 1];
+        sum2 += row[i + 2] * row[i + 2];
+        sum3 += row[i + 3] * row[i + 3];
+        i += 4;
+    }
+
+    let mut total = sum0 + sum1 + sum2 + sum3;
+    while i < row.len() {
+        total += row[i] * row[i];
+        i += 1;
+    }
+
+    total
+}
+
+#[inline]
+fn min_distance_sq_precise(row: &[f32], centroids_flat: &[f32], dim: usize) -> f32 {
+    let mut min_dist_sq = f32::INFINITY;
+
+    for centroid in centroids_flat.chunks_exact(dim) {
+        let mut dist_sq = 0.0f64;
+        let mut d = 0;
+        while d < dim {
+            let diff = row[d] as f64 - centroid[d] as f64;
+            dist_sq += diff * diff;
+            d += 1;
+        }
+
+        min_dist_sq = min_dist_sq.min(dist_sq as f32);
+    }
+
+    min_dist_sq
+}
+
+/// Find outliers with a blocked raw-slice kernel over centroid tiles.
+///
+/// This avoids materializing the intermediate [batch, num_centroids] scores matrix,
+/// removes iterator overhead from the hot loop, and parallelizes across embedding blocks.
+fn find_outliers_blocked(
     flat_embeddings: &Array2<f32>,
     centroids: &Array2<f32>,
     threshold_sq: f32,
 ) -> Vec<usize> {
     let n = flat_embeddings.nrows();
     let k = centroids.nrows();
+    let dim = flat_embeddings.ncols();
 
     if n == 0 || k == 0 {
         return Vec::new();
     }
 
-    // Pre-compute squared norms for embeddings and centroids
-    let emb_norms_sq: Vec<f32> = flat_embeddings
-        .axis_iter(Axis(0))
-        .into_par_iter()
-        .map(|row| row.dot(&row))
+    let embeddings_owned;
+    let embeddings_flat = if let Some(slice) = flat_embeddings.as_slice_memory_order() {
+        slice
+    } else {
+        embeddings_owned = flat_embeddings.as_standard_layout().to_owned();
+        embeddings_owned
+            .as_slice_memory_order()
+            .expect("standard-layout embeddings should be contiguous")
+    };
+    let centroids_owned;
+    let centroids_flat = if let Some(slice) = centroids.as_slice_memory_order() {
+        slice
+    } else {
+        centroids_owned = centroids.as_standard_layout().to_owned();
+        centroids_owned
+            .as_slice_memory_order()
+            .expect("standard-layout centroids should be contiguous")
+    };
+
+    let centroid_norms_sq: Vec<f32> = centroids_flat
+        .par_chunks_exact(dim)
+        .map(squared_norm)
         .collect();
 
-    let centroid_norms_sq: Vec<f32> = centroids
-        .axis_iter(Axis(0))
-        .into_par_iter()
-        .map(|row| row.dot(&row))
-        .collect();
+    let row_stride = dim * OUTLIER_EMBEDDING_TILE;
+    embeddings_flat
+        .par_chunks(row_stride)
+        .with_min_len(OUTLIER_BLOCKS_MIN_LEN)
+        .enumerate()
+        .flat_map_iter(|(block_idx, rows_block)| {
+            let row_count = rows_block.len() / dim;
+            let row_offset = block_idx * OUTLIER_EMBEDDING_TILE;
 
-    // Batch matrix multiplication: [n, d] @ [d, k] -> [n, k]
-    // This computes dot products: similarities[i, j] = embeddings[i] · centroids[j]
-    // Process in batches to limit memory usage
-    let batch_size = (2 * 1024 * 1024 * 1024 / (k * std::mem::size_of::<f32>())).clamp(1, 4096);
+            let mut min_dists = vec![f32::INFINITY; row_count];
+            let emb_norms: Vec<f32> = rows_block.chunks_exact(dim).map(squared_norm).collect();
 
-    let mut outlier_indices = Vec::new();
+            let mut centroid_idx = 0;
+            while centroid_idx + OUTLIER_CENTROID_TILE <= k {
+                let centroid_bases: [usize; OUTLIER_CENTROID_TILE] =
+                    std::array::from_fn(|j| (centroid_idx + j) * dim);
 
-    for batch_start in (0..n).step_by(batch_size) {
-        let batch_end = (batch_start + batch_size).min(n);
-        let batch = flat_embeddings.slice(s![batch_start..batch_end, ..]);
+                let mut dots = [[0.0f32; OUTLIER_CENTROID_TILE]; OUTLIER_EMBEDDING_TILE];
 
-        // Compute dot products: [batch, k]
-        let dot_products = batch.dot(&centroids.t());
+                let mut d = 0;
+                while d < dim {
+                    let centroid_vals: [f32; OUTLIER_CENTROID_TILE] =
+                        std::array::from_fn(|j| centroids_flat[centroid_bases[j] + d]);
 
-        // Find min L2² distance for each embedding in batch
-        for (batch_idx, row) in dot_products.axis_iter(Axis(0)).enumerate() {
-            let global_idx = batch_start + batch_idx;
-            let emb_norm_sq = emb_norms_sq[global_idx];
+                    for row_idx in 0..row_count {
+                        let x = rows_block[row_idx * dim + d];
+                        for j in 0..OUTLIER_CENTROID_TILE {
+                            dots[row_idx][j] += x * centroid_vals[j];
+                        }
+                    }
 
-            // L2² = ||a||² + ||b||² - 2*a·b
-            // Find minimum over all centroids
-            let min_dist_sq = row
-                .iter()
-                .zip(centroid_norms_sq.iter())
-                .map(|(&dot, &c_norm_sq)| emb_norm_sq + c_norm_sq - 2.0 * dot)
-                .fold(f32::INFINITY, f32::min);
+                    d += 1;
+                }
 
-            if min_dist_sq > threshold_sq {
-                outlier_indices.push(global_idx);
+                for row_idx in 0..row_count {
+                    let emb_norm_sq = emb_norms[row_idx];
+                    for j in 0..OUTLIER_CENTROID_TILE {
+                        let dist_sq = emb_norm_sq + centroid_norms_sq[centroid_idx + j]
+                            - 2.0 * dots[row_idx][j];
+                        min_dists[row_idx] = min_dists[row_idx].min(dist_sq);
+                    }
+                }
+
+                centroid_idx += OUTLIER_CENTROID_TILE;
             }
-        }
-    }
 
-    outlier_indices
+            while centroid_idx < k {
+                let centroid = &centroids_flat[centroid_idx * dim..(centroid_idx + 1) * dim];
+                for row_idx in 0..row_count {
+                    let row = &rows_block[row_idx * dim..(row_idx + 1) * dim];
+                    let mut dot = 0.0f32;
+                    let mut d = 0;
+                    while d < dim {
+                        dot += row[d] * centroid[d];
+                        d += 1;
+                    }
+
+                    let dist_sq = emb_norms[row_idx] + centroid_norms_sq[centroid_idx] - 2.0 * dot;
+                    min_dists[row_idx] = min_dists[row_idx].min(dist_sq);
+                }
+
+                centroid_idx += 1;
+            }
+
+            min_dists
+                .into_iter()
+                .enumerate()
+                .filter_map(move |(row_idx, min_dist_sq)| {
+                    let final_min_dist_sq = if (min_dist_sq - threshold_sq).abs()
+                        <= threshold_sq.abs().max(1.0) * OUTLIER_THRESHOLD_RECHECK_REL_EPS
+                    {
+                        let row = &rows_block[row_idx * dim..(row_idx + 1) * dim];
+                        min_distance_sq_precise(row, centroids_flat, dim)
+                    } else {
+                        min_dist_sq
+                    };
+
+                    (final_min_dist_sq > threshold_sq).then_some(row_offset + row_idx)
+                })
+        })
+        .collect()
+}
+
+fn find_outliers(
+    flat_embeddings: &Array2<f32>,
+    centroids: &Array2<f32>,
+    threshold_sq: f32,
+) -> Vec<usize> {
+    find_outliers_blocked(flat_embeddings, centroids, threshold_sq)
 }
 
 /// Expand centroids by clustering embeddings far from existing centroids.
@@ -778,16 +896,14 @@ pub fn update_index(
 
     // Build new partial IVF
     let mut partition_pids_map: HashMap<usize, Vec<i64>> = HashMap::new();
-    let mut pid_counter = old_num_documents as i64;
 
-    for doc_codes in &new_codes_accumulated {
+    for (pid_counter, doc_codes) in (old_num_documents as i64..).zip(new_codes_accumulated.iter()) {
         for &code in doc_codes {
             partition_pids_map
                 .entry(code)
                 .or_default()
                 .push(pid_counter);
         }
-        pid_counter += 1;
     }
 
     // Load old IVF and merge


### PR DESCRIPTION
## Summary

Extracted colgrep-related changes from #67 (Performance Exploration & Maximum Pipelining) to merge the PR incrementally.

- **Pipelined indexing**: tokenize → encode → pool → index stages in parallel threads with channel handoff — **2.5x faster index builds** on GPU, **9x less CPU time** (GPU offloads compute), **39% less peak RAM**
- **Dynamic batching**: documents bucketed by length into fixed shapes to minimize padding waste on GPU
- **FTS5 hybrid search**: SQLite full-text index fused with semantic results via RRF (configurable `--alpha`)
- **Acceleration mode**: `--force-cpu` / `--force-gpu` CLI flags and env vars, with Auto mode keeping CPU for single-query encoding to avoid CUDA launch overhead
- **ONNX session tuning**: memory pattern optimization kept enabled for GPU, TF32 on by default
- **Embedding text truncation** at 8K chars to bound encoder input
- **Small-project auto-detection** in session hook (≤50 files → auto-index)

Includes required dependency changes in `next-plaid` (text_search module, chunked encoding API, filtering fast paths, merge manifest caching) and `next-plaid-onnx` (streaming encoder, prepared batch API, `pool_document_embeddings`).

### Benchmark (Auto mode, H100 80GB, 15 Rust files ~12.5K LOC)

| Metric | main | This PR | Delta |
|---|---|---|---|
| Index build (wall) | 20.6s | 8.2s | **-60% (2.5x faster)** |
| Index build (CPU time) | 193s | 21.6s | **-89% (9x less)** |
| CPU utilization | 1107% (11 cores) | 414% (4 cores) | **-63%** |
| Peak RAM | 4.9 GB | 3.0 GB | **-39%** |
| Search avg/query | 0.458s | 0.457s | **identical** |

## Test plan

- [x] Full workspace compiles (`cargo check --features cuda` for all crates)
- [ ] Run `cargo test -p next-plaid --features cuda` 
- [ ] Run `cargo test -p colgrep`
- [ ] Manual smoke test: `colgrep init -y && colgrep "error handling"` on a real project
- [ ] Verify FTS5 hybrid search: `colgrep "auth" --alpha 0.5` returns blended results
- [ ] Verify `FORCE_GPU=1` and `FORCE_CPU=1` flags work correctly

Based on work by @cepera-ang in #67.