### PR TITLE
Add QML support to colgrep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "tree-sitter-ocaml",
  "tree-sitter-php",
  "tree-sitter-python",
+ "tree-sitter-qmljs",
  "tree-sitter-r",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -4751,6 +4752,16 @@ name = "tree-sitter-python"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-qmljs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67445ea937cd7eadaf2f628e2e7dd234374586cc31b4d1d63dbb5f5e7f9d9b62"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-zig = "1.1"
 tree-sitter-julia = "0.23"
 tree-sitter-sequel = "0.3"
 tree-sitter-html = "0.23"
+tree-sitter-qmljs = "0.3"
 
 # === Model download ===
 hf-hub = "0.4"

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -57,8 +57,8 @@ EXAMPLES:
 
 SUPPORTED LANGUAGES:
     Python, Rust, TypeScript, JavaScript, Go, Java, C, C++, C#, Ruby,
-    PHP, Swift, Kotlin, Scala, Lua, Elixir, Haskell, OCaml, R, Zig, Julia,
-    Shell/Bash, SQL, Markdown, Plain text
+    PHP, Swift, Kotlin, Scala, Lua, Elixir, Haskell, OCaml, QML, R, Zig,
+    Julia, Shell/Bash, SQL, Markdown, Plain text
 
 ENVIRONMENT:
     Indexes are stored in ~/.local/share/colgrep/ (or $XDG_DATA_HOME/colgrep)

