### PR TITLE
fix: normalize Windows verbatim paths in colgrep search output

### DIFF
--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -316,16 +316,68 @@ pub fn resolve_relative_paths() -> bool {
 
 /// Format a path for display, using relative or absolute based on config.
 fn display_path(path: &Path, use_relative: bool) -> String {
+    let current_dir = std::env::current_dir().ok();
+    display_path_with_cwd(path, current_dir.as_deref(), use_relative)
+}
+
+fn display_path_with_cwd(path: &Path, cwd: Option<&Path>, use_relative: bool) -> String {
+    let normalized_path = normalize_windows_path(path);
+
     if use_relative {
-        if let Ok(cwd) = std::env::current_dir() {
-            return path
-                .strip_prefix(&cwd)
-                .unwrap_or(path)
+        if let Some(cwd) = cwd {
+            let normalized_cwd = normalize_windows_path(cwd);
+            return normalized_path
+                .strip_prefix(&normalized_cwd)
+                .unwrap_or(&normalized_path)
                 .display()
                 .to_string();
         }
     }
-    path.display().to_string()
+
+    normalized_path.display().to_string()
+}
+
+fn is_external_project_path(search_path: &Path, cwd: Option<&Path>) -> bool {
+    let Some(cwd) = cwd else {
+        return false;
+    };
+
+    let normalized_search_path = normalize_windows_path(search_path);
+    let normalized_cwd = normalize_windows_path(cwd);
+    !normalized_search_path.starts_with(&normalized_cwd)
+}
+
+fn normalize_windows_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use std::path::{Component, Prefix};
+
+        let mut components = path.components();
+        match components.next() {
+            Some(Component::Prefix(prefix_component)) => match prefix_component.kind() {
+                Prefix::VerbatimDisk(drive) => {
+                    let mut normalized = PathBuf::from(format!("{}:\\", char::from(drive)));
+                    normalized.push(components.as_path());
+                    normalized
+                }
+                Prefix::VerbatimUNC(server, share) => {
+                    let mut normalized = PathBuf::from(format!(
+                        r"\\{}\{}",
+                        server.to_string_lossy(),
+                        share.to_string_lossy()
+                    ));
+                    normalized.push(components.as_path());
+                    normalized
+                }
+                _ => path.to_path_buf(),
+            },
+            _ => path.to_path_buf(),
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        path.to_path_buf()
+    }
 }
 
 /// Resolve verbose: saved config > default (false)
@@ -879,9 +931,8 @@ fn search_single_path(
     // Check for parent index unless the resolved path is outside
     // the current directory (external project)
     let parent_info = {
-        let is_external_project = std::env::current_dir()
-            .map(|cwd| !search_path.starts_with(&cwd))
-            .unwrap_or(false);
+        let current_dir = std::env::current_dir().ok();
+        let is_external_project = is_external_project_path(&search_path, current_dir.as_deref());
 
         if is_external_project {
             None
@@ -945,14 +996,14 @@ fn search_single_path(
                     if let Some(ref info) = parent_info {
                         eprintln!(
                             "📂 Using index: {} (subdir: {}): indexed {} files\n",
-                            info.project_path.display(),
+                            display_path(&info.project_path, false),
                             info.relative_subdir.display(),
                             changes
                         );
                     } else {
                         eprintln!(
                             "📂 Using index: {}: indexed {} files\n",
-                            effective_root.display(),
+                            display_path(&effective_root, false),
                             changes
                         );
                     }
@@ -1444,6 +1495,7 @@ fn search_single_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     // Test resolve_top_k function
     #[test]
@@ -1625,6 +1677,56 @@ mod tests {
         assert_eq!(
             merge_query_with_pattern("pub fn", "pub async fn test"),
             "pub fn async test"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_display_path_uses_relative_output_for_verbatim_windows_paths() {
+        let temp_dir = tempdir().unwrap();
+        let canonical_root = std::fs::canonicalize(temp_dir.path()).unwrap();
+        let search_result_path = canonical_root.join("src").join("main.rs");
+        let display = display_path_with_cwd(&search_result_path, Some(temp_dir.path()), true);
+
+        assert_eq!(
+            display,
+            PathBuf::from("src").join("main.rs").display().to_string()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_display_path_strips_verbatim_windows_prefix_in_absolute_mode() {
+        let temp_dir = tempdir().unwrap();
+        let canonical_root = std::fs::canonicalize(temp_dir.path()).unwrap();
+        let search_result_path = canonical_root.join("src").join("main.rs");
+
+        let display = display_path(&search_result_path, false);
+
+        assert!(!display.starts_with(r"\\?\"));
+        assert!(display.ends_with(r"src\main.rs"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_is_external_project_path_ignores_windows_verbatim_prefixes() {
+        let temp_dir = tempdir().unwrap();
+        let canonical_root = std::fs::canonicalize(temp_dir.path()).unwrap();
+
+        assert!(!is_external_project_path(
+            &canonical_root,
+            Some(temp_dir.path())
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_normalize_windows_path_strips_verbatim_unc_prefix() {
+        let raw_path = PathBuf::from(r"\\?\UNC\server\share\repo\src\main.rs");
+
+        assert_eq!(
+            normalize_windows_path(&raw_path),
+            PathBuf::from(r"\\server\share\repo\src\main.rs")
         );
     }
 }


### PR DESCRIPTION
What problem are you trying to solve?

On Windows, `colgrep settings --relative-paths` can report that relative paths are enabled while search output still prints absolute verbatim paths like `\\?\E:\UnrealProjects\ProjectGhost\Source\...`. The mismatch comes from comparing canonicalized Windows verbatim paths against a non-verbatim current working directory path, so relative-path stripping fails. The same verbatim path form can also leak into the `Using index:` status line.

What does this PR change?

This PR normalizes Windows verbatim paths before formatting search output and before checking whether a search path is outside the current directory for parent-index detection. It also routes the `Using index:` status message through the same normalized display path logic. The diff adds Windows regression tests for verbatim disk paths, UNC paths, and the parent-index external-path check. It does not change non-Windows path handling.

Is this change appropriate for the core library?

Yes. This is a bug in core `colgrep` CLI path formatting and path comparison on Windows. The fix is in `colgrep/src/commands/search.rs` and benefits any Windows user who enables relative paths.

What alternatives did you consider?

I considered changing how paths are stored in the index metadata or removing canonicalization earlier in the search flow. I rejected that because it is a broader behavior change with higher regression risk. Normalizing paths at the display/comparison layer fixes the user-visible bug with a smaller, more reviewable diff.

Does this PR contain multiple unrelated changes?

No. This PR fixes one Windows path-formatting problem in `colgrep` search output and adds the regression coverage needed to keep that behavior stable.

Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art

Related PRs:
- #39 `feat: use relative paths in search output`
- #20 `fix(colgrep): apply paths ignore based on relative paths, not absolute ones`

I did not find an open or closed PR for this exact Windows verbatim-path bug.

Environment tested

- Harness: Codex CLI
- Harness version: not exposed by the current session
- Model: GPT-5 Codex
- Model version/ID: not exposed by the current session
- OS: Windows 11 and WSL2 Ubuntu

Evaluation

What was the initial prompt you (or your human partner) used to start the session that led to this change?

`Check if colgrep settings --relative-paths works on Windows.`
The initial repro also required confirming that search results still showed `\\?\...` paths, tracing the relative-path stripping logic in `colgrep/src`, and checking whether the prefix was stored in index metadata.

How many eval sessions did you run AFTER making the change?

6

How did outcomes change compared to before the change?

Before the change, Windows search results still printed `\\?\...` absolute paths even after enabling `--relative-paths`, and the `Using index:` line could also surface the verbatim prefix. After the change, Windows search results are relative, the status line is normalized, and WSL2/Linux still returns normal relative paths without the Windows-specific prefix problem.

Rigor

- [ ] If this is a skills change: I used superpowers:writing-skills and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial checks run:
- Windows unit tests for verbatim disk paths
- Windows unit test for UNC path normalization
- Windows unit test for parent-index external-path detection with canonicalized paths
- Windows manual CLI verification for `settings --relative-paths` and live search output
- WSL2 Ubuntu native build and live search verification

Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
