### PR TITLE
Harden non-finite scores and rerank embedding validation

### DIFF
--- a/colgrep/src/parser/qml.rs
+++ b/colgrep/src/parser/qml.rs
@@ -432,17 +432,15 @@ fn extract_object_variables(node: Node, bytes: &[u8]) -> Vec<String> {
                     push_unique(&mut variables, name);
                 }
             }
-            "ui_binding" => {
-                if field_text(child, "name", bytes).as_deref() == Some("id") {
-                    if let Some(value) = child.child_by_field_name("value").and_then(|value| {
-                        value
-                            .utf8_text(bytes)
-                            .ok()
-                            .map(|text| text.trim().to_string())
-                    }) {
-                        if is_simple_identifier(&value) {
-                            push_unique(&mut variables, value);
-                        }
+            "ui_binding" if field_text(child, "name", bytes).as_deref() == Some("id") => {
+                if let Some(value) = child.child_by_field_name("value").and_then(|value| {
+                    value
+                        .utf8_text(bytes)
+                        .ok()
+                        .map(|text| text.trim().to_string())
+                }) {
+                    if is_simple_identifier(&value) {
+                        push_unique(&mut variables, value);
                     }
                 }
             }

--- a/next-plaid-api/src/handlers/rerank.rs
+++ b/next-plaid-api/src/handlers/rerank.rs
@@ -17,40 +17,16 @@ use crate::PrettyJson;
 
 /// Convert a Vec<Vec<f32>> to an ndarray::Array2<f32>.
 fn to_ndarray(embeddings: &[Vec<f32>]) -> ApiResult<Array2<f32>> {
-    if embeddings.is_empty() {
-        return Err(ApiError::BadRequest(
-            "Empty embeddings provided".to_string(),
-        ));
-    }
-
-    let rows = embeddings.len();
-    let cols = embeddings[0].len();
-
-    // Validate all rows have same dimension
-    for (i, row) in embeddings.iter().enumerate() {
-        if row.len() != cols {
-            return Err(ApiError::BadRequest(format!(
-                "Inconsistent embedding dimensions: row 0 has {} elements, row {} has {}",
-                cols,
-                i,
-                row.len()
-            )));
-        }
-    }
-
-    let flat: Vec<f32> = embeddings.iter().flatten().copied().collect();
-    Array2::from_shape_vec((rows, cols), flat)
-        .map_err(|e| ApiError::Internal(format!("Failed to create ndarray: {}", e)))
+    crate::models::json_embeddings_to_array2(embeddings, "query", "Query")
+        .map_err(ApiError::BadRequest)
 }
 
 /// Convert DocumentEmbeddings (JSON or base64) to an ndarray::Array2<f32>.
 fn doc_to_ndarray(doc: &crate::models::DocumentEmbeddings) -> ApiResult<Array2<f32>> {
     // Prefer base64 if provided
     if let (Some(b64), Some(shape)) = (&doc.embeddings_b64, &doc.shape) {
-        let floats =
-            crate::models::decode_b64_embeddings(b64, *shape).map_err(ApiError::BadRequest)?;
-        return Array2::from_shape_vec((shape[0], shape[1]), floats)
-            .map_err(|e| ApiError::Internal(format!("Failed to create ndarray: {}", e)));
+        return crate::models::decode_b64_embeddings_to_array2(b64, *shape, "document")
+            .map_err(ApiError::BadRequest);
     }
 
     // Fall back to JSON
@@ -59,7 +35,17 @@ fn doc_to_ndarray(doc: &crate::models::DocumentEmbeddings) -> ApiResult<Array2<f
             "Must provide either 'embeddings' or 'embeddings_b64' + 'shape'".to_string(),
         )
     })?;
-    to_ndarray(embeddings)
+    crate::models::json_embeddings_to_array2(embeddings, "document", "Document")
+        .map_err(ApiError::BadRequest)
+}
+
+fn score_desc_cmp(a: f32, b: f32) -> std::cmp::Ordering {
+    match (a.is_finite(), b.is_finite()) {
+        (true, true) => b.total_cmp(&a),
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        (false, false) => std::cmp::Ordering::Equal,
+    }
 }
 
 /// Compute ColBERT MaxSim score between a query and a document.
