### PR TITLE
fix(colgrep): validate ONNX Runtime dylib and surface indexer panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "libc",
+ "libloading 0.8.9",
  "ndarray 0.16.1",
  "next-plaid",
  "next-plaid-onnx",
@@ -844,7 +845,7 @@ version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -2110,6 +2111,16 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -2836,7 +2847,7 @@ version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
  "ndarray 0.17.2",
  "ort-sys",
  "smallvec",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -55,6 +55,7 @@ ureq = "2"
 flate2 = "1"
 tar = "0.4"
 dirs = "5"
+libloading = "0.8"
 
 # === CLI ===
 clap = { version = "4", features = ["derive"] }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -877,26 +877,19 @@ impl IndexBuilder {
 
             // Suppress stderr during model loading to hide CoreML's harmless
             // "Context leak detected" warnings on macOS.
-            // Use catch_unwind so that if ONNX Runtime panics (e.g., wrong dylib),
-            // the error message is still shown to the user after stderr is restored.
-            let model_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                crate::stderr::with_suppressed_stderr(|| {
-                    Colbert::builder(&self.model_path)
-                        .with_quantized(self.quantized)
-                        .with_parallel(num_sessions)
-                        .with_batch_size(batch)
-                        .with_dynamic_batch(self.dynamic_batch)
-                        .with_execution_provider(execution_provider)
-                        .build()
-                })
-            }));
-            let model = match model_result {
-                Ok(result) => result.context("Failed to load ColBERT model")?,
-                Err(panic_payload) => {
-                    // Re-panic with the original payload now that stderr is restored
-                    std::panic::resume_unwind(panic_payload);
-                }
-            };
+            // `with_suppressed_stderr` captures any panic message via a temporary
+            // panic hook and prints it to the restored stderr before resuming,
+            // so panics inside the suppressed region remain visible.
+            let model = crate::stderr::with_suppressed_stderr(|| {
+                Colbert::builder(&self.model_path)
+                    .with_quantized(self.quantized)
+                    .with_parallel(num_sessions)
+                    .with_batch_size(batch)
+                    .with_dynamic_batch(self.dynamic_batch)
+                    .with_execution_provider(execution_provider)
+                    .build()
+            })
+            .context("Failed to load ColBERT model")?;
 
             self.model = Some(model);
         }

