### PR TITLE
fix auto runtime-aware defaults before ORT init

### DIFF
--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -1,9 +1,23 @@
 use anyhow::Result;
 
 use colgrep::{
-    ensure_model, ensure_onnx_runtime, get_colgrep_data_dir, Config, DEFAULT_BATCH_SIZE,
-    DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MODEL, DEFAULT_POOL_FACTOR,
+    ensure_model, ensure_onnx_runtime, get_colgrep_data_dir, Config, DEFAULT_MAX_RECURSION_DEPTH,
+    DEFAULT_MODEL, DEFAULT_POOL_FACTOR,
 };
+
+fn format_parallel_setting(config: &Config) -> String {
+    config
+        .configured_parallel_sessions()
+        .map(|sessions| sessions.to_string())
+        .unwrap_or_else(|| "auto (runtime-resolved)".to_string())
+}
+
+fn format_batch_size_setting(config: &Config) -> String {
+    config
+        .configured_batch_size()
+        .map(|batch_size| batch_size.to_string())
+        .unwrap_or_else(|| "auto (runtime-resolved)".to_string())
+}
 
 pub fn cmd_set_model(model: &str) -> Result<()> {
     use next_plaid_onnx::Colbert;
@@ -170,21 +184,9 @@ pub fn cmd_config(
             println!("  pool-factor: {} (default)", DEFAULT_POOL_FACTOR);
         }
 
-        // Parallel sessions
-        let ps = config.get_parallel_sessions();
-        if config.parallel_sessions.is_some() {
-            println!("  parallel:    {}", ps);
-        } else {
-            println!("  parallel:    {} (auto, {} cpus)", ps, ps);
-        }
+        println!("  parallel:    {}", format_parallel_setting(&config));
 
-        // Batch size
-        let bs = config.get_batch_size();
-        if config.batch_size.is_some() {
-            println!("  batch-size:  {}", bs);
-        } else {
-            println!("  batch-size:  {} (default)", DEFAULT_BATCH_SIZE);
-        }
+        println!("  batch-size:  {}", format_batch_size_setting(&config));
 
         // k
         match config.get_default_k() {
@@ -332,8 +334,7 @@ pub fn cmd_config(
     if let Some(ps) = parallel_sessions {
         if ps == 0 {
             config.clear_parallel_sessions();
-            let auto_ps = config.get_parallel_sessions();
-            println!("✅ Reset parallel sessions to auto ({} cpus)", auto_ps);
+            println!("✅ Reset parallel sessions to auto (runtime-resolved)");
         } else {
             config.set_parallel_sessions(ps);
             println!("✅ Set parallel sessions to {}", ps);
@@ -345,7 +346,7 @@ pub fn cmd_config(
     if let Some(bs) = batch_size {
         if bs == 0 {
             config.clear_batch_size();
-            println!("✅ Reset batch size to {} (default)", DEFAULT_BATCH_SIZE);
+            println!("✅ Reset batch size to auto (runtime-resolved)");
         } else {
             config.set_batch_size(bs);
             println!("✅ Set batch size to {}", bs);
@@ -458,4 +459,46 @@ pub fn cmd_config(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_parallel_setting_explicit() {
+        let config = Config {
+            parallel_sessions: Some(4),
+            ..Default::default()
+        };
+
+        assert_eq!(format_parallel_setting(&config), "4");
+    }
+
+    #[test]
+    fn test_format_parallel_setting_auto() {
+        let config = Config::default();
+
+        assert_eq!(format_parallel_setting(&config), "auto (runtime-resolved)");
+    }
+
+    #[test]
+    fn test_format_batch_size_setting_explicit() {
+        let config = Config {
+            batch_size: Some(8),
+            ..Default::default()
+        };
+
+        assert_eq!(format_batch_size_setting(&config), "8");
+    }
+
+    #[test]
+    fn test_format_batch_size_setting_auto() {
+        let config = Config::default();
+
+        assert_eq!(
+            format_batch_size_setting(&config),
+            "auto (runtime-resolved)"
+        );
+    }
 }

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -16,6 +16,18 @@ pub struct InitOptions<'a> {
     pub static_batch: bool,
 }
 
+fn resolve_index_runtime_overrides(
+    config: &Config,
+    cli_batch_size: Option<usize>,
+) -> (Option<usize>, Option<usize>) {
+    (
+        config.configured_parallel_sessions(),
+        cli_batch_size
+            .map(|batch_size| batch_size.max(1))
+            .or_else(|| config.configured_batch_size()),
+    )
+}
+
 pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let path = std::fs::canonicalize(path)
         .map_err(|_| anyhow::anyhow!("Path does not exist: {}", path.display()))?;
@@ -29,12 +41,8 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
 
     let config = Config::load().unwrap_or_default();
     let quantized = !config.use_fp32();
-    let parallel_sessions = Some(config.get_parallel_sessions());
-    let batch_size = Some(
-        options
-            .batch_size
-            .unwrap_or_else(|| config.get_batch_size()),
-    );
+    let (parallel_sessions, batch_size) =
+        resolve_index_runtime_overrides(&config, options.batch_size);
 
     // Check if index already exists
     let has_existing_index = index_exists(&path) || find_parent_index(&path)?.is_some();
@@ -80,4 +88,47 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_index_runtime_overrides_preserves_explicit_values() {
+        let config = Config {
+            parallel_sessions: Some(3),
+            batch_size: Some(7),
+            ..Default::default()
+        };
+
+        let (parallel_sessions, batch_size) = resolve_index_runtime_overrides(&config, Some(9));
+
+        assert_eq!(parallel_sessions, Some(3));
+        assert_eq!(batch_size, Some(9));
+    }
+
+    #[test]
+    fn test_resolve_index_runtime_overrides_defers_auto_defaults() {
+        let config = Config::default();
+
+        let (parallel_sessions, batch_size) = resolve_index_runtime_overrides(&config, None);
+
+        assert_eq!(parallel_sessions, None);
+        assert_eq!(batch_size, None);
+    }
+
+    #[test]
+    fn test_resolve_index_runtime_overrides_normalizes_values() {
+        let config = Config {
+            parallel_sessions: Some(0),
+            batch_size: Some(0),
+            ..Default::default()
+        };
+
+        let (parallel_sessions, batch_size) = resolve_index_runtime_overrides(&config, Some(0));
+
+        assert_eq!(parallel_sessions, Some(1));
+        assert_eq!(batch_size, Some(1));
+    }
 }

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -274,13 +274,6 @@ pub fn resolve_model(cli_model: Option<&str>) -> String {
     DEFAULT_MODEL.to_string()
 }
 
-fn resolve_search_runtime_overrides(config: &Config) -> (Option<usize>, Option<usize>) {
-    (
-        config.configured_parallel_sessions(),
-        config.configured_batch_size(),
-    )
-}
-
 /// Resolve top_k: CLI arg > saved config > default
 pub fn resolve_top_k(cli_k: Option<usize>, default: usize) -> usize {
     if let Some(k) = cli_k {
@@ -927,8 +920,8 @@ fn search_single_path(
     // Resolve quantized setting from config (default: false = use FP32)
     let quantized = !config.use_fp32();
 
-    // Resolve parallel sessions and batch size from config
-    let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
+    let parallel_sessions = config.configured_parallel_sessions();
+    let batch_size = config.configured_batch_size();
 
     // Check if index already exists (suppress model output if so)
     let has_existing_index =
@@ -1543,44 +1536,6 @@ mod tests {
         let result = resolve_context_lines(None, 20);
         // Should be either 20 (default) or whatever is in config
         assert!(result <= 100); // sanity check
-    }
-
-    #[test]
-    fn test_resolve_search_runtime_overrides_preserves_explicit_values() {
-        let config = Config {
-            parallel_sessions: Some(4),
-            batch_size: Some(6),
-            ..Default::default()
-        };
-
-        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
-
-        assert_eq!(parallel_sessions, Some(4));
-        assert_eq!(batch_size, Some(6));
-    }
-
-    #[test]
-    fn test_resolve_search_runtime_overrides_defers_auto_defaults() {
-        let config = Config::default();
-
-        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
-
-        assert_eq!(parallel_sessions, None);
-        assert_eq!(batch_size, None);
-    }
-
-    #[test]
-    fn test_resolve_search_runtime_overrides_normalizes_values() {
-        let config = Config {
-            parallel_sessions: Some(0),
-            batch_size: Some(0),
-            ..Default::default()
-        };
-
-        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
-
-        assert_eq!(parallel_sessions, Some(1));
-        assert_eq!(batch_size, Some(1));
     }
 
     // Test strip_regex_for_semantic function

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -274,6 +274,13 @@ pub fn resolve_model(cli_model: Option<&str>) -> String {
     DEFAULT_MODEL.to_string()
 }
 
+fn resolve_search_runtime_overrides(config: &Config) -> (Option<usize>, Option<usize>) {
+    (
+        config.configured_parallel_sessions(),
+        config.configured_batch_size(),
+    )
+}
+
 /// Resolve top_k: CLI arg > saved config > default
 pub fn resolve_top_k(cli_k: Option<usize>, default: usize) -> usize {
     if let Some(k) = cli_k {
@@ -921,8 +928,7 @@ fn search_single_path(
     let quantized = !config.use_fp32();
 
     // Resolve parallel sessions and batch size from config
-    let parallel_sessions = Some(config.get_parallel_sessions());
-    let batch_size = Some(config.get_batch_size());
+    let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
 
     // Check if index already exists (suppress model output if so)
     let has_existing_index =
@@ -1537,6 +1543,44 @@ mod tests {
         let result = resolve_context_lines(None, 20);
         // Should be either 20 (default) or whatever is in config
         assert!(result <= 100); // sanity check
+    }
+
+    #[test]
+    fn test_resolve_search_runtime_overrides_preserves_explicit_values() {
+        let config = Config {
+            parallel_sessions: Some(4),
+            batch_size: Some(6),
+            ..Default::default()
+        };
+
+        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
+
+        assert_eq!(parallel_sessions, Some(4));
+        assert_eq!(batch_size, Some(6));
+    }
+
+    #[test]
+    fn test_resolve_search_runtime_overrides_defers_auto_defaults() {
+        let config = Config::default();
+
+        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
+
+        assert_eq!(parallel_sessions, None);
+        assert_eq!(batch_size, None);
+    }
+
+    #[test]
+    fn test_resolve_search_runtime_overrides_normalizes_values() {
+        let config = Config {
+            parallel_sessions: Some(0),
+            batch_size: Some(0),
+            ..Default::default()
+        };
+
+        let (parallel_sessions, batch_size) = resolve_search_runtime_overrides(&config);
+
+        assert_eq!(parallel_sessions, Some(1));
+        assert_eq!(batch_size, Some(1));
     }
 
     // Test strip_regex_for_semantic function

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -291,12 +291,18 @@ impl Config {
         self.pool_factor = None;
     }
 
+    /// Get the user-configured parallel session override, if any.
+    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later.
+    pub fn configured_parallel_sessions(&self) -> Option<usize> {
+        self.parallel_sessions.map(|sessions| sessions.max(1))
+    }
+
     /// Get the number of parallel sessions for encoding
     /// Returns the configured value or:
     /// - 1 session when CUDA is enabled AND cuDNN is available (GPUs work best with single session + large batches)
     /// - min(CPU count, 8) otherwise (CPUs benefit from parallel sessions)
     pub fn get_parallel_sessions(&self) -> usize {
-        self.parallel_sessions
+        self.configured_parallel_sessions()
             .unwrap_or_else(get_default_parallel_sessions)
     }
 
@@ -310,12 +316,19 @@ impl Config {
         self.parallel_sessions = None;
     }
 
+    /// Get the user-configured batch size override, if any.
+    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later.
+    pub fn configured_batch_size(&self) -> Option<usize> {
+        self.batch_size.map(|size| size.max(1))
+    }
+
     /// Get the batch size for encoding
     /// Returns the configured value or the runtime default:
     /// - 64 when CUDA is enabled AND cuDNN is available
     /// - 1 otherwise (CPU mode)
     pub fn get_batch_size(&self) -> usize {
-        self.batch_size.unwrap_or_else(get_default_batch_size)
+        self.configured_batch_size()
+            .unwrap_or_else(get_default_batch_size)
     }
 
     /// Set the batch size for encoding
@@ -669,6 +682,32 @@ mod tests {
         // Should be min(cpu_count, 16)
         assert!(sessions >= 1);
         assert!(sessions <= 16);
+    }
+
+    #[test]
+    fn test_config_auto_getters_resolve_to_concrete_values() {
+        let config = Config::default();
+
+        assert!(config.parallel_sessions.is_none());
+        assert!(config.batch_size.is_none());
+        assert!(config.configured_parallel_sessions().is_none());
+        assert!(config.configured_batch_size().is_none());
+        assert!(config.get_parallel_sessions() >= 1);
+        assert!(config.get_batch_size() >= 1);
+    }
+
+    #[test]
+    fn test_configured_runtime_overrides_normalize_legacy_zero_values() {
+        let config = Config {
+            parallel_sessions: Some(0),
+            batch_size: Some(0),
+            ..Default::default()
+        };
+
+        assert_eq!(config.configured_parallel_sessions(), Some(1));
+        assert_eq!(config.configured_batch_size(), Some(1));
+        assert_eq!(config.get_parallel_sessions(), 1);
+        assert_eq!(config.get_batch_size(), 1);
     }
 
     #[test]

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -56,26 +56,25 @@ pub fn get_default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE_CPU
 }
 
+pub fn get_default_cpu_parallel_sessions() -> usize {
+    let cpu_count = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(16);
+    cpu_count.min(MAX_PARALLEL_SESSIONS_CPU)
+}
+
 /// Get the effective default parallel sessions at runtime.
 /// When CUDA feature is enabled but cuDNN is not available, returns CPU default.
 #[cfg(feature = "cuda")]
 pub fn get_default_parallel_sessions() -> usize {
     match env_acceleration_mode_lossy() {
-        AccelerationMode::ForceCpu => {
-            let cpu_count = std::thread::available_parallelism()
-                .map(|p| p.get())
-                .unwrap_or(16);
-            cpu_count.min(MAX_PARALLEL_SESSIONS_CPU)
-        }
+        AccelerationMode::ForceCpu => get_default_cpu_parallel_sessions(),
         AccelerationMode::ForceGpu => DEFAULT_PARALLEL_SESSIONS_GPU,
         AccelerationMode::Auto => {
             if crate::onnx_runtime::is_cudnn_available() {
                 DEFAULT_PARALLEL_SESSIONS_GPU
             } else {
-                let cpu_count = std::thread::available_parallelism()
-                    .map(|p| p.get())
-                    .unwrap_or(16);
-                cpu_count.min(MAX_PARALLEL_SESSIONS_CPU)
+                get_default_cpu_parallel_sessions()
             }
         }
     }
@@ -83,10 +82,7 @@ pub fn get_default_parallel_sessions() -> usize {
 
 #[cfg(not(feature = "cuda"))]
 pub fn get_default_parallel_sessions() -> usize {
-    let cpu_count = std::thread::available_parallelism()
-        .map(|p| p.get())
-        .unwrap_or(16);
-    cpu_count.min(MAX_PARALLEL_SESSIONS_CPU)
+    get_default_cpu_parallel_sessions()
 }
 
 /// Default number of parallel sessions for GPU (CUDA)
@@ -291,8 +287,8 @@ impl Config {
         self.pool_factor = None;
     }
 
-    /// Get the user-configured parallel session override, if any.
-    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later.
+    /// Get the user-configured parallel session override, if any
+    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later
     pub fn configured_parallel_sessions(&self) -> Option<usize> {
         self.parallel_sessions.map(|sessions| sessions.max(1))
     }
@@ -300,7 +296,7 @@ impl Config {
     /// Get the number of parallel sessions for encoding
     /// Returns the configured value or:
     /// - 1 session when CUDA is enabled AND cuDNN is available (GPUs work best with single session + large batches)
-    /// - min(CPU count, 8) otherwise (CPUs benefit from parallel sessions)
+    /// - min(CPU count, 16) otherwise (CPUs benefit from parallel sessions)
     pub fn get_parallel_sessions(&self) -> usize {
         self.configured_parallel_sessions()
             .unwrap_or_else(get_default_parallel_sessions)
@@ -316,8 +312,8 @@ impl Config {
         self.parallel_sessions = None;
     }
 
-    /// Get the user-configured batch size override, if any.
-    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later.
+    /// Get the user-configured batch size override, if any
+    /// Returns None when config is in auto mode so runtime-aware defaults can be resolved later
     pub fn configured_batch_size(&self) -> Option<usize> {
         self.batch_size.map(|size| size.max(1))
     }
@@ -697,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn test_configured_runtime_overrides_normalize_legacy_zero_values() {
+    fn test_config_configured_runtime_overrides_normalize_legacy_zero_values() {
         let config = Config {
             parallel_sessions: Some(0),
             batch_size: Some(0),

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -779,12 +779,8 @@ impl IndexBuilder {
                             .context("Failed to initialize ONNX Runtime")?;
 
                         (
-                            self.parallel_sessions.unwrap_or_else(|| {
-                                let cpu_count = std::thread::available_parallelism()
-                                    .map(|p| p.get())
-                                    .unwrap_or(8);
-                                cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
-                            }),
+                            self.parallel_sessions
+                                .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
                             ExecutionProvider::Cpu,
                         )
                     }
@@ -833,12 +829,9 @@ impl IndexBuilder {
                             )
                         } else {
                             (
-                                self.parallel_sessions.unwrap_or_else(|| {
-                                    let cpu_count = std::thread::available_parallelism()
-                                        .map(|p| p.get())
-                                        .unwrap_or(8);
-                                    cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
-                                }),
+                                self.parallel_sessions.unwrap_or_else(
+                                    crate::config::get_default_cpu_parallel_sessions,
+                                ),
                                 ExecutionProvider::Cpu,
                             )
                         }
@@ -854,12 +847,8 @@ impl IndexBuilder {
                     .context("Failed to initialize ONNX Runtime")?;
 
                 (
-                    self.parallel_sessions.unwrap_or_else(|| {
-                        let cpu_count = std::thread::available_parallelism()
-                            .map(|p| p.get())
-                            .unwrap_or(8);
-                        cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
-                    }),
+                    self.parallel_sessions
+                        .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
                     ExecutionProvider::Cpu,
                 )
             };
@@ -929,12 +918,9 @@ impl IndexBuilder {
         self.model = None;
         apply_acceleration_mode(AccelerationMode::ForceCpu);
 
-        let num_sessions = self.parallel_sessions.unwrap_or_else(|| {
-            let cpu_count = std::thread::available_parallelism()
-                .map(|p| p.get())
-                .unwrap_or(8);
-            cpu_count.min(crate::config::MAX_PARALLEL_SESSIONS_CPU)
-        });
+        let num_sessions = self
+            .parallel_sessions
+            .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions);
         let batch = crate::config::DEFAULT_BATCH_SIZE_CPU;
 
         let model = crate::stderr::with_suppressed_stderr(|| {


### PR DESCRIPTION
## Summary

Fix auto-mode indexing/search so runtime-aware `parallel` and `batch-size` defaults are resolved **after** ONNX Runtime / cuDNN initialization, instead of being frozen to CPU defaults too early.

## Problem

`colgrep` currently has two different concepts mixed together:

- "configured override from config/CLI"
- "effective value right now"

`Config::get_parallel_sessions()` and `Config::get_batch_size()` return effective values immediately. In auto mode, the command layer was calling those getters **before** ORT/cuDNN had been initialized.

On CUDA builds, that means `is_cudnn_available()` is still false at that point, so auto mode gets concretized to CPU defaults too early. In practice this can freeze values
like:
- `parallel = 16`
- `batch-size = 1`
into GPU indexing runs that should have stayed runtime-resolved.
That was causing bogus GPU fallback / poor GPU behavior in normal `colgrep init -y` runs even when forced GPU worked.

## Fix

This PR separates those two concepts more explicitly:

- Keep `get_parallel_sessions()` / `get_batch_size()` as "effective value now" getters
- Add explicit `configured_parallel_sessions()` / `configured_batch_size()` accessors for the late-resolution path
- Use those configured override accessors from `init` / `search`, so `None` stays `None` until `IndexBuilder` resolves defaults after ORT init
- Normalize malformed legacy `0` values through the configured override accessors
- Reuse a single CPU parallel-session fallback helper so the CPU fallback is consistent
- Update `colgrep settings` output to show `auto (runtime-resolved)` instead of eagerly displaying misleading concrete values

## Why this approach

I did **not** change the semantics of the existing `get_*()` getters, because they are still useful for places that genuinely want the effective value immediately.

The bug was the command layer using the wrong API for a runtime-sensitive path. This PR makes that distinction explicit instead of relying on raw field access or changing
getter behavior globally.

## Validation

- `cargo fmt --all`
- `cargo clippy -p colgrep --all-targets -- -D warnings`
- `cargo test -p colgrep`

Generated with Codex gpt-5.4 xhigh, reviewed by human

Also verified against a real repo with sourced runtime env:

- normal auto-mode `colgrep init -y repo` completed successfully without the bogus GPU fallback behavior

Generated by Codex 5.4 xhigh, reviewed by human.