@@ -68,7 +54,7 @@ fn doc_to_ndarray(doc: &crate::models::DocumentEmbeddings) -> ApiResult<Array2<f
 /// then sum these maximum similarities.
 ///
 /// Assumes embeddings are already L2-normalized (as ColBERT models produce).
-fn compute_maxsim(query: &Array2<f32>, document: &Array2<f32>) -> f32 {
+fn compute_maxsim(query: &Array2<f32>, document: &Array2<f32>) -> ApiResult<f32> {
     let mut total_score = 0.0f32;
 
     // For each query token
@@ -83,6 +69,11 @@ fn compute_maxsim(query: &Array2<f32>, document: &Array2<f32>) -> f32 {
                 .zip(doc_row.iter())
                 .map(|(q, d)| q * d)
                 .sum();
+            if !sim.is_finite() {
+                return Err(ApiError::BadRequest(
+                    "Rerank score contains non-finite value".to_string(),
+                ));
+            }
             if sim > max_sim {
                 max_sim = sim;
             }
@@ -91,10 +82,15 @@ fn compute_maxsim(query: &Array2<f32>, document: &Array2<f32>) -> f32 {
         // Sum the max similarities
         if max_sim > f32::NEG_INFINITY {
             total_score += max_sim;
+            if !total_score.is_finite() {
+                return Err(ApiError::BadRequest(
+                    "Rerank score contains non-finite value".to_string(),
+                ));
+            }
         }
     }
 
-    total_score
+    Ok(total_score)
 }
 
 /// Rerank documents given pre-computed query and document embeddings.
@@ -126,14 +122,9 @@ pub async fn rerank(
 
     // Convert query to ndarray (base64 or JSON)
     let query = if let (Some(b64), Some(shape)) = (&request.query_b64, &request.query_shape) {
-        let floats =
-            crate::models::decode_b64_embeddings(b64, *shape).map_err(ApiError::BadRequest)?;
-        Array2::from_shape_vec((shape[0], shape[1]), floats)
-            .map_err(|e| ApiError::BadRequest(format!("Failed to create query array: {}", e)))?
+        crate::models::decode_b64_embeddings_to_array2(b64, *shape, "query")
+            .map_err(ApiError::BadRequest)?
     } else if let Some(ref q) = request.query {
-        if q.is_empty() {
-            return Err(ApiError::BadRequest("Empty query embeddings".to_string()));
-        }
         to_ndarray(q)?
     } else {
         return Err(ApiError::BadRequest(
@@ -166,19 +157,12 @@ pub async fn rerank(
     let mut results: Vec<RerankResult> = documents
         .iter()
         .enumerate()
-        .map(|(index, doc)| {
-            let score = compute_maxsim(&query, doc);
-            RerankResult { index, score }
-        })
-        .collect();
+        .map(|(index, doc)| compute_maxsim(&query, doc).map(|score| RerankResult { index, score }))
+        .collect::<ApiResult<Vec<_>>>()?;
     let scoring_ms = scoring_start.elapsed().as_millis() as u64;
 
     // Sort by score descending
-    results.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_by(|a, b| score_desc_cmp(a.score, b.score));
 
     let total_ms = start.elapsed().as_millis() as u64;
 
@@ -270,19 +254,12 @@ pub async fn rerank_with_encoding(
     let mut results: Vec<RerankResult> = doc_embeddings
         .iter()
         .enumerate()
-        .map(|(index, doc)| {
-            let score = compute_maxsim(&query, doc);
-            RerankResult { index, score }
-        })
-        .collect();
+        .map(|(index, doc)| compute_maxsim(&query, doc).map(|score| RerankResult { index, score }))
+        .collect::<ApiResult<Vec<_>>>()?;
     let scoring_ms = scoring_start.elapsed().as_millis() as u64;
 
     // Sort by score descending
-    results.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_by(|a, b| score_desc_cmp(a.score, b.score));
 
     let total_ms = start.elapsed().as_millis() as u64;
 
@@ -319,4 +296,60 @@ pub async fn rerank_with_encoding(
     Json(_request): Json<crate::models::RerankWithEncodingRequest>,
 ) -> ApiResult<PrettyJson<RerankResponse>> {
     Err(ApiError::ModelNotLoaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::ApiError;
+    use crate::models::DocumentEmbeddings;
+
+    #[test]
+    fn rerank_query_to_ndarray_rejects_non_finite_values() {
+        let error = super::to_ndarray(&[vec![1.0, f32::NAN]])
+            .expect_err("non-finite query embeddings must fail");
+
+        match error {
+            ApiError::BadRequest(message) => {
+                assert!(message.contains("non-finite value"), "{message}");
+                assert!(message.contains("row 0, col 1"), "{message}");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn rerank_document_to_ndarray_rejects_zero_dimension_b64_shape() {
+        let error = super::doc_to_ndarray(&DocumentEmbeddings {
+            embeddings: None,
+            embeddings_b64: Some(String::new()),
+            shape: Some([1, 0]),
+        })
+        .expect_err("zero-dimension b64 document must fail");
+
+        match error {
+            ApiError::BadRequest(message) => {
+                assert!(
+                    message.contains("Zero dimension document embeddings"),
+                    "{message}"
+                );
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn rerank_compute_maxsim_rejects_non_finite_scores() {
+        let query = ndarray::arr2(&[[f32::MAX, f32::MAX]]);
+        let document = ndarray::arr2(&[[f32::MAX, f32::MAX]]);
+
+        let error =
+            super::compute_maxsim(&query, &document).expect_err("overflowing score must fail");
+
+        match error {
+            ApiError::BadRequest(message) => {
+                assert!(message.contains("non-finite value"), "{message}");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
 }

--- a/next-plaid-api/src/models.rs
+++ b/next-plaid-api/src/models.rs
@@ -3,6 +3,7 @@
 //! This module defines the JSON structures used for API communication.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ndarray::Array2;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -862,7 +863,10 @@ pub fn decode_b64_embeddings(b64: &str, shape: [usize; 2]) -> Result<Vec<f32>, S
     let bytes = STANDARD
         .decode(b64)
         .map_err(|e| format!("Invalid base64: {}", e))?;
-    let expected = shape[0] * shape[1] * 4;
+    let expected: usize = shape[0]
+        .checked_mul(shape[1])
+        .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+        .ok_or_else(|| format!("Shape {:?} exceeds supported embedding size", shape))?;
     if bytes.len() != expected {
         return Err(format!(
             "Expected {} bytes for shape {:?}, got {}",
@@ -875,7 +879,75 @@ pub fn decode_b64_embeddings(b64: &str, shape: [usize; 2]) -> Result<Vec<f32>, S
         .chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect();
+    if let Some((index, value)) = floats
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        return Err(format!(
+            "Embedding contains non-finite value at flat index {}: {}",
+            index, value
+        ));
+    }
     Ok(floats)
+}
+
+fn validate_embedding_shape(shape: [usize; 2], label: &str) -> Result<(), String> {
+    if shape[0] == 0 {
+        return Err(format!("Empty {} embeddings", label));
+    }
+    if shape[1] == 0 {
+        return Err(format!("Zero dimension {} embeddings", label));
+    }
+    Ok(())
+}
+
+/// Convert base64-encoded embeddings into ndarray with shape and finite-value validation.
+pub fn decode_b64_embeddings_to_array2(
+    b64: &str,
+    shape: [usize; 2],
+    label: &str,
+) -> Result<Array2<f32>, String> {
+    validate_embedding_shape(shape, label)?;
+    let floats: Vec<f32> = decode_b64_embeddings(b64, shape)?;
+    Array2::from_shape_vec((shape[0], shape[1]), floats)
+        .map_err(|error| format!("Failed to create {} array: {}", label, error))
+}
+
+/// Convert JSON embeddings into ndarray with shape and finite-value validation.
+pub fn json_embeddings_to_array2(
+    embeddings: &[Vec<f32>],
+    label: &str,
+    singular_label: &str,
+) -> Result<Array2<f32>, String> {
+    let rows: usize = embeddings.len();
+    validate_embedding_shape([rows, embeddings.first().map_or(0, Vec::len)], label)?;
+    let cols: usize = embeddings[0].len();
+
+    for (row_index, row) in embeddings.iter().enumerate() {
+        if row.len() != cols {
+            return Err(format!(
+                "Inconsistent {} embedding dimension at row {}: expected {}, got {}",
+                label,
+                row_index,
+                cols,
+                row.len()
+            ));
+        }
+        for (column_index, value) in row.iter().enumerate() {
+            if !value.is_finite() {
+                return Err(format!(
+                    "{} embedding contains non-finite value at row {}, col {}",
+                    singular_label, row_index, column_index
+                ));
+            }
+        }
+    }
+
+    let flat: Vec<f32> = embeddings.iter().flatten().copied().collect();
+    Array2::from_shape_vec((rows, cols), flat)
+        .map_err(|error| format!("Failed to create {} array: {}", label, error))
 }
 
 /// Encode f32 embeddings as base64 little-endian.
@@ -906,4 +978,45 @@ pub struct ErrorResponse {
     /// Optional additional details
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_b64_embeddings_rejects_non_finite_values() {
+        let bytes: Vec<u8> = [1.0f32, f32::NAN]
+            .into_iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect();
+        let encoded: String = STANDARD.encode(bytes);
+
+        let error: String =
+            decode_b64_embeddings(&encoded, [1, 2]).expect_err("non-finite must fail");
+
+        assert!(error.contains("non-finite"), "{error}");
+        assert!(error.contains("flat index 1"), "{error}");
+    }
+
+    #[test]
+    fn decode_b64_embeddings_to_array2_rejects_empty_shape() {
+        let error: String = decode_b64_embeddings_to_array2("", [0, 4], "query")
+            .expect_err("empty shape must fail");
+        assert!(error.contains("Empty query embeddings"), "{error}");
+    }
+
+    #[test]
+    fn decode_b64_embeddings_to_array2_rejects_zero_dimension_shape() {
+        let error: String = decode_b64_embeddings_to_array2("", [2, 0], "query")
+            .expect_err("zero dimension must fail");
+        assert!(error.contains("Zero dimension query embeddings"), "{error}");
+    }
+
+    #[test]
+    fn json_embeddings_to_array2_rejects_zero_dimension_rows() {
+        let error: String = json_embeddings_to_array2(&[Vec::new()], "query", "Query")
+            .expect_err("zero dimension must fail");
+        assert!(error.contains("Zero dimension query embeddings"), "{error}");
+    }
 }

--- a/next-plaid/src/codec.rs
+++ b/next-plaid/src/codec.rs
@@ -19,6 +19,16 @@ fn max_nearest_centroid_memory() -> usize {
         .unwrap_or(DEFAULT_MAX_NEAREST_CENTROID_MEMORY)
 }
 
+#[inline]
+fn cmp_f32_for_max(a: &f32, b: &f32) -> std::cmp::Ordering {
+    match (a.is_finite(), b.is_finite()) {
+        (true, true) => a.total_cmp(b),
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        (false, false) => std::cmp::Ordering::Equal,
+    }
+}
+
 /// Storage backend for centroids, supporting both owned arrays and memory-mapped files.
 ///
 /// This enum enables `ResidualCodec` to work with centroids stored either:
@@ -321,7 +331,7 @@ impl ResidualCodec {
                     .map(|row| {
                         row.iter()
                             .enumerate()
-                            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+                            .max_by(|(_, a), (_, b)| cmp_f32_for_max(a, b))
                             .map(|(idx, _)| idx)
                             .unwrap_or(0)
                     })
@@ -717,5 +727,27 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_compress_into_codes_ignores_nan_scores_when_finite_choices_exist() {
+        let centroids = Array2::from_shape_vec(
+            (3, 2),
+            vec![
+                f32::NAN,
+                0.0, //
+                1.0,
+                0.0, //
+                0.0,
+                1.0, //
+            ],
+        )
+        .unwrap();
+        let avg_residual = Array1::zeros(2);
+        let codec = ResidualCodec::new(2, centroids, avg_residual, None, None).unwrap();
+        let embeddings = Array2::from_shape_vec((1, 2), vec![1.0, 0.0]).unwrap();
+
+        let codes = codec.compress_into_codes_cpu(&embeddings);
+        assert_eq!(codes[0], 1);
     }
 }

--- a/next-plaid/src/maxsim.rs
+++ b/next-plaid/src/maxsim.rs
@@ -496,8 +496,8 @@ mod tests {
 
     #[test]
     fn test_maxsim_score_ignores_non_finite_row_entries_when_finite_max_exists() {
-        let query = Array2::from_shape_vec((16, 2), vec![1.0, 0.0].repeat(16)).unwrap();
-        let mut doc_data = vec![0.5, 0.0].repeat(15);
+        let query = Array2::from_shape_vec((16, 2), [1.0, 0.0].repeat(16)).unwrap();
+        let mut doc_data = [0.5, 0.0].repeat(15);
         doc_data.extend([f32::NAN, 0.0]);
         let doc = Array2::from_shape_vec((16, 2), doc_data).unwrap();
 

--- a/next-plaid/src/maxsim.rs
+++ b/next-plaid/src/maxsim.rs
@@ -19,6 +19,21 @@
 use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
 
+#[inline]
+fn cmp_f32_for_max(a: &f32, b: &f32) -> std::cmp::Ordering {
+    match (a.is_finite(), b.is_finite()) {
+        (true, true) => a.total_cmp(b),
+        (true, false) => std::cmp::Ordering::Greater,
+        (false, true) => std::cmp::Ordering::Less,
+        (false, false) => std::cmp::Ordering::Equal,
+    }
+}
+
+#[inline]
+fn is_score_better(candidate: f32, current: f32) -> bool {
+    cmp_f32_for_max(&candidate, &current).is_gt()
+}
+
 // ============================================================================
 // SIMD Module - Platform-specific fast max/argmax
 // Adapted from https://github.com/lightonai/maxsim-cpu
@@ -31,11 +46,20 @@ mod simd {
     #[cfg(target_arch = "aarch64")]
     use std::arch::aarch64::*;
 
+    #[inline]
+    fn has_non_finite(slice: &[f32]) -> bool {
+        slice.iter().any(|value| !value.is_finite())
+    }
+
     /// Scalar fallback for max - used when SIMD is unavailable or slice is small.
     #[inline]
     #[allow(dead_code)] // Used conditionally on x86_64 without AVX2
     fn scalar_max(slice: &[f32]) -> f32 {
-        slice.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+        slice
+            .iter()
+            .copied()
+            .max_by(crate::maxsim::cmp_f32_for_max)
+            .unwrap_or(f32::NEG_INFINITY)
     }
 
     /// Scalar fallback for argmax - used when SIMD is unavailable or slice is small.
@@ -45,7 +69,7 @@ mod simd {
         slice
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .max_by(|(_, a), (_, b)| crate::maxsim::cmp_f32_for_max(a, b))
             .map(|(idx, _)| idx)
             .unwrap_or(0)
     }
@@ -111,7 +135,13 @@ mod simd {
 
             // Handle remaining elements
             for &val in &slice[i..] {
-                result = result.max(val);
+                if crate::maxsim::is_score_better(val, result) {
+                    result = val;
+                }
+            }
+
+            if !result.is_finite() || has_non_finite(slice) {
+                return scalar_max(slice);
             }
 
             result
@@ -123,7 +153,7 @@ mod simd {
     #[inline]
     pub fn simd_max(slice: &[f32]) -> f32 {
         if slice.len() < 4 {
-            return slice.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            return scalar_max(slice);
         }
 
         unsafe {
@@ -169,7 +199,13 @@ mod simd {
 
             // Handle remaining elements
             for &val in &slice[i..] {
-                result = result.max(val);
+                if crate::maxsim::is_score_better(val, result) {
+                    result = val;
+                }
+            }
+
+            if !result.is_finite() || has_non_finite(slice) {
+                return scalar_max(slice);
             }
 
             result
@@ -249,7 +285,7 @@ pub fn maxsim_score(query: &ArrayView2<f32>, doc: &ArrayView2<f32>) -> f32 {
     for q_idx in 0..q_len {
         let row = scores.row(q_idx);
         let max_sim = simd::simd_max(row.as_slice().unwrap());
-        if max_sim > f32::NEG_INFINITY {
+        if max_sim.is_finite() {
             total += max_sim;
         }
     }
@@ -266,11 +302,11 @@ fn maxsim_score_simple(query: &ArrayView2<f32>, doc: &ArrayView2<f32>) -> f32 {
         let mut max_sim = f32::NEG_INFINITY;
         for d_row in doc.axis_iter(Axis(0)) {
             let sim: f32 = q_row.dot(&d_row);
-            if sim > max_sim {
+            if is_score_better(sim, max_sim) {
                 max_sim = sim;
             }
         }
-        if max_sim > f32::NEG_INFINITY {
+        if max_sim.is_finite() {
             total += max_sim;
         }
     }
@@ -311,7 +347,7 @@ pub fn assign_to_centroids(
                 let mut best_score = f32::NEG_INFINITY;
                 for (idx, centroid) in centroids.axis_iter(Axis(0)).enumerate() {
                     let score: f32 = emb.iter().zip(centroid.iter()).map(|(a, b)| a * b).sum();
-                    if score > best_score {
+                    if is_score_better(score, best_score) {
                         best_score = score;
                         best_idx = idx;
                     }
@@ -394,6 +430,17 @@ mod tests {
     }
 
     #[test]
+    fn test_simd_max_ignores_non_finite_when_finite_values_exist() {
+        let data = vec![1.0, 2.0, 3.0, f32::NAN, 4.0, 5.0, 6.0, 7.0];
+        let max = simd::simd_max(&data);
+        assert_eq!(max, 7.0);
+
+        let data_with_infinity = vec![1.0, 2.0, 3.0, f32::INFINITY, 4.0, 5.0, 6.0, 7.0];
+        let max_with_infinity = simd::simd_max(&data_with_infinity);
+        assert_eq!(max_with_infinity, 7.0);
+    }
+
+    #[test]
     fn test_assign_to_centroids() {
         // 3 centroids in 4D space
         let centroids = Array2::from_shape_vec(
@@ -439,5 +486,23 @@ mod tests {
 
         let data3: Vec<f32> = (0..100).rev().map(|i| i as f32).collect();
         assert_eq!(simd::simd_argmax(&data3), 0);
+    }
+
+    #[test]
+    fn test_simd_argmax_ignores_nan_when_finite_values_exist() {
+        let data: Vec<f32> = vec![1.0, f32::NAN, 0.5];
+        assert_eq!(simd::simd_argmax(&data), 0);
+    }
+
+    #[test]
+    fn test_maxsim_score_ignores_non_finite_row_entries_when_finite_max_exists() {
+        let query = Array2::from_shape_vec((16, 2), vec![1.0, 0.0].repeat(16)).unwrap();
+        let mut doc_data = vec![0.5, 0.0].repeat(15);
+        doc_data.extend([f32::NAN, 0.0]);
+        let doc = Array2::from_shape_vec((16, 2), doc_data).unwrap();
+
+        let score = maxsim_score(&query.view(), &doc.view());
+
+        assert!((score - 8.0).abs() < 1e-5);
     }
 }

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -1,6 +1,6 @@
 //! Search functionality for PLAID
 
-use std::cmp::Reverse;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use ndarray::Array1;
@@ -103,9 +103,32 @@ impl PartialOrd for OrdF32 {
 
 impl Ord for OrdF32 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        cmp_score_ascending(self.0, other.0)
+    }
+}
+
+fn cmp_score_ascending(a: f32, b: f32) -> Ordering {
+    match (a.is_finite(), b.is_finite()) {
+        (true, true) => a.total_cmp(&b),
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        (false, false) => Ordering::Equal,
+    }
+}
+
+fn cmp_score_descending(a: f32, b: f32) -> Ordering {
+    cmp_score_ascending(b, a)
+}
+
+fn is_score_better(candidate: f32, current: f32) -> bool {
+    cmp_score_ascending(candidate, current).is_gt()
+}
+
+fn max_score(a: f32, b: f32) -> f32 {
+    if is_score_better(b, a) {
+        b
+    } else {
+        a
     }
 }
 
@@ -160,15 +183,15 @@ fn ivf_probe_batched(
                         heap.push(entry);
                         max_scores
                             .entry(global_c)
-                            .and_modify(|s| *s = s.max(score))
+                            .and_modify(|s| *s = max_score(*s, score))
                             .or_insert(score);
                     } else if let Some(&(Reverse(OrdF32(min_score)), _)) = heap.peek() {
-                        if score > min_score {
+                        if is_score_better(score, min_score) {
                             heap.pop();
                             heap.push(entry);
                             max_scores
                                 .entry(global_c)
-                                .and_modify(|s| *s = s.max(score))
+                                .and_modify(|s| *s = max_score(*s, score))
                                 .or_insert(score);
                         }
                     }
@@ -193,7 +216,7 @@ fn ivf_probe_batched(
                 if final_heaps[q_idx].len() < n_probe {
                     final_heaps[q_idx].push(entry);
                 } else if let Some(&(Reverse(OrdF32(min_score)), _)) = final_heaps[q_idx].peek() {
-                    if score > min_score {
+                    if is_score_better(score, min_score) {
                         final_heaps[q_idx].pop();
                         final_heaps[q_idx].push(entry);
                     }
@@ -381,9 +404,8 @@ pub fn search_one_mmap(
             // (but not sorted among themselves - which is fine since we use a HashSet)
             let n_probe = effective_n_ivf_probe.min(centroid_scores.len());
             if centroid_scores.len() > n_probe {
-                centroid_scores.select_nth_unstable_by(n_probe - 1, |a, b| {
-                    b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
-                });
+                centroid_scores
+                    .select_nth_unstable_by(n_probe - 1, |a, b| cmp_score_descending(a.1, b.1));
             }
 
             for (c, _) in centroid_scores.iter().take(n_probe) {
@@ -396,7 +418,7 @@ pub fn search_one_mmap(
             selected_centroids.retain(|&c| {
                 let max_score: f32 = (0..num_query_tokens)
                     .map(|q_idx| query_centroid_scores[[q_idx, c]])
-                    .max_by(|a, b| a.partial_cmp(b).unwrap())
+                    .max_by(|a, b| cmp_score_ascending(*a, *b))
                     .unwrap_or(f32::NEG_INFINITY);
                 max_score >= threshold
             });
@@ -435,7 +457,7 @@ pub fn search_one_mmap(
         .collect();
 
     // Sort by approximate score and take top candidates
-    approx_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    approx_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
     let top_candidates: Vec<i64> = approx_scores
         .iter()
         .take(params.n_full_scores)
@@ -471,7 +493,7 @@ pub fn search_one_mmap(
         .collect();
 
     // Sort by exact score
-    exact_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    exact_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
 
     // Return top-k results
     let result_count = params.top_k.min(exact_scores.len());
@@ -559,7 +581,7 @@ fn search_one_mmap_batched(
         .collect();
 
     // Sort by approximate score and take top candidates
-    approx_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    approx_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
     let top_candidates: Vec<i64> = approx_scores
         .iter()
         .take(params.n_full_scores)
@@ -595,7 +617,7 @@ fn search_one_mmap_batched(
         .collect();
 
     // Sort by exact score
-    exact_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    exact_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
 
     // Return top-k results
     let result_count = params.top_k.min(exact_scores.len());
@@ -690,5 +712,32 @@ mod tests {
         assert_eq!(params.top_k, 10);
         assert_eq!(params.n_ivf_probe, 8);
         assert_eq!(params.centroid_score_threshold, Some(0.4));
+    }
+
+    #[test]
+    fn test_cmp_score_descending_places_non_finite_scores_last() {
+        let mut scores = vec![1.0f32, f32::INFINITY, 0.5, f32::NAN];
+        scores.sort_by(|a, b| cmp_score_descending(*a, *b));
+
+        assert_eq!(scores[0], 1.0);
+        assert_eq!(scores[1], 0.5);
+        assert!(!scores[2].is_finite());
+        assert!(!scores[3].is_finite());
+    }
+
+    #[test]
+    fn test_score_replacement_treats_finite_values_as_better_than_non_finite() {
+        assert!(is_score_better(1.0, f32::NAN));
+        assert!(is_score_better(1.0, f32::INFINITY));
+        assert!(!is_score_better(f32::NAN, 1.0));
+        assert!(!is_score_better(f32::INFINITY, 1.0));
+    }
+
+    #[test]
+    fn test_max_score_keeps_finite_value_over_non_finite_value() {
+        assert_eq!(max_score(f32::NAN, 1.0), 1.0);
+        assert_eq!(max_score(1.0, f32::NAN), 1.0);
+        assert_eq!(max_score(f32::INFINITY, 1.0), 1.0);
+        assert_eq!(max_score(1.0, f32::INFINITY), 1.0);
     }
 }

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -716,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_cmp_score_descending_places_non_finite_scores_last() {
-        let mut scores = vec![1.0f32, f32::INFINITY, 0.5, f32::NAN];
+        let mut scores = [1.0f32, f32::INFINITY, 0.5, f32::NAN];
         scores.sort_by(|a, b| cmp_score_descending(*a, *b));
 
         assert_eq!(scores[0], 1.0);


### PR DESCRIPTION
## Summary
- keep non-finite similarity scores ordered behind finite results
- share stricter embedding decoding and validation in rerank handlers
- reject malformed or non-finite rerank inputs with explicit errors

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --features "openblas" -- -D warnings
- cargo test --features "openblas" rerank -- --nocapture (blocked locally: missing system OpenBLAS linker library)

Implemented entirely by Codex.