--- a/colgrep/src/parser/language.rs
+++ b/colgrep/src/parser/language.rs
@@ -45,6 +45,7 @@ pub fn detect_language(path: &Path) -> Option<Language> {
         "vue" => Some(Language::Vue),
         "svelte" => Some(Language::Svelte),
         // Text/documentation formats
+        "qml" => Some(Language::Qml),
         "html" | "htm" => Some(Language::Html),
         "md" | "markdown" => Some(Language::Markdown),
         "txt" | "text" | "rst" => Some(Language::Text),
@@ -108,6 +109,7 @@ pub fn get_tree_sitter_language(lang: Language) -> TsLanguage {
         Language::Sql => tree_sitter_sequel::LANGUAGE.into(),
         // Vue and Svelte use TypeScript parser for script blocks
         Language::Vue | Language::Svelte => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        Language::Qml => tree_sitter_qmljs::LANGUAGE.into(),
         // HTML uses tree-sitter-html
         Language::Html => tree_sitter_html::LANGUAGE.into(),
         // Text/config formats don't use tree-sitter - this should never be called
@@ -249,6 +251,7 @@ mod tests {
 
     #[test]
     fn test_detect_language_text() {
+        assert_eq!(detect_language(Path::new("shell.qml")), Some(Language::Qml));
         assert_eq!(
             detect_language(Path::new("README.md")),
             Some(Language::Markdown)
@@ -348,6 +351,7 @@ mod tests {
         assert!(!is_text_format(Language::Zig));
         assert!(!is_text_format(Language::Julia));
         assert!(!is_text_format(Language::Sql));
+        assert!(!is_text_format(Language::Qml));
         assert!(!is_text_format(Language::Vue));
         assert!(!is_text_format(Language::Svelte));
         assert!(!is_text_format(Language::Html));

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -17,6 +17,7 @@ mod call_graph;
 mod extract;
 mod html;
 mod language;
+mod qml;
 mod svelte;
 mod text;
 pub mod types;
@@ -99,6 +100,10 @@ pub fn extract_units(path: &Path, source: &str, lang: Language) -> Vec<CodeUnit>
     // Handle Svelte components with special extraction logic
     if lang == Language::Svelte {
         return svelte::extract_svelte_units(path, source);
+    }
+
+    if lang == Language::Qml {
+        return qml::extract_qml_units(path, source);
     }
 
     // Handle HTML files with special extraction logic

--- a/colgrep/src/parser/qml.rs
+++ b/colgrep/src/parser/qml.rs
@@ -435,7 +435,10 @@ fn extract_object_variables(node: Node, bytes: &[u8]) -> Vec<String> {
             "ui_binding" => {
                 if field_text(child, "name", bytes).as_deref() == Some("id") {
                     if let Some(value) = child.child_by_field_name("value").and_then(|value| {
-                        value.utf8_text(bytes).ok().map(|text| text.trim().to_string())
+                        value
+                            .utf8_text(bytes)
+                            .ok()
+                            .map(|text| text.trim().to_string())
                     }) {
                         if is_simple_identifier(&value) {
                             push_unique(&mut variables, value);
@@ -497,7 +500,12 @@ fn imports_used_in_code(imports: &[String], code: &str) -> Vec<String> {
 
 fn field_text(node: Node, field: &str, bytes: &[u8]) -> Option<String> {
     node.child_by_field_name(field)
-        .and_then(|child| child.utf8_text(bytes).ok().map(|text| text.trim().to_string()))
+        .and_then(|child| {
+            child
+                .utf8_text(bytes)
+                .ok()
+                .map(|text| text.trim().to_string())
+        })
         .filter(|text| !text.is_empty())
 }
 

--- a/colgrep/src/parser/qml.rs
+++ b/colgrep/src/parser/qml.rs
@@ -1,0 +1,488 @@
+//! QML file parsing.
+//!
+//! This module extracts code units from QML files by:
+//! 1. Parsing QML object definitions with tree-sitter-qmljs
+//! 2. Extracting embedded function declarations with the existing TypeScript analysis
+//! 3. Indexing inline components, properties, and signals as first-class units
+
+use super::extract::{extract_class, extract_constant, extract_function};
+use super::language::get_tree_sitter_language;
+use super::types::{CodeUnit, Language, UnitType};
+use std::path::Path;
+use tree_sitter::{Node, Parser};
+
+const SCRIPT_LANG: Language = Language::TypeScript;
+
+/// Main entry point for QML file parsing.
+pub fn extract_qml_units(path: &Path, source: &str) -> Vec<CodeUnit> {
+    let mut parser = Parser::new();
+    if parser
+        .set_language(&get_tree_sitter_language(Language::Qml))
+        .is_err()
+    {
+        return Vec::new();
+    }
+
+    let tree = match parser.parse(source, None) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let lines: Vec<&str> = source.lines().collect();
+    let bytes = source.as_bytes();
+    let file_imports = extract_qml_imports(&lines);
+    let max_depth = super::max_recursion_depth();
+
+    let mut units = Vec::new();
+    let mut depth_limit_hit = false;
+    extract_from_node(
+        tree.root_node(),
+        path,
+        &lines,
+        bytes,
+        &file_imports,
+        &mut units,
+        None,
+        0,
+        max_depth,
+        &mut depth_limit_hit,
+    );
+
+    if depth_limit_hit {
+        eprintln!(
+            "⚠️  Skipping {} (AST nesting exceeded max depth: {})",
+            path.display(),
+            max_depth
+        );
+        return Vec::new();
+    }
+
+    units
+}
+
+#[allow(clippy::too_many_arguments)]
+fn extract_from_node(
+    node: Node,
+    path: &Path,
+    lines: &[&str],
+    bytes: &[u8],
+    file_imports: &[String],
+    units: &mut Vec<CodeUnit>,
+    parent_object: Option<&str>,
+    depth: usize,
+    max_depth: usize,
+    depth_limit_hit: &mut bool,
+) {
+    if *depth_limit_hit {
+        return;
+    }
+    if depth > max_depth {
+        *depth_limit_hit = true;
+        return;
+    }
+
+    match node.kind() {
+        "ui_annotated_object" => {
+            if let Some(definition) = node.child_by_field_name("definition") {
+                extract_from_node(
+                    definition,
+                    path,
+                    lines,
+                    bytes,
+                    file_imports,
+                    units,
+                    parent_object,
+                    depth + 1,
+                    max_depth,
+                    depth_limit_hit,
+                );
+            }
+            return;
+        }
+        "ui_inline_component" => {
+            if let Some(unit) = extract_inline_component(node, path, lines, bytes, parent_object) {
+                let component_name = unit.name.clone();
+                units.push(unit);
+                if let Some(component) = node.child_by_field_name("component") {
+                    recurse_initializer(
+                        component,
+                        path,
+                        lines,
+                        bytes,
+                        file_imports,
+                        units,
+                        Some(component_name.as_str()),
+                        depth + 1,
+                        max_depth,
+                        depth_limit_hit,
+                    );
+                }
+            }
+            return;
+        }
+        "ui_object_definition" => {
+            if let Some(unit) = extract_object_definition(node, path, lines, bytes, parent_object) {
+                let object_name = unit.name.clone();
+                units.push(unit);
+                recurse_initializer(
+                    node,
+                    path,
+                    lines,
+                    bytes,
+                    file_imports,
+                    units,
+                    Some(object_name.as_str()),
+                    depth + 1,
+                    max_depth,
+                    depth_limit_hit,
+                );
+                return;
+            }
+        }
+        "function_declaration" | "generator_function_declaration" => {
+            if let Some(mut unit) =
+                extract_function(node, path, lines, bytes, SCRIPT_LANG, parent_object, &[])
+            {
+                unit.language = Language::Qml;
+                unit.imports = imports_used_in_code(file_imports, &unit.code);
+                units.push(unit);
+            }
+            return;
+        }
+        "variable_declaration" => {
+            if let Some(mut unit) = extract_constant(node, path, lines, bytes, SCRIPT_LANG, &[]) {
+                unit.language = Language::Qml;
+                units.push(unit);
+            }
+            return;
+        }
+        "enum_declaration" => {
+            if let Some(mut unit) = extract_class(node, path, lines, bytes, SCRIPT_LANG, &[]) {
+                unit.language = Language::Qml;
+                unit.parent_class = parent_object.map(ToString::to_string);
+                units.push(unit);
+            }
+            return;
+        }
+        "ui_signal" => {
+            if let Some(unit) = extract_signal(node, path, lines, bytes, parent_object) {
+                units.push(unit);
+            }
+            return;
+        }
+        "ui_property" => {
+            if let Some(unit) = extract_property(node, path, lines, bytes, parent_object) {
+                units.push(unit);
+            }
+            return;
+        }
+        _ => {}
+    }
+
+    for child in node.children(&mut node.walk()) {
+        extract_from_node(
+            child,
+            path,
+            lines,
+            bytes,
+            file_imports,
+            units,
+            parent_object,
+            depth + 1,
+            max_depth,
+            depth_limit_hit,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn recurse_initializer(
+    node: Node,
+    path: &Path,
+    lines: &[&str],
+    bytes: &[u8],
+    file_imports: &[String],
+    units: &mut Vec<CodeUnit>,
+    parent_object: Option<&str>,
+    depth: usize,
+    max_depth: usize,
+    depth_limit_hit: &mut bool,
+) {
+    let Some(initializer) = node.child_by_field_name("initializer") else {
+        return;
+    };
+
+    for child in initializer.children(&mut initializer.walk()) {
+        extract_from_node(
+            child,
+            path,
+            lines,
+            bytes,
+            file_imports,
+            units,
+            parent_object,
+            depth + 1,
+            max_depth,
+            depth_limit_hit,
+        );
+    }
+}
+
+fn extract_object_definition(
+    node: Node,
+    path: &Path,
+    _lines: &[&str],
+    bytes: &[u8],
+    parent_object: Option<&str>,
+) -> Option<CodeUnit> {
+    let name = field_text(node, "type_name", bytes)?;
+    let code = node_text(node, bytes)?;
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    let mut unit = CodeUnit::new(
+        name,
+        path.to_path_buf(),
+        start_line,
+        end_line,
+        Language::Qml,
+        UnitType::Class,
+        parent_object,
+    );
+    unit.signature = first_non_empty_line(&code);
+    unit.variables = extract_object_variables(node, bytes);
+    unit.code = code;
+
+    Some(unit)
+}
+
+fn extract_inline_component(
+    node: Node,
+    path: &Path,
+    _lines: &[&str],
+    bytes: &[u8],
+    parent_object: Option<&str>,
+) -> Option<CodeUnit> {
+    let name = field_text(node, "name", bytes)?;
+    let code = node_text(node, bytes)?;
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    let mut unit = CodeUnit::new(
+        name,
+        path.to_path_buf(),
+        start_line,
+        end_line,
+        Language::Qml,
+        UnitType::Class,
+        parent_object,
+    );
+    unit.signature = first_non_empty_line(&code);
+    unit.extends = node
+        .child_by_field_name("component")
+        .and_then(|component| field_text(component, "type_name", bytes));
+    unit.code = code;
+
+    // Inline components wrap a named reusable type, so include the component name itself.
+    unit.variables = vec!["component".to_string()];
+
+    Some(unit)
+}
+
+fn extract_signal(
+    node: Node,
+    path: &Path,
+    lines: &[&str],
+    bytes: &[u8],
+    parent_object: Option<&str>,
+) -> Option<CodeUnit> {
+    let name = field_text(node, "name", bytes)?;
+    let code = node_text(node, bytes)?;
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    let mut unit = CodeUnit::new(
+        name,
+        path.to_path_buf(),
+        start_line,
+        end_line,
+        Language::Qml,
+        if parent_object.is_some() {
+            UnitType::Method
+        } else {
+            UnitType::Function
+        },
+        parent_object,
+    );
+    unit.signature = lines
+        .get(node.start_position().row)
+        .map(|line| line.trim().to_string())
+        .unwrap_or_default();
+    unit.parameters = extract_signal_parameters(node, bytes);
+    unit.code = code;
+
+    Some(unit)
+}
+
+fn extract_property(
+    node: Node,
+    path: &Path,
+    lines: &[&str],
+    bytes: &[u8],
+    parent_object: Option<&str>,
+) -> Option<CodeUnit> {
+    let name = field_text(node, "name", bytes)?;
+    let code = node_text(node, bytes)?;
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    let mut unit = CodeUnit::new(
+        name,
+        path.to_path_buf(),
+        start_line,
+        end_line,
+        Language::Qml,
+        UnitType::Constant,
+        parent_object,
+    );
+    unit.signature = lines
+        .get(node.start_position().row)
+        .map(|line| line.trim().to_string())
+        .unwrap_or_default();
+    unit.return_type = field_text(node, "type", bytes);
+    unit.code = code;
+
+    Some(unit)
+}
+
+fn extract_signal_parameters(node: Node, bytes: &[u8]) -> Vec<String> {
+    let Some(parameters) = node.child_by_field_name("parameters") else {
+        return Vec::new();
+    };
+
+    let mut result = Vec::new();
+    for child in parameters.children(&mut parameters.walk()) {
+        if child.kind() != "ui_signal_parameter" {
+            continue;
+        }
+        if let Ok(text) = child.utf8_text(bytes) {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                result.push(trimmed.to_string());
+            }
+        }
+    }
+    result
+}
+
+fn extract_object_variables(node: Node, bytes: &[u8]) -> Vec<String> {
+    let Some(initializer) = node.child_by_field_name("initializer") else {
+        return Vec::new();
+    };
+
+    let mut variables = Vec::new();
+    for child in initializer.children(&mut initializer.walk()) {
+        match child.kind() {
+            "ui_property" => {
+                if let Some(name) = field_text(child, "name", bytes) {
+                    push_unique(&mut variables, name);
+                }
+            }
+            "ui_binding" => {
+                if field_text(child, "name", bytes).as_deref() == Some("id") {
+                    if let Some(value) = child.child_by_field_name("value").and_then(|value| {
+                        value.utf8_text(bytes).ok().map(|text| text.trim().to_string())
+                    }) {
+                        if is_simple_identifier(&value) {
+                            push_unique(&mut variables, value);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    variables
+}
+
+fn extract_qml_imports(lines: &[&str]) -> Vec<String> {
+    let mut imports = Vec::new();
+
+    for line in lines {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("import ") {
+            continue;
+        }
+
+        let rest = trimmed.trim_start_matches("import ").trim();
+        if rest.is_empty() {
+            continue;
+        }
+
+        if let Some(module) = rest.split_whitespace().next() {
+            let module = module.trim_matches('"').trim_matches('\'');
+            if !module.is_empty() {
+                push_unique(&mut imports, module.to_string());
+            }
+        }
+
+        if let Some((_, alias)) = rest.split_once(" as ") {
+            let alias = alias.split_whitespace().next().unwrap_or("").trim();
+            if !alias.is_empty() {
+                push_unique(&mut imports, alias.to_string());
+            }
+        }
+    }
+
+    imports
+}
+
+fn imports_used_in_code(imports: &[String], code: &str) -> Vec<String> {
+    let mut used = Vec::new();
+    for import_name in imports {
+        let dotted = format!("{import_name}.");
+        let spaced = format!("{import_name} ");
+        let qualified = format!("{import_name} {{");
+        if code.contains(&dotted) || code.contains(&spaced) || code.contains(&qualified) {
+            push_unique(&mut used, import_name.clone());
+        }
+    }
+    used
+}
+
+fn field_text(node: Node, field: &str, bytes: &[u8]) -> Option<String> {
+    node.child_by_field_name(field)
+        .and_then(|child| child.utf8_text(bytes).ok().map(|text| text.trim().to_string()))
+        .filter(|text| !text.is_empty())
+}
+
+fn node_text(node: Node, bytes: &[u8]) -> Option<String> {
+    node.utf8_text(bytes)
+        .ok()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn first_non_empty_line(code: &str) -> String {
+    code.lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn is_simple_identifier(text: &str) -> bool {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}

--- a/colgrep/src/parser/qml.rs
+++ b/colgrep/src/parser/qml.rs
@@ -176,6 +176,12 @@ fn extract_from_node(
             }
             return;
         }
+        "ui_binding" => {
+            if let Some(unit) = extract_handler_binding(node, path, lines, bytes, parent_object) {
+                units.push(unit);
+            }
+            return;
+        }
         _ => {}
     }
 
@@ -355,6 +361,44 @@ fn extract_property(
     Some(unit)
 }
 
+fn extract_handler_binding(
+    node: Node,
+    path: &Path,
+    lines: &[&str],
+    bytes: &[u8],
+    parent_object: Option<&str>,
+) -> Option<CodeUnit> {
+    let name = field_text(node, "name", bytes)?;
+    if !looks_like_signal_handler(&name) {
+        return None;
+    }
+
+    let code = node_text(node, bytes)?;
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    let mut unit = CodeUnit::new(
+        name,
+        path.to_path_buf(),
+        start_line,
+        end_line,
+        Language::Qml,
+        if parent_object.is_some() {
+            UnitType::Method
+        } else {
+            UnitType::Function
+        },
+        parent_object,
+    );
+    unit.signature = lines
+        .get(node.start_position().row)
+        .map(|line| line.trim().to_string())
+        .unwrap_or_default();
+    unit.code = code;
+
+    Some(unit)
+}
+
 fn extract_signal_parameters(node: Node, bytes: &[u8]) -> Vec<String> {
     let Some(parameters) = node.child_by_field_name("parameters") else {
         return Vec::new();
@@ -479,6 +523,13 @@ fn is_simple_identifier(text: &str) -> bool {
     }
 
     chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn looks_like_signal_handler(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('o'))
+        && matches!(chars.next(), Some('n'))
+        && matches!(chars.next(), Some(ch) if ch.is_ascii_uppercase())
 }
 
 fn push_unique(values: &mut Vec<String>, value: String) {

--- a/colgrep/src/parser/test_core.rs
+++ b/colgrep/src/parser/test_core.rs
@@ -259,6 +259,7 @@ fn test_detect_language_markdown() {
 
 #[test]
 fn test_detect_language_text() {
+    assert_eq!(detect_language(Path::new("shell.qml")), Some(Language::Qml));
     assert_eq!(
         detect_language(Path::new("notes.txt")),
         Some(Language::Text)
@@ -424,9 +425,26 @@ fn test_is_text_format_false() {
     assert!(!is_text_format(Language::Elixir));
     assert!(!is_text_format(Language::Haskell));
     assert!(!is_text_format(Language::Ocaml));
+    assert!(!is_text_format(Language::Qml));
 }
 
 // ==================== extract_units tests ====================
+
+#[test]
+fn test_extract_qml_as_document() {
+    let source = r#"import Quickshell
+
+PanelWindow {
+    implicitHeight: 32
+}"#;
+    let units = extract_units(Path::new("shell.qml"), source, Language::Qml);
+
+    assert_eq!(units.len(), 1);
+    assert_eq!(units[0].language, Language::Qml);
+    assert_eq!(units[0].unit_type, UnitType::Document);
+    assert_eq!(units[0].line, 1);
+    assert_eq!(units[0].end_line, 5);
+}
 
 #[test]
 fn test_extract_python_function() {

--- a/colgrep/src/parser/test_core.rs
+++ b/colgrep/src/parser/test_core.rs
@@ -431,7 +431,7 @@ fn test_is_text_format_false() {
 // ==================== extract_units tests ====================
 
 #[test]
-fn test_extract_qml_as_document() {
+fn test_extract_qml_root_object() {
     let source = r#"import Quickshell
 
 PanelWindow {
@@ -440,9 +440,10 @@ PanelWindow {
     let units = extract_units(Path::new("shell.qml"), source, Language::Qml);
 
     assert_eq!(units.len(), 1);
+    assert_eq!(units[0].name, "PanelWindow");
     assert_eq!(units[0].language, Language::Qml);
-    assert_eq!(units[0].unit_type, UnitType::Document);
-    assert_eq!(units[0].line, 1);
+    assert_eq!(units[0].unit_type, UnitType::Class);
+    assert_eq!(units[0].line, 3);
     assert_eq!(units[0].end_line, 5);
 }
 

--- a/colgrep/src/parser/tests/mod.rs
+++ b/colgrep/src/parser/tests/mod.rs
@@ -17,6 +17,7 @@ mod test_lua;
 mod test_ocaml;
 mod test_php;
 mod test_python;
+mod test_qml;
 mod test_ruby;
 mod test_rust;
 mod test_scala;

--- a/colgrep/src/parser/tests/test_qml.rs
+++ b/colgrep/src/parser/tests/test_qml.rs
@@ -98,3 +98,42 @@ Singleton {
     let toggle_text = build_embedding_text(toggle_mute);
     assert!(toggle_text.contains("Method: toggleMute"));
 }
+
+#[test]
+fn test_extract_handler_binding_as_method() {
+    let source = r#"import Quickshell
+
+Timer {
+    onTriggered: {
+        root.syncPopout();
+    }
+}"#;
+
+    let units = parse(source, Language::Qml, "test.qml");
+
+    let handler = get_unit_by_name(&units, "onTriggered").unwrap();
+    assert_eq!(handler.unit_type, UnitType::Method);
+    assert_eq!(handler.parent_class.as_deref(), Some("Timer"));
+    let handler_text = build_embedding_text(handler);
+    assert!(handler_text.contains("Method: onTriggered"));
+    assert!(handler_text.contains("root.syncPopout()"));
+}
+
+#[test]
+fn test_extract_grouped_binding_notation_as_nested_object() {
+    let source = r#"import QtQuick
+
+Button {
+    icon {
+        source: "foo.png"
+        color: "transparent"
+    }
+}"#;
+
+    let units = parse(source, Language::Qml, "test.qml");
+
+    let icon = get_unit_by_name(&units, "icon").unwrap();
+    assert_eq!(icon.unit_type, UnitType::Class);
+    assert_eq!(icon.parent_class.as_deref(), Some("Button"));
+    assert!(icon.code.contains("source: \"foo.png\""));
+}

--- a/colgrep/src/parser/tests/test_qml.rs
+++ b/colgrep/src/parser/tests/test_qml.rs
@@ -23,7 +23,10 @@ PanelWindow {
 
     let root = get_unit_by_name(&units, "PanelWindow").unwrap();
     assert_eq!(root.unit_type, UnitType::Class);
-    assert_eq!(root.variables, vec!["root".to_string(), "shell".to_string(), "count".to_string()]);
+    assert_eq!(
+        root.variables,
+        vec!["root".to_string(), "shell".to_string(), "count".to_string()]
+    );
     let root_text = build_embedding_text(root);
     assert!(root_text.contains("Class: PanelWindow"));
     assert!(root_text.contains("Code:\nPanelWindow {"));

--- a/colgrep/src/parser/tests/test_qml.rs
+++ b/colgrep/src/parser/tests/test_qml.rs
@@ -1,0 +1,100 @@
+//! Tests for QML code extraction.
+
+use super::common::*;
+use crate::embed::build_embedding_text;
+use crate::parser::{Language, UnitType};
+
+#[test]
+fn test_extract_root_object_properties_signal_and_function() {
+    let source = r#"import Quickshell
+
+PanelWindow {
+    id: root
+    required property var shell
+    readonly property int count: 0
+    signal toggled(next: bool)
+
+    function increment(step): void {
+        return step + 1;
+    }
+}"#;
+
+    let units = parse(source, Language::Qml, "test.qml");
+
+    let root = get_unit_by_name(&units, "PanelWindow").unwrap();
+    assert_eq!(root.unit_type, UnitType::Class);
+    assert_eq!(root.variables, vec!["root".to_string(), "shell".to_string(), "count".to_string()]);
+    let root_text = build_embedding_text(root);
+    assert!(root_text.contains("Class: PanelWindow"));
+    assert!(root_text.contains("Code:\nPanelWindow {"));
+
+    let increment = get_unit_by_name(&units, "increment").unwrap();
+    assert_eq!(increment.unit_type, UnitType::Method);
+    let increment_text = build_embedding_text(increment);
+    assert!(increment_text.contains("Method: increment"));
+    assert!(increment_text.contains("Class: PanelWindow"));
+
+    let toggled = get_unit_by_name(&units, "toggled").unwrap();
+    assert_eq!(toggled.unit_type, UnitType::Method);
+    assert_eq!(toggled.parameters, vec!["next: bool".to_string()]);
+
+    let shell = get_unit_by_name(&units, "shell").unwrap();
+    assert_eq!(shell.unit_type, UnitType::Constant);
+    assert_eq!(shell.return_type.as_deref(), Some("var"));
+}
+
+#[test]
+fn test_extract_inline_component_without_duplicate_component_object() {
+    let source = r#"import QtQuick
+
+Item {
+    component FancyChip: Rectangle {
+        property string label: "Hello"
+
+        function activate(): void {
+            console.log(label);
+        }
+    }
+}"#;
+
+    let units = parse(source, Language::Qml, "test.qml");
+
+    let fancy_chip = get_unit_by_name(&units, "FancyChip").unwrap();
+    assert_eq!(fancy_chip.unit_type, UnitType::Class);
+    assert_eq!(fancy_chip.extends.as_deref(), Some("Rectangle"));
+
+    let activate = get_unit_by_name(&units, "activate").unwrap();
+    assert_eq!(activate.parent_class.as_deref(), Some("FancyChip"));
+
+    let rectangle_units = units.iter().filter(|unit| unit.name == "Rectangle").count();
+    assert_eq!(rectangle_units, 0);
+}
+
+#[test]
+fn test_extract_nested_objects() {
+    let source = r#"import Quickshell
+
+Singleton {
+    function toggleMute(): void {
+        sink.audio.muted = !sink.audio.muted;
+    }
+
+    PwObjectTracker {
+        objects: [Pipewire.defaultAudioSink]
+    }
+}"#;
+
+    let units = parse(source, Language::Qml, "test.qml");
+
+    let singleton = get_unit_by_name(&units, "Singleton").unwrap();
+    assert_eq!(singleton.unit_type, UnitType::Class);
+
+    let tracker = get_unit_by_name(&units, "PwObjectTracker").unwrap();
+    assert_eq!(tracker.unit_type, UnitType::Class);
+    assert_eq!(tracker.parent_class.as_deref(), Some("Singleton"));
+
+    let toggle_mute = get_unit_by_name(&units, "toggleMute").unwrap();
+    assert_eq!(toggle_mute.unit_type, UnitType::Method);
+    let toggle_text = build_embedding_text(toggle_mute);
+    assert!(toggle_text.contains("Method: toggleMute"));
+}

--- a/colgrep/src/parser/types.rs
+++ b/colgrep/src/parser/types.rs
@@ -31,6 +31,7 @@ pub enum Language {
     Sql,
     Vue,
     Svelte,
+    Qml,
     // Text/config formats (no tree-sitter, indexed as documents)
     Html,
     Markdown,
@@ -78,6 +79,7 @@ impl FromStr for Language {
             "vue" => Ok(Language::Vue),
             "svelte" => Ok(Language::Svelte),
             // Text/config formats
+            "qml" => Ok(Language::Qml),
             "html" | "htm" => Ok(Language::Html),
             "markdown" | "md" => Ok(Language::Markdown),
             "text" | "txt" => Ok(Language::Text),


### PR DESCRIPTION
## What changed
- add native QML parsing to `colgrep` via `tree-sitter-qmljs`
- index QML object definitions, inline components, properties, signals, and handler bindings
- add parser coverage for Quickshell-style patterns including grouped bindings and nested handlers
- recognize `.qml` files in language detection and mention QML in CLI supported languages

## Why
Quickshell/QML code was not indexed at all because `.qml` files were not recognized by the parser pipeline. This made semantic and hybrid search miss the actual implementation files.

## Impact
`colgrep` can now search QML codebases, including Quickshell configs, using the normal CLI and `--code-only` flows.

## Validation
- `cargo test --manifest-path /home/rbw/repo/next-plaid/colgrep/Cargo.toml --target-dir /tmp/next-plaid-target test_qml -- --nocapture`
- `cargo test --manifest-path /home/rbw/repo/next-plaid/colgrep/Cargo.toml --target-dir /tmp/next-plaid-target test_detect_language_text -- --nocapture`
- `cargo test --manifest-path /home/rbw/repo/next-plaid/colgrep/Cargo.toml --target-dir /tmp/next-plaid-target test_is_text_format -- --nocapture`
- manual verification with `colgrep` against my own quickshell / Qml config

AI Disclaimer - done with Codex 5.4 xhigh
Code has been reviewed by a human (myself) although I'm no Rust programmer.