--- a/colgrep/src/onnx_runtime.rs
+++ b/colgrep/src/onnx_runtime.rs
@@ -132,10 +132,19 @@ pub fn ensure_onnx_runtime() -> Result<PathBuf> {
     // 1. Check if already set
     if let Ok(path) = env::var("ORT_DYLIB_PATH") {
         let path = PathBuf::from(&path);
-        if path.exists() {
+        if path.exists() && is_valid_ort_dylib(&path) {
             pin_runtime_library(&path);
             return Ok(path);
         }
+        // Path from env is missing or can't be loaded (wrong arch, broken
+        // symlink, stale Homebrew formula, ...). Clear it so the search and
+        // download fallback below don't propagate the unusable value into
+        // `ort::setup_api`, where a failed dlopen turns into an .expect() panic.
+        eprintln!(
+            "⚠️  ORT_DYLIB_PATH={} is not a loadable ONNX Runtime dylib; ignoring.",
+            path.display()
+        );
+        env::remove_var("ORT_DYLIB_PATH");
     }
 
     // 2. Search common locations (skip for CUDA - we want our managed GPU version)
@@ -347,16 +356,46 @@ fn check_cudnn_available() -> bool {
     false
 }
 
+/// Try to dlopen `path` and confirm it exposes `OrtGetApiBase`.
+///
+/// This filters out candidates that pass `path.exists()` but would make
+/// `ort::setup_api` panic: wrong architecture (x86_64 dylib on aarch64, or
+/// vice versa), broken symlinks that resolve to something non-loadable,
+/// companion providers such as `libonnxruntime_providers_shared`, and
+/// stale Homebrew installs that fail code-signature validation.
+fn is_valid_ort_dylib(path: &Path) -> bool {
+    unsafe {
+        match libloading::Library::new(path) {
+            Ok(lib) => lib
+                .get::<unsafe extern "C" fn() -> *const std::ffi::c_void>(b"OrtGetApiBase\0")
+                .is_ok(),
+            Err(_) => false,
+        }
+    }
+}
+
 /// Search for ONNX Runtime in common locations
 #[cfg(not(feature = "cuda"))]
 fn find_onnx_runtime() -> Option<PathBuf> {
     let search_paths = get_search_paths();
+    let mut rejected: Vec<PathBuf> = Vec::new();
+
+    let try_candidate = |candidate: PathBuf, rejected: &mut Vec<PathBuf>| -> Option<PathBuf> {
+        if !candidate.exists() {
+            return None;
+        }
+        if is_valid_ort_dylib(&candidate) {
+            Some(candidate)
+        } else {
+            rejected.push(candidate);
+            None
+        }
+    };
 
     for base_path in search_paths {
         // Direct library file
-        let lib_path = base_path.join(ORT_LIB_NAME);
-        if lib_path.exists() {
-            return Some(lib_path);
+        if let Some(p) = try_candidate(base_path.join(ORT_LIB_NAME), &mut rejected) {
+            return Some(p);
         }
 
         // Versioned library (e.g., libonnxruntime.so.1.23.0 on Linux, libonnxruntime.1.20.1.dylib on macOS)
@@ -370,15 +409,35 @@ fn find_onnx_runtime() -> Option<PathBuf> {
                     || name_str.starts_with("libonnxruntime.dylib")
                     || (name_str.starts_with("libonnxruntime.") && name_str.ends_with(".dylib"))
                 {
-                    return Some(entry.path());
+                    if let Some(p) = try_candidate(entry.path(), &mut rejected) {
+                        return Some(p);
+                    }
                 }
             }
         }
 
         // Check lib subdirectory
-        let lib_subdir = base_path.join("lib").join(ORT_LIB_NAME);
-        if lib_subdir.exists() {
-            return Some(lib_subdir);
+        if let Some(p) = try_candidate(base_path.join("lib").join(ORT_LIB_NAME), &mut rejected) {
+            return Some(p);
+        }
+    }
+
+    if !rejected.is_empty() {
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        let unique: Vec<&PathBuf> = rejected
+            .iter()
+            .filter(|p| {
+                let canon = p.canonicalize().unwrap_or_else(|_| (*p).clone());
+                seen.insert(canon)
+            })
+            .collect();
+        eprintln!(
+            "⚠️  Found {} ONNX Runtime candidate(s) that failed to load (wrong arch, broken \
+             signature, or companion library); downloading a managed copy instead:",
+            unique.len()
+        );
+        for p in unique {
+            eprintln!("    - {}", p.display());
         }
     }
 

--- a/colgrep/src/onnx_runtime.rs
+++ b/colgrep/src/onnx_runtime.rs
@@ -423,21 +423,29 @@ fn find_onnx_runtime() -> Option<PathBuf> {
     }
 
     if !rejected.is_empty() {
-        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-        let unique: Vec<&PathBuf> = rejected
-            .iter()
-            .filter(|p| {
-                let canon = p.canonicalize().unwrap_or_else(|_| (*p).clone());
-                seen.insert(canon)
-            })
-            .collect();
-        eprintln!(
-            "⚠️  Found {} ONNX Runtime candidate(s) that failed to load (wrong arch, broken \
-             signature, or companion library); downloading a managed copy instead:",
-            unique.len()
-        );
-        for p in unique {
-            eprintln!("    - {}", p.display());
+        // Guard against repeat logging: `ensure_onnx_runtime` can be re-entered
+        // within a single process (tests, re-execs that restore the env, code
+        // paths that clear ORT_DYLIB_PATH), and once we've explained the
+        // rejection the user doesn't need to see it again.
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        if !WARNED.swap(true, Ordering::Relaxed) {
+            let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+            let unique: Vec<&PathBuf> = rejected
+                .iter()
+                .filter(|p| {
+                    let canon = p.canonicalize().unwrap_or_else(|_| (*p).clone());
+                    seen.insert(canon)
+                })
+                .collect();
+            eprintln!(
+                "⚠️  Found {} ONNX Runtime candidate(s) that failed to load (wrong arch, broken \
+                 signature, or companion library); downloading a managed copy instead:",
+                unique.len()
+            );
+            for p in unique {
+                eprintln!("    - {}", p.display());
+            }
         }
     }
 

--- a/colgrep/src/stderr.rs
+++ b/colgrep/src/stderr.rs
@@ -67,11 +67,51 @@ impl SuppressStderr {
 }
 
 /// Execute a closure with stderr suppressed.
+///
+/// If the closure panics, the panic message and location are captured via a
+/// temporary panic hook and printed to the (restored) stderr before the panic
+/// is resumed. This prevents panics inside suppressed regions from becoming
+/// silent, while still letting the panic propagate up the stack normally.
+///
 /// If suppression fails, the closure runs with stderr unchanged.
 pub fn with_suppressed_stderr<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
 {
-    let _guard = SuppressStderr::new();
-    f()
+    use std::panic::{self, AssertUnwindSafe};
+    use std::sync::{Arc, Mutex};
+
+    // Buffer to capture panic info written during the suppressed region.
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_for_hook = Arc::clone(&captured);
+
+    let prev_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        let mut buf = format!("{}\n", info);
+        // Include a backtrace when requested so RUST_BACKTRACE still works.
+        let bt = std::backtrace::Backtrace::capture();
+        if bt.status() == std::backtrace::BacktraceStatus::Captured {
+            buf.push_str(&format!("stack backtrace:\n{}\n", bt));
+        }
+        if let Ok(mut slot) = captured_for_hook.lock() {
+            *slot = Some(buf);
+        }
+    }));
+
+    let guard = SuppressStderr::new();
+    let result = panic::catch_unwind(AssertUnwindSafe(f));
+    drop(guard);
+
+    // Restore the user's panic hook before doing anything else.
+    panic::set_hook(prev_hook);
+
+    match result {
+        Ok(value) => value,
+        Err(payload) => {
+            if let Some(msg) = captured.lock().ok().and_then(|mut s| s.take()) {
+                eprint!("{}", msg);
+            }
+            panic::resume_unwind(payload);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a silent `exit 101` panic during `📂 Building index...` on macOS
when a broken/incompatible ONNX Runtime dylib is discovered before
colgrep's managed copy. Two bugs, one user-visible symptom.

## The bug, as reported

On a Homebrew + Apple Silicon setup:

```
$ colgrep "hi" ./api/src/db.rs -k 1
🤖 Model: lightonai/LateOn-Code-edge
📂 Building index...
[exit 101]     # RUST_BACKTRACE=full shows nothing
```

`colgrep clear`, model switches, `--fp32`, single-file scope, `colgrep
update --force-cpu` — none recover. `colgrep init <file>` correctly
prints backtraces for `anyhow` errors, so the issue is specific to how
the indexer path propagates a panic.

## Root cause

Two independent bugs chained together:

### 1. `find_onnx_runtime` accepts a dylib it cannot load

`colgrep/src/onnx_runtime.rs::find_onnx_runtime` walks a list of
candidate paths (managed cache → conda → venv → Homebrew → system).
The only admission check is `path.exists()`. On the reporter's machine
the managed cache is empty, so the walk reaches
`/opt/homebrew/lib/libonnxruntime.dylib`. `otool -L` on that file
shows:

```
/opt/homebrew/opt/onnxruntime/lib/libonnxruntime.1.23.2.dylib
/opt/homebrew/opt/onnx/lib/libonnx.dylib
/opt/homebrew/opt/onnx/lib/libonnx_proto.dylib
/opt/homebrew/opt/protobuf/lib/libprotobuf-lite.33.2.0.dylib
/opt/homebrew/opt/re2/lib/libre2.11.dylib
/opt/homebrew/opt/abseil/lib/libabsl_flags_*.dylib
...
```

The file itself is a valid arm64 Mach-O, but one of the transitive deps
is missing/mismatched, so `dlopen` fails. `ort::setup_api`
(`ort-2.0.0-rc.11/src/lib.rs:191`) calls `.expect()` on that load and
panics.

This is why `colgrep clear` can't help: the bad path comes from the
environment search, not from project state.

### 2. `with_suppressed_stderr` eats the panic message

`ensure_model_created` wraps `Colbert::builder(...).build()` in
`with_suppressed_stderr` (to hide harmless CoreML "Context leak"
warnings). The old implementation `dup2`s stderr to `/dev/null` for
the duration of the closure. The default panic hook fires at the panic
site — writing to the suppressed fd, i.e. `/dev/null`. Then the
`SuppressStderr` guard drops (stderr restored), `catch_unwind` returns
`Err`, and the call site calls `resume_unwind` — which by design does
**not** re-run the panic hook. Net result: the user sees only the
status line, and `RUST_BACKTRACE` has no effect.

## Fix

### `colgrep/src/onnx_runtime.rs`
- New `is_valid_ort_dylib(path)` helper: `libloading::Library::new` +
  `OrtGetApiBase` symbol lookup. This filters:
  - wrong arch (x86_64 dylib on aarch64 or vice versa),
  - broken symlinks that resolve to non-loadable files,
  - companion libraries like `libonnxruntime_providers_shared` that
    lack `OrtGetApiBase`,
  - stale Homebrew installs whose transitive deps no longer resolve.
- `find_onnx_runtime` validates each candidate before returning it;
  failed candidates are collected and printed (deduped by
  canonicalized path) so the user sees why we fell through.
- `ORT_DYLIB_PATH` from the environment is validated too and cleared
  if it points to an unusable dylib, instead of being forwarded to
  `ort` where it would panic.

### `colgrep/src/stderr.rs`
- `with_suppressed_stderr` now installs a temporary panic hook that
  captures panic message + `std::backtrace::Backtrace::capture()` into
  a buffer, performs `catch_unwind` internally, restores stderr,
  reinstates the previous hook, prints the captured buffer to the
  restored stderr if the closure panicked, then `resume_unwind`s.
  `RUST_BACKTRACE=full` now surfaces the real panic.

### `colgrep/src/index/mod.rs`
- Call site simplified — the outer `catch_unwind` / `resume_unwind`
  dance is redundant now that `with_suppressed_stderr` handles it.

### `colgrep/Cargo.toml`
- Added `libloading = "0.8"` (used directly for dylib probing).

## Verified behaviour (reporter's machine)

Before the fix:

```
🤖 Model: lightonai/LateOn-Code-edge
📂 Building index...
[exit 101, stderr empty even with RUST_BACKTRACE=full]
```

With only the stderr fix (to confirm root cause):

```
panicked at ort-2.0.0-rc.11/src/lib.rs:191:41:
Failed to load ONNX Runtime dylib: Error { code: GenericFailure, msg:
  \"failed to load from \`/opt/homebrew/lib/libonnxruntime.dylib\`: dlopen failed\" }
stack backtrace: ...
```

With both fixes:

```
⚠️  Found 2 ONNX Runtime candidate(s) that failed to load (wrong arch,
   broken signature, or companion library); downloading a managed copy instead:
    - /opt/homebrew/lib/libonnxruntime.dylib
    - /opt/homebrew/lib/libonnxruntime.1.23.2.dylib
⚙️  Runtime: ONNX 1.23.0 (CPU)
🤖 Model: lightonai/LateOn-Code-edge
📂 Building index...
📂 Using index: .../colgrep/src: indexed 70 files
.../colgrep/src/lib.rs:1-45 (score: 1.84)
```

Managed dylib cached at
`~/.cache/colgrep/onnxruntime/1.23.0/cpu/libonnxruntime.dylib`.

## Test plan

- [x] Reproduce the silent `exit 101` on macOS arm64 with the broken
      Homebrew install.
- [x] Confirm the stderr fix alone surfaces the real panic from
      `ort::setup_api`.
- [x] Confirm the validation fix alone causes the broken candidate to
      be rejected and the managed download to run.
- [x] Confirm end-to-end: index builds and search returns a hit.
- [ ] Run on Linux + CPU to confirm no regression for the common path
      (managed cache first, no stray Homebrew candidate).
- [ ] Run on Linux + CUDA build to confirm the `ORT_DYLIB_PATH`
      validation doesn't break the re-exec flow for cuDNN.
- [ ] `cargo test -p colgrep`.