### PR TITLE
Add MCP project sync staged upload API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,7 @@ dependencies = [
  "arc-swap",
  "axum",
  "base64 0.22.1",
+ "futures-util",
  "ndarray 0.16.1",
  "ndarray-rand",
  "next-plaid",

--- a/colgrep/src/parser/qml.rs
+++ b/colgrep/src/parser/qml.rs
@@ -432,17 +432,15 @@ fn extract_object_variables(node: Node, bytes: &[u8]) -> Vec<String> {
                     push_unique(&mut variables, name);
                 }
             }
-            "ui_binding" => {
-                if field_text(child, "name", bytes).as_deref() == Some("id") {
-                    if let Some(value) = child.child_by_field_name("value").and_then(|value| {
-                        value
-                            .utf8_text(bytes)
-                            .ok()
-                            .map(|text| text.trim().to_string())
-                    }) {
-                        if is_simple_identifier(&value) {
-                            push_unique(&mut variables, value);
-                        }
+            "ui_binding" if field_text(child, "name", bytes).as_deref() == Some("id") => {
+                if let Some(value) = child.child_by_field_name("value").and_then(|value| {
+                    value
+                        .utf8_text(bytes)
+                        .ok()
+                        .map(|text| text.trim().to_string())
+                }) {
+                    if is_simple_identifier(&value) {
+                        push_unique(&mut variables, value);
                     }
                 }
             }

--- a/next-plaid-api/Cargo.toml
+++ b/next-plaid-api/Cargo.toml
@@ -18,6 +18,7 @@ axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.5", features = ["util", "limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
+futures-util = "0.3"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/next-plaid-api/src/error.rs
+++ b/next-plaid-api/src/error.rs
@@ -4,7 +4,7 @@
 //! with appropriate status codes and JSON error bodies.
 
 use axum::{
-    http::StatusCode,
+    http::{header::RETRY_AFTER, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -30,6 +30,10 @@ pub enum ApiError {
     #[error("Invalid request: {0}")]
     BadRequest(String),
 
+    /// Request conflicts with current resource state
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     /// Embedding dimension mismatch
     #[error("Embedding dimension mismatch: expected {expected}, got {actual}")]
     DimensionMismatch { expected: usize, actual: usize },
@@ -46,6 +50,25 @@ pub enum ApiError {
     #[error("Service unavailable: {0}")]
     ServiceUnavailable(String),
 
+    /// Service temporarily unavailable with structured retry details
+    #[error("Service unavailable: {message}")]
+    ServiceUnavailableDetailed {
+        message: String,
+        details: serde_json::Value,
+        retry_after_seconds: Option<u64>,
+    },
+
+    /// Request body exceeded the configured limit
+    #[error("Content too large: {message}")]
+    ContentTooLarge {
+        message: String,
+        details: serde_json::Value,
+    },
+
+    /// Request timed out before completion
+    #[error("Request timed out: {0}")]
+    RequestTimeout(String),
+
     /// Model not loaded (encoding endpoints require --model flag)
     #[error("Model not loaded. Start the server with --model <path> to enable encoding.")]
     ModelNotLoaded,
@@ -58,6 +81,10 @@ pub enum ApiError {
     /// NextPlaid library error
     #[error("Next-Plaid error: {0}")]
     NextPlaid(#[from] next_plaid::Error),
+
+    /// Project sync job not found
+    #[error("Project sync job not found: {0}")]
+    ProjectSyncJobNotFound(String),
 }
 
 /// JSON error response body.
@@ -74,11 +101,21 @@ pub struct ErrorResponse {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let (status, code, message) = match &self {
-            ApiError::IndexNotFound(msg) => (StatusCode::NOT_FOUND, "INDEX_NOT_FOUND", msg.clone()),
-            ApiError::IndexAlreadyExists(msg) => {
-                (StatusCode::CONFLICT, "INDEX_ALREADY_EXISTS", msg.clone())
-            }
+        let (status, code, message, details, retry_after_seconds) = match &self {
+            ApiError::IndexNotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                "INDEX_NOT_FOUND",
+                msg.clone(),
+                None,
+                None,
+            ),
+            ApiError::IndexAlreadyExists(msg) => (
+                StatusCode::CONFLICT,
+                "INDEX_ALREADY_EXISTS",
+                msg.clone(),
+                None,
+                None,
+            ),
             ApiError::IndexNotDeclared(msg) => (
                 StatusCode::NOT_FOUND,
                 "INDEX_NOT_DECLARED",
@@ -86,51 +123,114 @@ impl IntoResponse for ApiError {
                     "Index '{}' not declared. Call POST /indices first to declare the index.",
                     msg
                 ),
+                None,
+                None,
             ),
-            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", msg.clone()),
+            ApiError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                "BAD_REQUEST",
+                msg.clone(),
+                None,
+                None,
+            ),
+            ApiError::Conflict(msg) => (StatusCode::CONFLICT, "CONFLICT", msg.clone(), None, None),
             ApiError::DimensionMismatch { expected, actual } => (
                 StatusCode::BAD_REQUEST,
                 "DIMENSION_MISMATCH",
                 format!("Expected dimension {}, got {}", expected, actual),
+                None,
+                None,
             ),
-            ApiError::MetadataNotFound(msg) => {
-                (StatusCode::NOT_FOUND, "METADATA_NOT_FOUND", msg.clone())
-            }
+            ApiError::MetadataNotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                "METADATA_NOT_FOUND",
+                msg.clone(),
+                None,
+                None,
+            ),
             ApiError::Internal(msg) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "INTERNAL_ERROR",
                 msg.clone(),
+                None,
+                None,
             ),
             ApiError::ServiceUnavailable(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "SERVICE_UNAVAILABLE",
                 msg.clone(),
+                None,
+                None,
+            ),
+            ApiError::ServiceUnavailableDetailed {
+                message,
+                details,
+                retry_after_seconds,
+            } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SERVICE_UNAVAILABLE",
+                message.clone(),
+                Some(details.clone()),
+                *retry_after_seconds,
+            ),
+            ApiError::ContentTooLarge { message, details } => (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "CONTENT_TOO_LARGE",
+                message.clone(),
+                Some(details.clone()),
+                None,
+            ),
+            ApiError::RequestTimeout(msg) => (
+                StatusCode::REQUEST_TIMEOUT,
+                "REQUEST_TIMEOUT",
+                msg.clone(),
+                None,
+                None,
             ),
             ApiError::ModelNotLoaded => (
                 StatusCode::BAD_REQUEST,
                 "MODEL_NOT_LOADED",
                 "No model loaded. Start the server with --model <path> to enable encoding."
                     .to_string(),
+                None,
+                None,
             ),
             ApiError::ModelError(msg) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "MODEL_ERROR",
                 msg.clone(),
+                None,
+                None,
             ),
             ApiError::NextPlaid(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "NEXT_PLAID_ERROR",
                 e.to_string(),
+                None,
+                None,
+            ),
+            ApiError::ProjectSyncJobNotFound(job_id) => (
+                StatusCode::NOT_FOUND,
+                "PROJECT_SYNC_JOB_NOT_FOUND",
+                format!("Project sync job '{}' not found", job_id),
+                None,
+                None,
             ),
         };
 
         let body = ErrorResponse {
             code,
             message,
-            details: None,
+            details,
         };
 
-        (status, Json(body)).into_response()
+        let mut response = (status, Json(body)).into_response();
+        if let Some(seconds) = retry_after_seconds {
+            let value =
+                HeaderValue::from_str(&seconds.to_string()).expect("Retry-After must be valid");
+            response.headers_mut().insert(RETRY_AFTER, value);
+        }
+        response
     }
 }
 

--- a/next-plaid-api/src/handlers/documents.rs
+++ b/next-plaid-api/src/handlers/documents.rs
@@ -54,6 +54,20 @@ fn max_queued_tasks_per_index() -> usize {
 static REPAIR_LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Arc<std::sync::Mutex<()>>>>> =
     OnceLock::new();
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IndexDbSyncCheck {
+    pub(crate) in_sync: bool,
+    pub(crate) index_count: usize,
+    pub(crate) db_count: usize,
+    pub(crate) check_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PreflightRepairMetrics {
+    pub(crate) repaired: bool,
+    pub(crate) repair_ms: u64,
+}
+
 /// Get or create a repair lock for the given index path.
 /// Used to serialize repair operations on a specific index.
 fn get_repair_lock(index_path: &str) -> Arc<std::sync::Mutex<()>> {
@@ -75,7 +89,7 @@ fn get_repair_lock(index_path: &str) -> Arc<std::sync::Mutex<()>> {
 /// Returns Ok(true) if repair was performed, Ok(false) if no repair needed.
 ///
 /// Thread-safety: Uses a per-index lock to prevent concurrent repair operations.
-fn repair_index_db_sync(index_path: &str) -> Result<bool, String> {
+pub(crate) fn repair_index_db_sync(index_path: &str) -> Result<bool, String> {
     // Acquire per-index repair lock to prevent concurrent repairs
     let repair_lock = get_repair_lock(index_path);
     let _guard = repair_lock
@@ -159,11 +173,84 @@ fn repair_index_db_sync(index_path: &str) -> Result<bool, String> {
     Ok(true)
 }
 
+fn verify_index_db_sync(index_path: &str) -> Result<IndexDbSyncCheck, String> {
+    let check_start = std::time::Instant::now();
+    let path = std::path::Path::new(index_path);
+    let has_index_metadata = path.join("metadata.json").exists();
+    let has_metadata_db = filtering::exists(index_path);
+    let index_count = if has_index_metadata {
+        Metadata::load_from_path(path)
+            .map_err(|error| format!("Failed to load index metadata: {}", error))?
+            .num_documents
+    } else {
+        0
+    };
+    let db_count = if has_metadata_db {
+        filtering::count(index_path)
+            .map_err(|error| format!("Failed to get DB count: {}", error))?
+    } else {
+        0
+    };
+    let in_sync = match (has_index_metadata, has_metadata_db) {
+        (true, true) => index_count == db_count,
+        (true, false) => index_count == 0,
+        (false, true) => db_count == 0,
+        (false, false) => true,
+    };
+    Ok(IndexDbSyncCheck {
+        in_sync,
+        index_count,
+        db_count,
+        check_ms: check_start.elapsed().as_millis() as u64,
+    })
+}
+
+pub(crate) async fn verify_index_db_sync_locked(
+    index_path: &str,
+) -> Result<IndexDbSyncCheck, String> {
+    let index_path_owned = index_path.to_string();
+    task::spawn_blocking(move || verify_index_db_sync(&index_path_owned))
+        .await
+        .map_err(|error| format!("Index/DB sync verification worker panicked: {}", error))?
+}
+
+fn run_preflight_repair(index_path: &str) -> Result<PreflightRepairMetrics, String> {
+    let repair_start = std::time::Instant::now();
+    let repaired = repair_index_db_sync(index_path)?;
+    Ok(PreflightRepairMetrics {
+        repaired,
+        repair_ms: repair_start.elapsed().as_millis() as u64,
+    })
+}
+
+pub(crate) async fn run_preflight_repair_locked(
+    index_path: &str,
+) -> Result<PreflightRepairMetrics, String> {
+    let index_path_owned = index_path.to_string();
+    task::spawn_blocking(move || run_preflight_repair(&index_path_owned))
+        .await
+        .map_err(|error| format!("Index/DB sync repair worker panicked: {}", error))?
+}
+
+fn build_update_config(stored_config: &IndexConfigStored) -> UpdateConfig {
+    let default_update_config = UpdateConfig::default();
+    UpdateConfig {
+        batch_size: stored_config.batch_size,
+        kmeans_niters: default_update_config.kmeans_niters,
+        max_points_per_centroid: default_update_config.max_points_per_centroid,
+        n_samples_kmeans: default_update_config.n_samples_kmeans,
+        seed: stored_config.seed.unwrap_or(default_update_config.seed),
+        start_from_scratch: stored_config.start_from_scratch,
+        buffer_size: default_update_config.buffer_size,
+        force_cpu: default_update_config.force_cpu,
+    }
+}
+
 // --- Batch Collection ---
 
 /// Get the maximum number of documents to batch together before processing.
 /// Configurable via MAX_BATCH_DOCUMENTS env var (default: 300).
-fn max_batch_documents() -> usize {
+pub(crate) fn max_batch_documents() -> usize {
     static VALUE: OnceLock<usize> = OnceLock::new();
     *VALUE.get_or_init(|| {
         std::env::var("MAX_BATCH_DOCUMENTS")
@@ -194,6 +281,50 @@ struct BatchItem {
     metadata: Vec<serde_json::Value>,
 }
 
+pub(crate) struct PreparedUpdateWithEncodingBatch {
+    pub(crate) embeddings: Vec<Array2<f32>>,
+    pub(crate) metadata: Vec<serde_json::Value>,
+}
+
+fn validate_update_with_encoding_request(req: &UpdateWithEncodingRequest) -> ApiResult<()> {
+    if req.documents.is_empty() {
+        return Err(ApiError::BadRequest(
+            "At least one document is required".to_string(),
+        ));
+    }
+
+    if req.metadata.len() != req.documents.len() {
+        return Err(ApiError::BadRequest(format!(
+            "Metadata length ({}) must match documents length ({})",
+            req.metadata.len(),
+            req.documents.len()
+        )));
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn prepare_update_with_encoding_batch(
+    state: Arc<AppState>,
+    req: UpdateWithEncodingRequest,
+) -> ApiResult<PreparedUpdateWithEncodingBatch> {
+    validate_update_with_encoding_request(&req)?;
+
+    let UpdateWithEncodingRequest {
+        documents,
+        metadata,
+        pool_factor,
+    } = req;
+
+    let embeddings =
+        encode_texts_internal(state, &documents, InputType::Document, pool_factor).await?;
+
+    Ok(PreparedUpdateWithEncodingBatch {
+        embeddings,
+        metadata,
+    })
+}
+
 /// Handle to a batch queue for an index.
 struct BatchQueue {
     sender: mpsc::Sender<BatchItem>,
@@ -202,28 +333,14 @@ struct BatchQueue {
 /// Global registry of batch queues per index.
 static BATCH_QUEUES: OnceLock<std::sync::Mutex<HashMap<String, BatchQueue>>> = OnceLock::new();
 
-/// Global registry to manage locks per index name.
+/// Global registry to manage locks per index path.
 /// We use tokio::sync::Mutex to allow tasks to wait asynchronously without blocking threads.
 static INDEX_LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
 
-/// Global registry to manage semaphores per index name.
+/// Global registry to manage semaphores per index path.
 /// Limits the number of queued background tasks to prevent resource exhaustion.
 static INDEX_SEMAPHORES: OnceLock<std::sync::Mutex<HashMap<String, Arc<Semaphore>>>> =
     OnceLock::new();
-
-/// Helper to get (or create) an async mutex for a specific index.
-/// Used to serialize updates to a specific index.
-/// Uses the index name as key (assumes unique names within a single server instance).
-pub fn get_index_lock(name: &str) -> Arc<Mutex<()>> {
-    let locks: &std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>> =
-        INDEX_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    let mut map = locks
-        .lock()
-        .expect("INDEX_LOCKS mutex poisoned - a thread panicked while holding this lock");
-    map.entry(name.to_string())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .clone()
-}
 
 /// Helper to get (or create) an async mutex for a specific index path.
 /// Used when full path isolation is needed (e.g., in tests with separate temp directories).
@@ -238,15 +355,21 @@ pub fn get_index_lock_by_path(path: &str) -> Arc<Mutex<()>> {
         .clone()
 }
 
-/// Helper to get (or create) a semaphore for a specific index name.
+pub(crate) fn get_index_write_lock(state: &AppState, name: &str) -> Arc<Mutex<()>> {
+    let path_str = state.index_path(name).to_string_lossy().to_string();
+    get_index_lock_by_path(&path_str)
+}
+
+/// Helper to get (or create) a semaphore for a specific index path.
 /// The semaphore limits queued background tasks to prevent unbounded growth.
-fn get_index_semaphore(name: &str) -> Arc<Semaphore> {
+fn get_index_semaphore(state: &AppState, name: &str) -> Arc<Semaphore> {
+    let path_str = state.index_path(name).to_string_lossy().to_string();
     let sems: &std::sync::Mutex<HashMap<String, Arc<Semaphore>>> =
         INDEX_SEMAPHORES.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
     let mut map = sems
         .lock()
         .expect("INDEX_SEMAPHORES mutex poisoned - a thread panicked while holding this lock");
-    map.entry(name.to_string())
+    map.entry(path_str)
         .or_insert_with(|| Arc::new(Semaphore::new(max_queued_tasks_per_index())))
         .clone()
 }
@@ -348,12 +471,175 @@ async fn batch_worker(
 }
 
 /// Metrics returned from the blocking batch processing.
-struct BatchMetrics {
+pub(crate) struct BatchMetrics {
     index_update_ms: u64,
     metadata_update_ms: u64,
     first_doc_id: Option<i64>,
     last_doc_id: Option<i64>,
     evicted_count: usize,
+}
+
+fn run_embeddings_batch_after_repair_blocking(
+    index_name: String,
+    path_str: String,
+    state: Arc<AppState>,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+) -> Result<BatchMetrics, String> {
+    let stored_config = state
+        .get_index_config(&index_name)
+        .ok_or_else(|| format!("Failed to load config for index '{}'", index_name))?;
+
+    let fts_tokenizer =
+        crate::models::parse_fts_tokenizer(&stored_config.fts_tokenizer).unwrap_or_default();
+    let index_config = IndexConfig {
+        nbits: stored_config.nbits,
+        batch_size: stored_config.batch_size,
+        seed: stored_config.seed,
+        start_from_scratch: stored_config.start_from_scratch,
+        fts_tokenizer: fts_tokenizer.clone(),
+        ..Default::default()
+    };
+    let update_config = build_update_config(&stored_config);
+
+    let index_update_start = std::time::Instant::now();
+    let index_result =
+        MmapIndex::update_or_create(&embeddings, &path_str, &index_config, &update_config);
+
+    let (mut index, doc_ids) = match index_result {
+        Ok((idx, ids)) => (idx, ids),
+        Err(error) => {
+            return Err(format!("Index update failed: {}", error));
+        }
+    };
+    let index_update_ms = index_update_start.elapsed().as_millis() as u64;
+
+    let first_doc_id = doc_ids.first().copied();
+    let last_doc_id = doc_ids.last().copied();
+
+    let metadata_update_start = std::time::Instant::now();
+    let db_existed = filtering::exists(&path_str);
+    let db_result = if db_existed {
+        filtering::update(&path_str, &metadata, &doc_ids)
+    } else {
+        filtering::create(&path_str, &metadata, &doc_ids)
+    };
+
+    if let Err(error) = db_result {
+        if let Err(rollback_error) = index.delete_with_options(&doc_ids, false) {
+            tracing::error!(
+                index = %index_name,
+                error = %rollback_error,
+                operation = "rollback",
+                "update.rollback.failed"
+            );
+        }
+        return Err(format!("Failed to update metadata: {}", error));
+    }
+
+    if let Err(error) =
+        next_plaid::text_search::index(&path_str, &metadata, &doc_ids, &fts_tokenizer)
+    {
+        tracing::warn!(
+            index = %index_name,
+            error = %error,
+            "update.fts_index.failed"
+        );
+    }
+    let metadata_update_ms = metadata_update_start.elapsed().as_millis() as u64;
+
+    let evicted_count = if let Some(max_docs) = stored_config.max_documents {
+        match evict_oldest_documents(&mut index, max_docs) {
+            Ok(count) => count,
+            Err(error) => {
+                tracing::warn!(
+                    index = %index_name,
+                    error = %error,
+                    max_documents = max_docs,
+                    "update.eviction.failed"
+                );
+                0
+            }
+        }
+    } else {
+        0
+    };
+
+    state.unload_index(&index_name);
+    let reloaded_index =
+        MmapIndex::load(&path_str).map_err(|error| format!("Failed to load index: {}", error))?;
+    state.register_index(&index_name, reloaded_index);
+
+    Ok(BatchMetrics {
+        index_update_ms,
+        metadata_update_ms,
+        first_doc_id,
+        last_doc_id,
+        evicted_count,
+    })
+}
+
+async fn run_embeddings_batch_after_repair_locked(
+    index_name: &str,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+    state: &Arc<AppState>,
+) -> Result<BatchMetrics, String> {
+    let name_inner = index_name.to_string();
+    let state_clone = state.clone();
+    let path_str = state.index_path(index_name).to_string_lossy().to_string();
+    task::spawn_blocking(move || {
+        run_embeddings_batch_after_repair_blocking(
+            name_inner,
+            path_str,
+            state_clone,
+            embeddings,
+            metadata,
+        )
+    })
+    .await
+    .map_err(|error| format!("Update batch worker panicked: {}", error))?
+}
+
+async fn run_embeddings_batch_with_preflight_locked(
+    index_name: &str,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+    state: &Arc<AppState>,
+) -> Result<BatchMetrics, String> {
+    let path_str = state.index_path(index_name).to_string_lossy().to_string();
+    run_preflight_repair_locked(&path_str).await?;
+    run_embeddings_batch_after_repair_locked(index_name, embeddings, metadata, state).await
+}
+
+async fn run_embeddings_batch(
+    index_name: &str,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+    state: &Arc<AppState>,
+) -> Result<BatchMetrics, String> {
+    let lock = get_index_write_lock(state, index_name);
+    let _guard = lock.lock().await;
+
+    commit_embeddings_batch_locked(index_name, embeddings, metadata, state).await
+}
+
+pub(crate) async fn commit_embeddings_batch_locked(
+    index_name: &str,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+    state: &Arc<AppState>,
+) -> Result<BatchMetrics, String> {
+    run_embeddings_batch_with_preflight_locked(index_name, embeddings, metadata, state).await
+}
+
+pub(crate) async fn commit_embeddings_batch_after_repair_locked(
+    index_name: &str,
+    embeddings: Vec<Array2<f32>>,
+    metadata: Vec<serde_json::Value>,
+    state: &Arc<AppState>,
+) -> Result<BatchMetrics, String> {
+    run_embeddings_batch_after_repair_locked(index_name, embeddings, metadata, state).await
 }
 
 /// Process a batch of documents for the given index.
@@ -365,130 +651,12 @@ async fn process_batch(
 ) {
     let doc_count = embeddings.len();
     let start = std::time::Instant::now();
-
-    let name_inner = index_name.to_string();
-    let state_clone = state.clone();
-    let path_str = state.index_path(index_name).to_string_lossy().to_string();
-
-    // Acquire per-index lock using full path for isolation
-    let lock = get_index_lock_by_path(&path_str);
-    let _guard = lock.lock().await;
-
-    // Run heavy work in blocking thread
-    let result = task::spawn_blocking(move || -> Result<BatchMetrics, String> {
-        // Load stored config from the shared state cache. The config update endpoint
-        // writes through this cache first, so background updates should read from the
-        // same source of truth instead of racing a fresh config.json reopen.
-        let stored_config = state_clone
-            .get_index_config(&name_inner)
-            .ok_or_else(|| format!("Failed to load config for index '{}'", name_inner))?;
-
-        // Check and automatically repair sync issues between index and DB
-        if let Err(e) = repair_index_db_sync(&path_str) {
-            return Err(format!("Index/DB sync repair failed: {}", e));
-        }
-
-        // Build IndexConfig
-        let fts_tokenizer =
-            crate::models::parse_fts_tokenizer(&stored_config.fts_tokenizer).unwrap_or_default();
-        let index_config = IndexConfig {
-            nbits: stored_config.nbits,
-            batch_size: stored_config.batch_size,
-            seed: stored_config.seed,
-            start_from_scratch: stored_config.start_from_scratch,
-            fts_tokenizer: fts_tokenizer.clone(),
-            ..Default::default()
-        };
-        let update_config = UpdateConfig::default();
-
-        // STEP 1: Update vector index FIRST
-        let index_update_start = std::time::Instant::now();
-        let index_result =
-            MmapIndex::update_or_create(&embeddings, &path_str, &index_config, &update_config);
-
-        let (mut index, doc_ids) = match index_result {
-            Ok((idx, ids)) => (idx, ids),
-            Err(e) => {
-                return Err(format!("Index update failed: {}", e));
-            }
-        };
-        let index_update_ms = index_update_start.elapsed().as_millis() as u64;
-
-        let first_doc_id = doc_ids.first().copied();
-        let last_doc_id = doc_ids.last().copied();
-
-        // STEP 2: Update metadata DB using the ACTUAL doc_ids from the index
-        let metadata_update_start = std::time::Instant::now();
-        let db_existed = filtering::exists(&path_str);
-        let db_result = if db_existed {
-            filtering::update(&path_str, &metadata, &doc_ids)
-        } else {
-            filtering::create(&path_str, &metadata, &doc_ids)
-        };
-
-        if let Err(e) = db_result {
-            // ROLLBACK: Remove the documents we just added to the index
-            if let Err(rollback_err) = index.delete_with_options(&doc_ids, false) {
-                tracing::error!(
-                    index = %name_inner,
-                    error = %rollback_err,
-                    operation = "rollback",
-                    "update.rollback.failed"
-                );
-            }
-            return Err(format!("Failed to update metadata: {}", e));
-        }
-
-        // STEP 3: Index metadata into FTS5 for full-text / hybrid search
-        if let Err(e) =
-            next_plaid::text_search::index(&path_str, &metadata, &doc_ids, &fts_tokenizer)
-        {
-            tracing::warn!(
-                index = %name_inner,
-                error = %e,
-                "update.fts_index.failed"
-            );
-            // Non-fatal: FTS is optional, semantic search still works
-        }
-        let metadata_update_ms = metadata_update_start.elapsed().as_millis() as u64;
-
-        // Eviction: Check if over max_documents limit
-        let evicted_count = if let Some(max_docs) = stored_config.max_documents {
-            match evict_oldest_documents(&mut index, max_docs) {
-                Ok(count) => count,
-                Err(e) => {
-                    tracing::warn!(
-                        index = %name_inner,
-                        error = %e,
-                        max_documents = max_docs,
-                        "update.eviction.failed"
-                    );
-                    0
-                }
-            }
-        } else {
-            0
-        };
-
-        // Reload State
-        state_clone.unload_index(&name_inner);
-        let idx = MmapIndex::load(&path_str).map_err(|e| format!("Failed to load index: {}", e))?;
-        state_clone.register_index(&name_inner, idx);
-
-        Ok(BatchMetrics {
-            index_update_ms,
-            metadata_update_ms,
-            first_doc_id,
-            last_doc_id,
-            evicted_count,
-        })
-    })
-    .await;
+    let result = run_embeddings_batch(index_name, embeddings, metadata, state).await;
 
     let total_ms = start.elapsed().as_millis() as u64;
 
     match result {
-        Ok(Ok(metrics)) => {
+        Ok(metrics) => {
             tracing::info!(
                 index = %index_name,
                 num_documents = doc_count,
@@ -510,15 +678,6 @@ async fn process_batch(
                     "update.batch.slow"
                 );
             }
-        }
-        Ok(Err(e)) => {
-            tracing::error!(
-                index = %index_name,
-                num_documents = doc_count,
-                error = %e,
-                total_ms = total_ms,
-                "update.batch.failed"
-            );
         }
         Err(e) => {
             tracing::error!(
@@ -798,7 +957,7 @@ async fn process_delete_batch(
     let path_str = state.index_path(index_name).to_string_lossy().to_string();
 
     // Acquire per-index lock using full path for isolation
-    let lock = get_index_lock_by_path(&path_str);
+    let lock = get_index_write_lock(state, index_name);
     let _guard = lock.lock().await;
 
     // Run in blocking thread
@@ -939,7 +1098,7 @@ pub async fn create_index(
     }
 
     // Lock mainly to prevent race condition on file existence check
-    let lock = get_index_lock(&req.name);
+    let lock = get_index_write_lock(&state, &req.name);
     let _guard = lock.lock().await;
 
     // Check if index already exists (either declared or populated)
@@ -1146,10 +1305,10 @@ pub async fn add_documents(
     let name_clone = name.clone();
     let state_clone = state.clone();
     let metadata = req.metadata;
-    let lock = get_index_lock(&name);
+    let lock = get_index_write_lock(&state, &name);
 
     // Acquire semaphore permit to limit queued tasks
-    let semaphore = get_index_semaphore(&name);
+    let semaphore = get_index_semaphore(&state, &name);
     let permit = semaphore.clone().try_acquire_owned().map_err(|_| {
         ApiError::ServiceUnavailable(format!(
             "Update queue full for index '{}'. Max {} pending updates. Retry later.",
@@ -1366,7 +1525,7 @@ pub async fn delete_index(
 ) -> ApiResult<Json<DeleteIndexResponse>> {
     let trace_id = trace_id.map(|t| t.0).unwrap_or_default();
 
-    let lock = get_index_lock(&name);
+    let lock = get_index_write_lock(&state, &name);
     let _guard = lock.lock().await;
 
     // Stop background workers by removing their queue entries.
@@ -1387,12 +1546,10 @@ pub async fn delete_index(
     state.unload_index(&name);
     state.invalidate_config_cache(&name);
 
-    // Drop the lock guard before removing the directory, so the async mutex
-    // isn't held while we delete (similar to colgrep's drop(lock) pattern).
-    drop(_guard);
-
-    // Delete from disk. On Windows, recently dropped mmap/file handles can take a
-    // brief moment to release after unload, so retry a few times before failing.
+    // Keep the path lock until directory removal completes so project_sync
+    // replace/rollback work cannot interleave with delete_index on the same path.
+    // On Windows, recently dropped mmap/file handles can take a brief moment to
+    // release after unload, so retry a few times before failing.
     let path = state.index_path(&name);
     if path.exists() {
         let mut last_err = None;
@@ -1564,7 +1721,7 @@ pub async fn update_index_config(
 ) -> ApiResult<Json<UpdateIndexConfigResponse>> {
     let trace_id = trace_id.map(|t| t.0).unwrap_or_default();
 
-    let lock = get_index_lock(&name);
+    let lock = get_index_write_lock(&state, &name);
     let _guard = lock.lock().await;
 
     // Load existing config from cache (or disk if not cached)
@@ -1639,21 +1796,7 @@ pub async fn update_index_with_encoding(
         return Err(ApiError::IndexNotDeclared(name));
     }
 
-    // Validate input
-    if req.documents.is_empty() {
-        return Err(ApiError::BadRequest(
-            "At least one document is required".to_string(),
-        ));
-    }
-
-    // Validate metadata length
-    if req.metadata.len() != req.documents.len() {
-        return Err(ApiError::BadRequest(format!(
-            "Metadata length ({}) must match documents length ({})",
-            req.metadata.len(),
-            req.documents.len()
-        )));
-    }
+    validate_update_with_encoding_request(&req)?;
 
     // Get or create the batch queue for this index FIRST
     let sender = get_or_create_batch_queue(&name, state.clone());
@@ -1672,20 +1815,13 @@ pub async fn update_index_with_encoding(
     })?;
 
     // Now encode - we have a guaranteed slot in the batch queue
-    let embeddings = encode_texts_internal(
-        state.clone(),
-        &req.documents,
-        InputType::Document,
-        req.pool_factor,
-    )
-    .await?;
-
-    let doc_count = embeddings.len();
+    let prepared = prepare_update_with_encoding_batch(state.clone(), req).await?;
+    let doc_count = prepared.embeddings.len();
 
     // Create batch item
     let batch_item = BatchItem {
-        embeddings,
-        metadata: req.metadata,
+        embeddings: prepared.embeddings,
+        metadata: prepared.metadata,
     };
 
     // Send using the reserved permit - this is guaranteed to succeed
@@ -1699,4 +1835,81 @@ pub async fn update_index_with_encoding(
 
     // Immediate Response
     Ok((StatusCode::ACCEPTED, Json("Update queued for batching")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_index_lock_by_path, get_index_semaphore, get_index_write_lock};
+    use crate::state::{ApiConfig, AppState};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[cfg(feature = "model")]
+    fn build_test_state(index_dir: std::path::PathBuf) -> AppState {
+        AppState::with_model_pool(
+            ApiConfig {
+                index_dir,
+                default_top_k: 10,
+            },
+            None,
+            None,
+        )
+    }
+
+    #[cfg(not(feature = "model"))]
+    fn build_test_state(index_dir: std::path::PathBuf) -> AppState {
+        AppState::new(ApiConfig {
+            index_dir,
+            default_top_k: 10,
+        })
+    }
+
+    #[test]
+    fn get_index_write_lock_uses_same_path_key_as_project_sync() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = build_test_state(temp_dir.path().to_path_buf());
+        let path_str = state.index_path("shared").to_string_lossy().to_string();
+
+        let documents_lock = get_index_write_lock(&state, "shared");
+        let project_sync_lock = get_index_lock_by_path(&path_str);
+
+        assert!(Arc::ptr_eq(&documents_lock, &project_sync_lock));
+    }
+
+    #[test]
+    fn get_index_write_lock_distinguishes_same_name_in_different_roots() {
+        let temp_dir_a = TempDir::new().expect("temp dir should exist");
+        let temp_dir_b = TempDir::new().expect("temp dir should exist");
+        let state_a = build_test_state(temp_dir_a.path().to_path_buf());
+        let state_b = build_test_state(temp_dir_b.path().to_path_buf());
+
+        let lock_a = get_index_write_lock(&state_a, "shared");
+        let lock_b = get_index_write_lock(&state_b, "shared");
+
+        assert!(!Arc::ptr_eq(&lock_a, &lock_b));
+    }
+
+    #[test]
+    fn get_index_semaphore_uses_same_path_key_within_root() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = build_test_state(temp_dir.path().to_path_buf());
+
+        let semaphore_a = get_index_semaphore(&state, "shared");
+        let semaphore_b = get_index_semaphore(&state, "shared");
+
+        assert!(Arc::ptr_eq(&semaphore_a, &semaphore_b));
+    }
+
+    #[test]
+    fn get_index_semaphore_distinguishes_same_name_in_different_roots() {
+        let temp_dir_a = TempDir::new().expect("temp dir should exist");
+        let temp_dir_b = TempDir::new().expect("temp dir should exist");
+        let state_a = build_test_state(temp_dir_a.path().to_path_buf());
+        let state_b = build_test_state(temp_dir_b.path().to_path_buf());
+
+        let semaphore_a = get_index_semaphore(&state_a, "shared");
+        let semaphore_b = get_index_semaphore(&state_b, "shared");
+
+        assert!(!Arc::ptr_eq(&semaphore_a, &semaphore_b));
+    }
 }

--- a/next-plaid-api/src/handlers/mod.rs
+++ b/next-plaid-api/src/handlers/mod.rs
@@ -3,11 +3,13 @@
 pub mod documents;
 pub mod encode;
 pub mod metadata;
+pub mod project_sync;
 pub mod rerank;
 pub mod search;
 
 pub use documents::*;
 pub use encode::*;
 pub use metadata::*;
+pub use project_sync::*;
 pub use rerank::*;
 pub use search::*;

--- a/next-plaid-api/src/handlers/project_sync.rs
+++ b/next-plaid-api/src/handlers/project_sync.rs
@@ -1,0 +1,2562 @@
+//! Staged project sync upload handlers for MCP project uploads.
+
+use std::collections::{HashMap, HashSet};
+use std::fs as std_fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::{
+    body::Body,
+    extract::{rejection::JsonRejection, Path as AxumPath, State},
+    http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE},
+        HeaderMap,
+    },
+    Json,
+};
+use futures_util::StreamExt;
+use next_plaid::{filtering, MmapIndex};
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+use tokio::task;
+use uuid::Uuid;
+
+use crate::error::{ApiError, ApiResult};
+use crate::handlers::documents::{
+    commit_embeddings_batch_after_repair_locked, get_index_write_lock, max_batch_documents,
+    prepare_update_with_encoding_batch, repair_index_db_sync, run_preflight_repair_locked,
+    verify_index_db_sync_locked, IndexDbSyncCheck,
+};
+use crate::models::{
+    ErrorResponse, ProjectSyncCreateJobRequest, ProjectSyncCreateJobResponse,
+    ProjectSyncJobResponse, ProjectSyncJobStatus, UpdateWithEncodingRequest,
+};
+use crate::state::AppState;
+use crate::PrettyJson;
+
+const PROJECT_SYNC_CONTENT_TYPE: &str = "application/x-ndjson";
+const DEFAULT_MAX_INGEST_REQUEST_BYTES: u64 = 100 * 1024 * 1024;
+const DEFAULT_MAX_PENDING_INGEST_BYTES: u64 = 1024 * 1024 * 1024;
+const RETRY_AFTER_SECONDS_HINT: u64 = 5;
+const PROJECT_SYNC_UPLOAD_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const PROJECT_SYNC_UPLOAD_IDLE_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const PROJECT_SYNC_STALE_JOB_TIMEOUT_MS: u64 = 30 * 60 * 1000;
+const PROJECT_SYNC_UPLOAD_PROGRESS_UPDATE_INTERVAL_MS: u64 = 5 * 1000;
+const PROJECT_SYNC_UPLOAD_PROGRESS_UPDATE_BYTES: u64 = 1024 * 1024;
+
+static CREATE_JOB_LOCK: OnceLock<Arc<Mutex<()>>> = OnceLock::new();
+static JOB_LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Weak<Mutex<()>>>>> = OnceLock::new();
+static PENDING_BYTES_BY_ROOT: OnceLock<std::sync::Mutex<HashMap<String, u64>>> = OnceLock::new();
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct ProjectSyncJobManifest {
+    job_id: String,
+    index_name: String,
+    status: ProjectSyncJobStatus,
+    declared_bytes: u64,
+    uploaded_bytes: u64,
+    content_type: String,
+    reserved_bytes: bool,
+    error: Option<String>,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectSyncUploadRecord {
+    path: String,
+    content: String,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectSyncSpoolState {
+    final_bytes: Option<u64>,
+    temp_bytes: Option<u64>,
+}
+
+impl ProjectSyncSpoolState {
+    fn has_any_spool(self) -> bool {
+        self.final_bytes.is_some() || self.temp_bytes.is_some()
+    }
+
+    fn has_exact_final_only(self, expected_bytes: u64) -> bool {
+        self.final_bytes == Some(expected_bytes) && self.temp_bytes.is_none()
+    }
+
+    fn has_exact_temp_only(self, expected_bytes: u64) -> bool {
+        self.temp_bytes == Some(expected_bytes) && self.final_bytes.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectSyncSpoolFix {
+    None,
+    PromoteTempToFinal,
+    DeleteAll,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProjectSyncRecoveryAction {
+    Persist {
+        manifest: ProjectSyncJobManifest,
+        requeue: bool,
+        spool_fix: ProjectSyncSpoolFix,
+    },
+    Quarantine {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectSyncRecoveredJob {
+    reserved_bytes: u64,
+    requeue: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectSyncUploadResult {
+    Uploaded { uploaded_bytes: u64 },
+    Cancelled,
+}
+
+async fn verify_project_sync_postflight_locked(
+    index_path: &str,
+) -> Result<IndexDbSyncCheck, String> {
+    verify_index_db_sync_locked(index_path).await
+}
+
+fn repair_project_sync_postflight_locked(index_path: &str) -> Result<bool, String> {
+    repair_index_db_sync(index_path)
+}
+
+async fn run_project_sync_postflight_locked(index_path: &str) -> ApiResult<bool> {
+    let postflight_check = verify_project_sync_postflight_locked(index_path)
+        .await
+        .map_err(|error| {
+            ApiError::Internal(format!("Index/DB sync postflight check failed: {}", error))
+        })?;
+    if postflight_check.in_sync {
+        return Ok(false);
+    }
+
+    repair_project_sync_postflight_locked(index_path).map_err(|error| {
+        ApiError::Internal(format!("Index/DB sync postflight repair failed: {}", error))
+    })?;
+
+    let postflight_verify = verify_project_sync_postflight_locked(index_path)
+        .await
+        .map_err(|error| {
+            ApiError::Internal(format!("Index/DB sync re-verify failed: {}", error))
+        })?;
+    if !postflight_verify.in_sync {
+        return Err(ApiError::Internal(format!(
+            "Index/DB mismatch persists after postflight repair: index_count={} db_count={}",
+            postflight_verify.index_count, postflight_verify.db_count
+        )));
+    }
+
+    Ok(true)
+}
+
+pub(crate) fn max_ingest_request_bytes() -> u64 {
+    static VALUE: OnceLock<u64> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("MAX_INGEST_REQUEST_BYTES")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_MAX_INGEST_REQUEST_BYTES)
+    })
+}
+
+fn max_pending_ingest_bytes() -> u64 {
+    static VALUE: OnceLock<u64> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("MAX_PENDING_INGEST_BYTES")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_MAX_PENDING_INGEST_BYTES)
+    })
+}
+
+fn create_job_lock() -> Arc<Mutex<()>> {
+    CREATE_JOB_LOCK
+        .get_or_init(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn job_lock(job_id: &str) -> Arc<Mutex<()>> {
+    let locks = JOB_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut guard = locks
+        .lock()
+        .expect("JOB_LOCKS mutex poisoned - a task panicked while holding this lock");
+    if let Some(lock) = guard.get(job_id).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    guard.retain(|_, lock| lock.strong_count() > 0);
+    let lock = Arc::new(Mutex::new(()));
+    guard.insert(job_id.to_string(), Arc::downgrade(&lock));
+    lock
+}
+
+fn pending_bytes_map() -> &'static std::sync::Mutex<HashMap<String, u64>> {
+    PENDING_BYTES_BY_ROOT.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn pending_bytes_key(state: &AppState) -> String {
+    project_sync_jobs_path(state).to_string_lossy().to_string()
+}
+
+fn pending_ingest_bytes(state: &AppState) -> u64 {
+    let guard = pending_bytes_map()
+        .lock()
+        .expect("PENDING_BYTES_BY_ROOT mutex poisoned");
+    guard.get(&pending_bytes_key(state)).copied().unwrap_or(0)
+}
+
+fn set_pending_ingest_bytes(state: &AppState, bytes: u64) {
+    let mut guard = pending_bytes_map()
+        .lock()
+        .expect("PENDING_BYTES_BY_ROOT mutex poisoned");
+    guard.insert(pending_bytes_key(state), bytes);
+}
+
+fn reserve_pending_ingest_bytes(state: &AppState, bytes: u64) {
+    let mut guard = pending_bytes_map()
+        .lock()
+        .expect("PENDING_BYTES_BY_ROOT mutex poisoned");
+    let entry = guard.entry(pending_bytes_key(state)).or_insert(0);
+    *entry = entry.saturating_add(bytes);
+}
+
+fn release_pending_ingest_bytes(state: &AppState, bytes: u64) {
+    let mut guard = pending_bytes_map()
+        .lock()
+        .expect("PENDING_BYTES_BY_ROOT mutex poisoned");
+    let entry = guard.entry(pending_bytes_key(state)).or_insert(0);
+    *entry = entry.saturating_sub(bytes);
+}
+
+fn now_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn project_sync_jobs_path(state: &AppState) -> PathBuf {
+    state.config.index_dir.join("_project_sync_jobs")
+}
+
+fn job_dir(state: &AppState, job_id: &str) -> PathBuf {
+    project_sync_jobs_path(state).join(job_id)
+}
+
+fn manifest_path(state: &AppState, job_id: &str) -> PathBuf {
+    job_dir(state, job_id).join("manifest.json")
+}
+
+fn spool_path(state: &AppState, job_id: &str) -> PathBuf {
+    job_dir(state, job_id).join("spool.ndjson")
+}
+
+fn temp_spool_path(state: &AppState, job_id: &str) -> PathBuf {
+    job_dir(state, job_id).join("spool.ndjson.tmp")
+}
+
+fn snapshot_path(state: &AppState, job_id: &str) -> PathBuf {
+    job_dir(state, job_id).join("index_snapshot")
+}
+
+fn sanitize_marker_segment(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => character,
+            _ => '_',
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "index".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn dirty_marker_path(state: &AppState, index_name: &str, job_id: &str) -> PathBuf {
+    project_sync_jobs_path(state).join("_dirty").join(format!(
+        "{}-{}.json",
+        sanitize_marker_segment(index_name),
+        job_id
+    ))
+}
+
+fn manifest_to_response(manifest: &ProjectSyncJobManifest) -> ProjectSyncJobResponse {
+    ProjectSyncJobResponse {
+        job_id: manifest.job_id.clone(),
+        index_name: manifest.index_name.clone(),
+        status: manifest.status,
+        declared_bytes: manifest.declared_bytes,
+        uploaded_bytes: manifest.uploaded_bytes,
+        content_type: manifest.content_type.clone(),
+        error: manifest.error.clone(),
+    }
+}
+
+fn is_terminal_status(status: ProjectSyncJobStatus) -> bool {
+    matches!(
+        status,
+        ProjectSyncJobStatus::Completed
+            | ProjectSyncJobStatus::Failed
+            | ProjectSyncJobStatus::Cancelled
+            | ProjectSyncJobStatus::Expired
+    )
+}
+
+fn is_expirable_status(status: ProjectSyncJobStatus) -> bool {
+    matches!(
+        status,
+        ProjectSyncJobStatus::Created
+            | ProjectSyncJobStatus::Uploading
+            | ProjectSyncJobStatus::Uploaded
+            | ProjectSyncJobStatus::Queued
+    )
+}
+
+fn is_project_sync_manifest_expired(manifest: &ProjectSyncJobManifest, now_ms: u64) -> bool {
+    is_expirable_status(manifest.status)
+        && now_ms.saturating_sub(manifest.updated_at_ms) > PROJECT_SYNC_STALE_JOB_TIMEOUT_MS
+}
+
+fn project_sync_expired_message() -> String {
+    format!(
+        "project_sync job expired after {} seconds without progress",
+        PROJECT_SYNC_STALE_JOB_TIMEOUT_MS / 1000
+    )
+}
+
+fn is_cancellation_requested(status: ProjectSyncJobStatus) -> bool {
+    matches!(
+        status,
+        ProjectSyncJobStatus::Cancelling | ProjectSyncJobStatus::Cancelled
+    )
+}
+
+fn upload_cancelled_conflict(job_id: &str) -> ApiError {
+    ApiError::Conflict(format!(
+        "project_sync job '{}' was cancelled during upload",
+        job_id
+    ))
+}
+
+fn upload_completion_conflict(job_id: &str, status: ProjectSyncJobStatus) -> ApiError {
+    ApiError::Conflict(format!(
+        "project_sync job '{}' cannot accept upload completion from status {:?}",
+        job_id, status
+    ))
+}
+
+fn normalize_content_type(value: &str) -> &str {
+    value.split(';').next().map(str::trim).unwrap_or(value)
+}
+
+fn validate_project_sync_content_type(content_type: &str) -> ApiResult<()> {
+    let normalized = normalize_content_type(content_type);
+    if normalized != PROJECT_SYNC_CONTENT_TYPE {
+        return Err(ApiError::BadRequest(format!(
+            "project_sync content_type must be '{}', got '{}'",
+            PROJECT_SYNC_CONTENT_TYPE, content_type
+        )));
+    }
+    Ok(())
+}
+
+fn parse_content_length(headers: &HeaderMap) -> ApiResult<u64> {
+    let value = headers
+        .get(CONTENT_LENGTH)
+        .ok_or_else(|| ApiError::BadRequest("Missing Content-Length header".to_string()))?;
+    let text = value
+        .to_str()
+        .map_err(|error| ApiError::BadRequest(format!("Invalid Content-Length: {}", error)))?;
+    text.parse::<u64>()
+        .map_err(|error| ApiError::BadRequest(format!("Invalid Content-Length: {}", error)))
+}
+
+fn request_content_type(headers: &HeaderMap) -> ApiResult<String> {
+    let value = headers
+        .get(CONTENT_TYPE)
+        .ok_or_else(|| ApiError::BadRequest("Missing Content-Type header".to_string()))?;
+    value
+        .to_str()
+        .map(str::to_string)
+        .map_err(|error| ApiError::BadRequest(format!("Invalid Content-Type: {}", error)))
+}
+
+fn backlog_details(
+    required_bytes: u64,
+    pending_ingest_bytes: u64,
+    max_pending_ingest_bytes: u64,
+) -> serde_json::Value {
+    let available_bytes = max_pending_ingest_bytes.saturating_sub(pending_ingest_bytes);
+    serde_json::json!({
+        "required_bytes": required_bytes,
+        "available_bytes": available_bytes,
+        "pending_ingest_bytes": pending_ingest_bytes,
+        "max_pending_ingest_bytes": max_pending_ingest_bytes,
+        "retry_after_seconds_hint": RETRY_AFTER_SECONDS_HINT
+    })
+}
+
+fn content_too_large_details(
+    required_bytes: u64,
+    max_ingest_request_bytes: u64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "required_bytes": required_bytes,
+        "max_ingest_request_bytes": max_ingest_request_bytes
+    })
+}
+
+fn project_sync_upload_idle_timeout() -> Duration {
+    Duration::from_millis(PROJECT_SYNC_UPLOAD_IDLE_TIMEOUT_MS)
+}
+
+fn project_sync_upload_timeout_message(idle_timeout: Duration) -> String {
+    format!(
+        "project_sync upload timed out after {} seconds without receiving request body data",
+        idle_timeout.as_secs()
+    )
+}
+
+async fn read_manifest(state: &AppState, job_id: &str) -> ApiResult<ProjectSyncJobManifest> {
+    let path = manifest_path(state, job_id);
+    let contents = fs::read(&path).await.map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => ApiError::ProjectSyncJobNotFound(job_id.to_string()),
+        _ => ApiError::Internal(format!("Failed to read project_sync manifest: {}", error)),
+    })?;
+    serde_json::from_slice::<ProjectSyncJobManifest>(&contents)
+        .map_err(|error| ApiError::Internal(format!("Invalid project_sync manifest: {}", error)))
+}
+
+async fn write_manifest(state: &AppState, manifest: &ProjectSyncJobManifest) -> ApiResult<()> {
+    let dir = job_dir(state, &manifest.job_id);
+    fs::create_dir_all(&dir).await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to create project_sync job directory: {}",
+            error
+        ))
+    })?;
+
+    let path = manifest_path(state, &manifest.job_id);
+    let tmp_path = dir.join("manifest.json.tmp");
+    let bytes = serde_json::to_vec_pretty(manifest)
+        .map_err(|error| ApiError::Internal(format!("Failed to serialize manifest: {}", error)))?;
+
+    fs::write(&tmp_path, bytes)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to write manifest tmp: {}", error)))?;
+    fs::rename(&tmp_path, &path)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to persist manifest: {}", error)))
+}
+
+async fn update_manifest_status(
+    state: &AppState,
+    job_id: &str,
+    status: ProjectSyncJobStatus,
+    error: Option<String>,
+) -> ApiResult<ProjectSyncJobManifest> {
+    let mut manifest = read_manifest(state, job_id).await?;
+    manifest.status = status;
+    manifest.error = error;
+    manifest.updated_at_ms = now_epoch_ms();
+    write_manifest(state, &manifest).await?;
+    Ok(manifest)
+}
+
+async fn release_reserved_bytes(
+    state: &AppState,
+    manifest: &mut ProjectSyncJobManifest,
+) -> ApiResult<()> {
+    if manifest.reserved_bytes {
+        release_pending_ingest_bytes(state, manifest.declared_bytes);
+        manifest.reserved_bytes = false;
+    }
+    manifest.updated_at_ms = now_epoch_ms();
+    write_manifest(state, manifest).await
+}
+
+async fn cleanup_project_sync_spool(state: &AppState, job_id: &str) -> ApiResult<()> {
+    remove_file_if_exists(&temp_spool_path(state, job_id)).await?;
+    remove_file_if_exists(&spool_path(state, job_id)).await
+}
+
+async fn persist_terminal_project_sync_manifest(
+    state: &AppState,
+    manifest: &mut ProjectSyncJobManifest,
+    status: ProjectSyncJobStatus,
+    error: Option<String>,
+) -> ApiResult<()> {
+    manifest.status = status;
+    manifest.error = error;
+    cleanup_project_sync_spool(state, &manifest.job_id).await?;
+    release_reserved_bytes(state, manifest).await
+}
+
+async fn remove_file_if_exists(path: &Path) -> ApiResult<()> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(ApiError::Internal(format!(
+            "Failed to remove file '{}': {}",
+            path.display(),
+            error
+        ))),
+    }
+}
+
+async fn inspect_spool_state(state: &AppState, job_id: &str) -> ApiResult<ProjectSyncSpoolState> {
+    let final_bytes = file_len_if_exists(&spool_path(state, job_id)).await?;
+    let temp_bytes = file_len_if_exists(&temp_spool_path(state, job_id)).await?;
+    Ok(ProjectSyncSpoolState {
+        final_bytes,
+        temp_bytes,
+    })
+}
+
+async fn file_len_if_exists(path: &Path) -> ApiResult<Option<u64>> {
+    match fs::metadata(path).await {
+        Ok(metadata) => Ok(Some(metadata.len())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ApiError::Internal(format!(
+            "Failed to inspect project_sync spool file '{}': {}",
+            path.display(),
+            error
+        ))),
+    }
+}
+
+async fn apply_spool_fix(
+    state: &AppState,
+    job_id: &str,
+    spool_fix: ProjectSyncSpoolFix,
+) -> ApiResult<()> {
+    match spool_fix {
+        ProjectSyncSpoolFix::None => Ok(()),
+        ProjectSyncSpoolFix::PromoteTempToFinal => {
+            let temp_path = temp_spool_path(state, job_id);
+            let final_path = spool_path(state, job_id);
+            remove_file_if_exists(&final_path).await?;
+            fs::rename(&temp_path, &final_path).await.map_err(|error| {
+                ApiError::Internal(format!(
+                    "Failed to promote project_sync temp spool to final: {}",
+                    error
+                ))
+            })
+        }
+        ProjectSyncSpoolFix::DeleteAll => cleanup_project_sync_spool(state, job_id).await,
+    }
+}
+
+fn recover_manifest_for_restart(
+    mut manifest: ProjectSyncJobManifest,
+    spool_state: ProjectSyncSpoolState,
+    recovered_at_ms: u64,
+) -> ProjectSyncRecoveryAction {
+    manifest.updated_at_ms = recovered_at_ms;
+
+    if is_terminal_status(manifest.status) {
+        manifest.reserved_bytes = false;
+        return ProjectSyncRecoveryAction::Persist {
+            manifest,
+            requeue: false,
+            spool_fix: ProjectSyncSpoolFix::DeleteAll,
+        };
+    }
+
+    if is_project_sync_manifest_expired(&manifest, recovered_at_ms) {
+        manifest.status = ProjectSyncJobStatus::Expired;
+        manifest.error = Some(project_sync_expired_message());
+        manifest.reserved_bytes = false;
+        return ProjectSyncRecoveryAction::Persist {
+            manifest,
+            requeue: false,
+            spool_fix: ProjectSyncSpoolFix::DeleteAll,
+        };
+    }
+
+    match manifest.status {
+        ProjectSyncJobStatus::Created | ProjectSyncJobStatus::Uploading => {
+            if spool_state.has_exact_final_only(manifest.declared_bytes) {
+                manifest.status = ProjectSyncJobStatus::Uploaded;
+                manifest.uploaded_bytes = manifest.declared_bytes;
+                manifest.error = None;
+                return ProjectSyncRecoveryAction::Persist {
+                    manifest,
+                    requeue: false,
+                    spool_fix: ProjectSyncSpoolFix::None,
+                };
+            }
+            if spool_state.has_exact_temp_only(manifest.declared_bytes) {
+                manifest.status = ProjectSyncJobStatus::Uploaded;
+                manifest.uploaded_bytes = manifest.declared_bytes;
+                manifest.error = None;
+                return ProjectSyncRecoveryAction::Persist {
+                    manifest,
+                    requeue: false,
+                    spool_fix: ProjectSyncSpoolFix::PromoteTempToFinal,
+                };
+            }
+            manifest.status = ProjectSyncJobStatus::Created;
+            manifest.uploaded_bytes = 0;
+            if spool_state.has_any_spool() {
+                manifest.error =
+                    Some("Interrupted upload was discarded during recovery".to_string());
+            }
+            ProjectSyncRecoveryAction::Persist {
+                manifest,
+                requeue: false,
+                spool_fix: if spool_state.has_any_spool() {
+                    ProjectSyncSpoolFix::DeleteAll
+                } else {
+                    ProjectSyncSpoolFix::None
+                },
+            }
+        }
+        ProjectSyncJobStatus::Uploaded | ProjectSyncJobStatus::Queued => {
+            if spool_state.has_exact_final_only(manifest.declared_bytes) {
+                manifest.uploaded_bytes = manifest.declared_bytes;
+                return ProjectSyncRecoveryAction::Persist {
+                    requeue: manifest.status == ProjectSyncJobStatus::Queued,
+                    manifest,
+                    spool_fix: ProjectSyncSpoolFix::None,
+                };
+            }
+            if spool_state.has_exact_temp_only(manifest.declared_bytes) {
+                manifest.uploaded_bytes = manifest.declared_bytes;
+                return ProjectSyncRecoveryAction::Persist {
+                    requeue: manifest.status == ProjectSyncJobStatus::Queued,
+                    manifest,
+                    spool_fix: ProjectSyncSpoolFix::PromoteTempToFinal,
+                };
+            }
+            manifest.status = ProjectSyncJobStatus::Failed;
+            manifest.error =
+                Some("project_sync spool is missing or incomplete after restart".to_string());
+            manifest.reserved_bytes = false;
+            ProjectSyncRecoveryAction::Persist {
+                manifest,
+                requeue: false,
+                spool_fix: ProjectSyncSpoolFix::DeleteAll,
+            }
+        }
+        ProjectSyncJobStatus::Running => ProjectSyncRecoveryAction::Quarantine {
+            reason: "Running jobs must be recovered via snapshot-aware recovery".to_string(),
+        },
+        ProjectSyncJobStatus::Cancelling => ProjectSyncRecoveryAction::Quarantine {
+            reason: "Cancelling jobs must be recovered via snapshot-aware recovery".to_string(),
+        },
+        ProjectSyncJobStatus::Completed
+        | ProjectSyncJobStatus::Failed
+        | ProjectSyncJobStatus::Cancelled
+        | ProjectSyncJobStatus::Expired => ProjectSyncRecoveryAction::Quarantine {
+            reason: "Unexpected terminal state in non-terminal recovery branch".to_string(),
+        },
+    }
+}
+
+async fn quarantine_project_sync_path(
+    state: &AppState,
+    path: &Path,
+    entry_name: &str,
+    reason: &str,
+) -> ApiResult<()> {
+    let corrupt_root = project_sync_jobs_path(state).join("_corrupt");
+    fs::create_dir_all(&corrupt_root).await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to create project_sync corrupt directory: {}",
+            error
+        ))
+    })?;
+    let quarantine_name = format!("{}-{}", now_epoch_ms(), entry_name);
+    let destination = corrupt_root.join(quarantine_name);
+    fs::rename(path, &destination).await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to quarantine project_sync path '{}': {}",
+            path.display(),
+            error
+        ))
+    })?;
+    fs::write(destination.join("reason.txt"), reason.as_bytes())
+        .await
+        .map_err(|error| {
+            ApiError::Internal(format!(
+                "Failed to persist project_sync quarantine reason: {}",
+                error
+            ))
+        })?;
+    Ok(())
+}
+
+async fn recover_project_sync_job_dir(
+    state: &Arc<AppState>,
+    entry_name: &str,
+    entry_path: &Path,
+) -> ApiResult<Option<ProjectSyncRecoveredJob>> {
+    let manifest_path = entry_path.join("manifest.json");
+    let manifest_bytes = match fs::read(&manifest_path).await {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            quarantine_project_sync_path(
+                state,
+                entry_path,
+                entry_name,
+                "Missing project_sync manifest.json",
+            )
+            .await?;
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(ApiError::Internal(format!(
+                "Failed to read project_sync manifest during recovery: {}",
+                error
+            )));
+        }
+    };
+
+    let manifest = match serde_json::from_slice::<ProjectSyncJobManifest>(&manifest_bytes) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            quarantine_project_sync_path(
+                state,
+                entry_path,
+                entry_name,
+                &format!("Invalid project_sync manifest.json: {}", error),
+            )
+            .await?;
+            return Ok(None);
+        }
+    };
+
+    if manifest.job_id != entry_name {
+        quarantine_project_sync_path(
+            state,
+            entry_path,
+            entry_name,
+            &format!(
+                "Manifest job_id '{}' does not match directory '{}'",
+                manifest.job_id, entry_name
+            ),
+        )
+        .await?;
+        return Ok(None);
+    }
+
+    let recovered_at_ms = now_epoch_ms();
+    if manifest.status == ProjectSyncJobStatus::Running
+        || manifest.status == ProjectSyncJobStatus::Cancelling
+    {
+        return recover_interrupted_project_sync_job(state, manifest, recovered_at_ms).await;
+    }
+
+    let spool_state = inspect_spool_state(state, entry_name).await?;
+    match recover_manifest_for_restart(manifest, spool_state, recovered_at_ms) {
+        ProjectSyncRecoveryAction::Persist {
+            manifest,
+            requeue,
+            spool_fix,
+        } => {
+            apply_spool_fix(state, &manifest.job_id, spool_fix).await?;
+            write_manifest(state, &manifest).await?;
+            Ok(Some(ProjectSyncRecoveredJob {
+                reserved_bytes: if manifest.reserved_bytes {
+                    manifest.declared_bytes
+                } else {
+                    0
+                },
+                requeue,
+            }))
+        }
+        ProjectSyncRecoveryAction::Quarantine { reason } => {
+            quarantine_project_sync_path(state, entry_path, entry_name, &reason).await?;
+            Ok(None)
+        }
+    }
+}
+
+async fn recover_interrupted_project_sync_job(
+    state: &Arc<AppState>,
+    manifest: ProjectSyncJobManifest,
+    recovered_at_ms: u64,
+) -> ApiResult<Option<ProjectSyncRecoveredJob>> {
+    let snapshot = snapshot_path(state, &manifest.job_id);
+    if snapshot.exists() {
+        if let Err(rollback_error) =
+            restore_project_sync_snapshot_locked(state.clone(), &manifest.index_name, &snapshot)
+                .await
+        {
+            let dirty_result = mark_project_sync_dirty(
+                state,
+                &manifest.index_name,
+                &manifest.job_id,
+                "Interrupted during startup recovery",
+                &rollback_error,
+            )
+            .await;
+            let error = match dirty_result {
+                Ok(()) => format!(
+                    "Job was interrupted during indexing and snapshot restore failed: {}; index marked dirty",
+                    rollback_error
+                ),
+                Err(dirty_error) => format!(
+                    "Job was interrupted during indexing and snapshot restore failed: {}; failed to persist dirty marker: {}",
+                    rollback_error, dirty_error
+                ),
+            };
+            let mut failed_manifest = manifest;
+            failed_manifest.updated_at_ms = recovered_at_ms;
+            persist_terminal_project_sync_manifest(
+                state,
+                &mut failed_manifest,
+                ProjectSyncJobStatus::Failed,
+                Some(error),
+            )
+            .await?;
+            return Ok(Some(ProjectSyncRecoveredJob {
+                reserved_bytes: 0,
+                requeue: false,
+            }));
+        }
+
+        if let Err(cleanup_error) = remove_project_sync_snapshot(&snapshot).await {
+            tracing::warn!(
+                job_id = %manifest.job_id,
+                error = %cleanup_error,
+                "project_sync.recovery.snapshot_cleanup_failed"
+            );
+        }
+
+        let mut recovered_manifest = manifest;
+        let recovered_status = if recovered_manifest.status == ProjectSyncJobStatus::Cancelling {
+            ProjectSyncJobStatus::Cancelled
+        } else {
+            ProjectSyncJobStatus::Failed
+        };
+        let recovered_error = if recovered_status == ProjectSyncJobStatus::Cancelled {
+            "Cancelled by client".to_string()
+        } else {
+            "Job was interrupted during indexing and rolled back from snapshot".to_string()
+        };
+        recovered_manifest.updated_at_ms = recovered_at_ms;
+        persist_terminal_project_sync_manifest(
+            state,
+            &mut recovered_manifest,
+            recovered_status,
+            Some(recovered_error),
+        )
+        .await?;
+        return Ok(Some(ProjectSyncRecoveredJob {
+            reserved_bytes: 0,
+            requeue: false,
+        }));
+    }
+
+    let dirty_result = mark_project_sync_dirty(
+        state,
+        &manifest.index_name,
+        &manifest.job_id,
+        "Interrupted during startup recovery",
+        "Snapshot is missing",
+    )
+    .await;
+    let error = match dirty_result {
+        Ok(()) => {
+            "Job was interrupted during indexing and snapshot is missing; index marked dirty"
+                .to_string()
+        }
+        Err(dirty_error) => format!(
+            "Job was interrupted during indexing and snapshot is missing; failed to persist dirty marker: {}",
+            dirty_error
+        ),
+    };
+    let mut failed_manifest = manifest;
+    failed_manifest.updated_at_ms = recovered_at_ms;
+    persist_terminal_project_sync_manifest(
+        state,
+        &mut failed_manifest,
+        ProjectSyncJobStatus::Failed,
+        Some(error),
+    )
+    .await?;
+    Ok(Some(ProjectSyncRecoveredJob {
+        reserved_bytes: 0,
+        requeue: false,
+    }))
+}
+
+pub async fn recover_project_sync_jobs(state: Arc<AppState>) -> ApiResult<()> {
+    let jobs_root = project_sync_jobs_path(&state);
+    fs::create_dir_all(jobs_root.join("_corrupt"))
+        .await
+        .map_err(|error| {
+            ApiError::Internal(format!(
+                "Failed to create project_sync recovery directories: {}",
+                error
+            ))
+        })?;
+
+    let mut pending_bytes: u64 = 0;
+    let mut requeue_job_ids: Vec<String> = Vec::new();
+    let mut entries = fs::read_dir(&jobs_root).await.map_err(|error| {
+        ApiError::Internal(format!("Failed to scan project_sync jobs: {}", error))
+    })?;
+
+    while let Some(entry) = entries.next_entry().await.map_err(|error| {
+        ApiError::Internal(format!("Failed to read project_sync entry: {}", error))
+    })? {
+        let entry_name = entry.file_name().to_string_lossy().to_string();
+        if entry_name == "_corrupt" || entry_name == "_dirty" {
+            continue;
+        }
+
+        let entry_path = entry.path();
+        let file_type = entry.file_type().await.map_err(|error| {
+            ApiError::Internal(format!(
+                "Failed to inspect project_sync entry type: {}",
+                error
+            ))
+        })?;
+        if !file_type.is_dir() {
+            quarantine_project_sync_path(
+                &state,
+                &entry_path,
+                &entry_name,
+                "Unexpected non-directory entry in project_sync jobs root",
+            )
+            .await?;
+            continue;
+        }
+
+        if let Some(recovered_job) =
+            recover_project_sync_job_dir(&state, &entry_name, &entry_path).await?
+        {
+            pending_bytes = pending_bytes.saturating_add(recovered_job.reserved_bytes);
+            if recovered_job.requeue {
+                requeue_job_ids.push(entry_name);
+            }
+        }
+    }
+
+    set_pending_ingest_bytes(&state, pending_bytes);
+
+    for job_id in &requeue_job_ids {
+        let worker_state = state.clone();
+        let worker_job_id = job_id.clone();
+        tokio::spawn(async move {
+            run_project_sync_job(worker_state, worker_job_id).await;
+        });
+    }
+
+    tracing::info!(
+        pending_ingest_bytes = pending_bytes,
+        requeued_jobs = requeue_job_ids.len(),
+        "project_sync.recovery.completed"
+    );
+
+    Ok(())
+}
+
+async fn expire_project_sync_job_if_stale(
+    state: &AppState,
+    job_id: &str,
+    now_ms: u64,
+) -> ApiResult<()> {
+    let lock = job_lock(job_id);
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(state, job_id).await?;
+    if !is_project_sync_manifest_expired(&manifest, now_ms) {
+        return Ok(());
+    }
+
+    persist_terminal_project_sync_manifest(
+        state,
+        &mut manifest,
+        ProjectSyncJobStatus::Expired,
+        Some(project_sync_expired_message()),
+    )
+    .await
+}
+
+async fn sweep_expired_project_sync_jobs(state: &AppState, now_ms: u64) -> ApiResult<()> {
+    let jobs_root = project_sync_jobs_path(state);
+    let mut entries = match fs::read_dir(&jobs_root).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(ApiError::Internal(format!(
+                "Failed to scan project_sync jobs for expiration: {}",
+                error
+            )))
+        }
+    };
+
+    while let Some(entry) = entries.next_entry().await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to read project_sync expiration entry: {}",
+            error
+        ))
+    })? {
+        let entry_name = entry.file_name().to_string_lossy().to_string();
+        if entry_name == "_corrupt" || entry_name == "_dirty" {
+            continue;
+        }
+
+        let file_type = entry.file_type().await.map_err(|error| {
+            ApiError::Internal(format!(
+                "Failed to inspect project_sync expiration entry type: {}",
+                error
+            ))
+        })?;
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        expire_project_sync_job_if_stale(state, &entry_name, now_ms).await?;
+    }
+
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/indices/{name}/project_sync/jobs",
+    tag = "project_sync",
+    params(
+        ("name" = String, Path, description = "Index name")
+    ),
+    request_body = ProjectSyncCreateJobRequest,
+    responses(
+        (status = 200, description = "Project sync job accepted", body = ProjectSyncCreateJobResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Index not declared", body = ErrorResponse),
+        (status = 413, description = "Upload is too large", body = ErrorResponse),
+        (status = 503, description = "Project sync backlog is full", body = ErrorResponse)
+    )
+)]
+pub async fn create_project_sync_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+    request: Result<Json<ProjectSyncCreateJobRequest>, JsonRejection>,
+) -> ApiResult<Json<ProjectSyncCreateJobResponse>> {
+    let Json(request) = request.map_err(|error| ApiError::BadRequest(error.body_text()))?;
+
+    if name.is_empty() {
+        return Err(ApiError::BadRequest(
+            "Index name cannot be empty".to_string(),
+        ));
+    }
+    if request.declared_bytes == 0 {
+        return Err(ApiError::BadRequest(
+            "declared_bytes must be greater than 0".to_string(),
+        ));
+    }
+    validate_project_sync_content_type(&request.content_type)?;
+
+    let index_path = state.index_path(&name);
+    if !index_path.join("config.json").exists() {
+        return Err(ApiError::IndexNotDeclared(name));
+    }
+
+    let max_request_bytes = max_ingest_request_bytes();
+    if request.declared_bytes > max_request_bytes {
+        return Err(ApiError::ContentTooLarge {
+            message: format!(
+                "declared_bytes {} exceeds MAX_INGEST_REQUEST_BYTES {}",
+                request.declared_bytes, max_request_bytes
+            ),
+            details: content_too_large_details(request.declared_bytes, max_request_bytes),
+        });
+    }
+
+    let create_lock = create_job_lock();
+    let _create_guard = create_lock.lock().await;
+    sweep_expired_project_sync_jobs(&state, now_epoch_ms()).await?;
+
+    let max_pending_bytes = max_pending_ingest_bytes();
+    let current_pending_bytes = pending_ingest_bytes(&state);
+    let available_bytes = max_pending_bytes.saturating_sub(current_pending_bytes);
+    if request.declared_bytes > available_bytes {
+        return Err(ApiError::ServiceUnavailableDetailed {
+            message: "project_sync backlog is full".to_string(),
+            details: backlog_details(
+                request.declared_bytes,
+                current_pending_bytes,
+                max_pending_bytes,
+            ),
+            retry_after_seconds: Some(RETRY_AFTER_SECONDS_HINT),
+        });
+    }
+
+    let job_id = Uuid::new_v4().to_string();
+    let now = now_epoch_ms();
+    let manifest = ProjectSyncJobManifest {
+        job_id: job_id.clone(),
+        index_name: name,
+        status: ProjectSyncJobStatus::Created,
+        declared_bytes: request.declared_bytes,
+        uploaded_bytes: 0,
+        content_type: request.content_type,
+        reserved_bytes: true,
+        error: None,
+        created_at_ms: now,
+        updated_at_ms: now,
+    };
+
+    reserve_pending_ingest_bytes(&state, manifest.declared_bytes);
+    if let Err(error) = write_manifest(&state, &manifest).await {
+        release_pending_ingest_bytes(&state, manifest.declared_bytes);
+        return Err(error);
+    }
+
+    Ok(Json(ProjectSyncCreateJobResponse {
+        job_id,
+        status: ProjectSyncJobStatus::Created,
+        declared_bytes: manifest.declared_bytes,
+    }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/project_sync/jobs/{job_id}/upload",
+    tag = "project_sync",
+    params(
+        ("job_id" = String, Path, description = "Project sync job id")
+    ),
+    request_body(content = String, content_type = "application/x-ndjson"),
+    responses(
+        (status = 200, description = "Project sync upload stored", body = ProjectSyncJobResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 404, description = "Job not found", body = ErrorResponse),
+        (status = 408, description = "Project sync upload timed out", body = ErrorResponse),
+        (status = 409, description = "Job is not uploadable", body = ErrorResponse)
+    )
+)]
+pub async fn upload_project_sync_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(job_id): AxumPath<String>,
+    headers: HeaderMap,
+    body: Body,
+) -> ApiResult<PrettyJson<ProjectSyncJobResponse>> {
+    upload_project_sync_job_with_idle_timeout(
+        state,
+        &job_id,
+        headers,
+        body,
+        project_sync_upload_idle_timeout(),
+    )
+    .await
+}
+
+async fn upload_project_sync_job_with_idle_timeout(
+    state: Arc<AppState>,
+    job_id: &str,
+    headers: HeaderMap,
+    body: Body,
+    idle_timeout: Duration,
+) -> ApiResult<PrettyJson<ProjectSyncJobResponse>> {
+    let lock = job_lock(job_id);
+    let content_type = request_content_type(&headers)?;
+    validate_project_sync_content_type(&content_type)?;
+    let content_length = parse_content_length(&headers)?;
+
+    let tmp_path = temp_spool_path(&state, job_id);
+    let final_path = spool_path(&state, job_id);
+
+    {
+        let _guard = lock.lock().await;
+        let mut manifest = read_manifest(&state, job_id).await?;
+
+        if manifest.status != ProjectSyncJobStatus::Created {
+            return Err(ApiError::Conflict(format!(
+                "project_sync job '{}' is not uploadable from status {:?}",
+                job_id, manifest.status
+            )));
+        }
+        if content_length != manifest.declared_bytes {
+            return Err(ApiError::BadRequest(format!(
+                "Content-Length {} does not match declared_bytes {}",
+                content_length, manifest.declared_bytes
+            )));
+        }
+        if normalize_content_type(&content_type) != normalize_content_type(&manifest.content_type) {
+            return Err(ApiError::BadRequest(format!(
+                "Content-Type '{}' does not match job content_type '{}'",
+                content_type, manifest.content_type
+            )));
+        }
+
+        remove_file_if_exists(&tmp_path).await?;
+        remove_file_if_exists(&final_path).await?;
+        manifest.status = ProjectSyncJobStatus::Uploading;
+        manifest.uploaded_bytes = 0;
+        manifest.error = None;
+        manifest.updated_at_ms = now_epoch_ms();
+        write_manifest(&state, &manifest).await?;
+    }
+
+    let upload_result = upload_project_sync_body(
+        state.clone(),
+        job_id,
+        body,
+        &tmp_path,
+        &final_path,
+        content_length,
+        idle_timeout,
+    )
+    .await;
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(&state, job_id).await?;
+
+    match upload_result {
+        Ok(ProjectSyncUploadResult::Uploaded { uploaded_bytes }) => {
+            if manifest.status == ProjectSyncJobStatus::Uploading {
+                manifest.status = ProjectSyncJobStatus::Uploaded;
+                manifest.uploaded_bytes = uploaded_bytes;
+                manifest.error = None;
+                manifest.updated_at_ms = now_epoch_ms();
+                write_manifest(&state, &manifest).await?;
+                return Ok(PrettyJson(manifest_to_response(&manifest)));
+            }
+            if is_cancellation_requested(manifest.status) {
+                manifest.uploaded_bytes = 0;
+                persist_terminal_project_sync_manifest(
+                    &state,
+                    &mut manifest,
+                    ProjectSyncJobStatus::Cancelled,
+                    Some("Cancelled by client".to_string()),
+                )
+                .await?;
+                return Err(upload_cancelled_conflict(job_id));
+            }
+            cleanup_project_sync_spool(&state, job_id).await?;
+            Err(upload_completion_conflict(job_id, manifest.status))
+        }
+        Ok(ProjectSyncUploadResult::Cancelled) => {
+            manifest.uploaded_bytes = 0;
+            persist_terminal_project_sync_manifest(
+                &state,
+                &mut manifest,
+                ProjectSyncJobStatus::Cancelled,
+                Some("Cancelled by client".to_string()),
+            )
+            .await?;
+            Err(upload_cancelled_conflict(job_id))
+        }
+        Err(error) => {
+            if manifest.status == ProjectSyncJobStatus::Uploading {
+                cleanup_project_sync_spool(&state, job_id).await?;
+                manifest.status = ProjectSyncJobStatus::Created;
+                manifest.uploaded_bytes = 0;
+                manifest.error = Some(error.to_string());
+                manifest.updated_at_ms = now_epoch_ms();
+                write_manifest(&state, &manifest).await?;
+                return Err(error);
+            }
+            if is_cancellation_requested(manifest.status) {
+                manifest.uploaded_bytes = 0;
+                persist_terminal_project_sync_manifest(
+                    &state,
+                    &mut manifest,
+                    ProjectSyncJobStatus::Cancelled,
+                    Some("Cancelled by client".to_string()),
+                )
+                .await?;
+                return Err(upload_cancelled_conflict(job_id));
+            }
+            cleanup_project_sync_spool(&state, job_id).await?;
+            Err(upload_completion_conflict(job_id, manifest.status))
+        }
+    }
+}
+
+async fn refresh_project_sync_upload_progress(
+    state: &AppState,
+    job_id: &str,
+    uploaded_bytes: u64,
+) -> ApiResult<()> {
+    let lock = job_lock(job_id);
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(state, job_id).await?;
+    if manifest.status != ProjectSyncJobStatus::Uploading {
+        return Ok(());
+    }
+    manifest.uploaded_bytes = uploaded_bytes;
+    manifest.updated_at_ms = now_epoch_ms();
+    write_manifest(state, &manifest).await
+}
+
+async fn upload_project_sync_body(
+    state: Arc<AppState>,
+    job_id: &str,
+    body: Body,
+    tmp_path: &Path,
+    final_path: &Path,
+    declared_bytes: u64,
+    idle_timeout: Duration,
+) -> ApiResult<ProjectSyncUploadResult> {
+    let mut file = fs::File::create(tmp_path)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to create spool file: {}", error)))?;
+    let mut stream = body.into_data_stream();
+    let mut uploaded_bytes: u64 = 0;
+    let mut last_progress_update_ms = now_epoch_ms();
+    let mut next_progress_update_bytes = PROJECT_SYNC_UPLOAD_PROGRESS_UPDATE_BYTES;
+    let mut last_chunk_at = tokio::time::Instant::now();
+
+    loop {
+        if project_sync_cancellation_requested(&state, job_id).await? {
+            return Ok(ProjectSyncUploadResult::Cancelled);
+        }
+
+        let next_chunk = tokio::select! {
+            chunk = stream.next() => chunk,
+            _ = tokio::time::sleep(PROJECT_SYNC_UPLOAD_CANCEL_POLL_INTERVAL) => {
+                if last_chunk_at.elapsed() >= idle_timeout {
+                    return Err(ApiError::RequestTimeout(project_sync_upload_timeout_message(
+                        idle_timeout,
+                    )));
+                }
+                continue;
+            }
+        };
+
+        let Some(chunk_result) = next_chunk else {
+            break;
+        };
+
+        if project_sync_cancellation_requested(&state, job_id).await? {
+            return Ok(ProjectSyncUploadResult::Cancelled);
+        }
+
+        let chunk = chunk_result.map_err(|error| {
+            ApiError::BadRequest(format!("Failed to read upload body: {}", error))
+        })?;
+        if !chunk.is_empty() {
+            last_chunk_at = tokio::time::Instant::now();
+        }
+        uploaded_bytes = uploaded_bytes.saturating_add(chunk.len() as u64);
+        if uploaded_bytes > declared_bytes {
+            return Err(ApiError::BadRequest(format!(
+                "Upload body exceeds declared_bytes {}",
+                declared_bytes
+            )));
+        }
+        file.write_all(&chunk).await.map_err(|error| {
+            ApiError::Internal(format!("Failed to write spool file: {}", error))
+        })?;
+        let current_time_ms = now_epoch_ms();
+        if uploaded_bytes >= next_progress_update_bytes
+            || current_time_ms.saturating_sub(last_progress_update_ms)
+                >= PROJECT_SYNC_UPLOAD_PROGRESS_UPDATE_INTERVAL_MS
+        {
+            refresh_project_sync_upload_progress(&state, job_id, uploaded_bytes).await?;
+            last_progress_update_ms = current_time_ms;
+            next_progress_update_bytes =
+                uploaded_bytes.saturating_add(PROJECT_SYNC_UPLOAD_PROGRESS_UPDATE_BYTES);
+        }
+        if project_sync_cancellation_requested(&state, job_id).await? {
+            return Ok(ProjectSyncUploadResult::Cancelled);
+        }
+    }
+
+    file.flush()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to flush spool file: {}", error)))?;
+    drop(file);
+
+    if project_sync_cancellation_requested(&state, job_id).await? {
+        return Ok(ProjectSyncUploadResult::Cancelled);
+    }
+
+    if uploaded_bytes != declared_bytes {
+        return Err(ApiError::BadRequest(format!(
+            "Uploaded {} bytes, expected {}",
+            uploaded_bytes, declared_bytes
+        )));
+    }
+
+    fs::rename(tmp_path, final_path)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to persist spool file: {}", error)))?;
+
+    if project_sync_cancellation_requested(&state, job_id).await? {
+        return Ok(ProjectSyncUploadResult::Cancelled);
+    }
+
+    Ok(ProjectSyncUploadResult::Uploaded { uploaded_bytes })
+}
+
+#[utoipa::path(
+    post,
+    path = "/project_sync/jobs/{job_id}/finalize",
+    tag = "project_sync",
+    params(
+        ("job_id" = String, Path, description = "Project sync job id")
+    ),
+    responses(
+        (status = 200, description = "Project sync job queued", body = ProjectSyncJobResponse),
+        (status = 404, description = "Job not found", body = ErrorResponse),
+        (status = 409, description = "Job is not finalizable", body = ErrorResponse)
+    )
+)]
+pub async fn finalize_project_sync_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(job_id): AxumPath<String>,
+) -> ApiResult<PrettyJson<ProjectSyncJobResponse>> {
+    let lock = job_lock(&job_id);
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(&state, &job_id).await?;
+
+    if manifest.status != ProjectSyncJobStatus::Uploaded {
+        return Err(ApiError::Conflict(format!(
+            "project_sync job '{}' is not finalizable from status {:?}",
+            job_id, manifest.status
+        )));
+    }
+    if manifest.uploaded_bytes != manifest.declared_bytes {
+        return Err(ApiError::Conflict(format!(
+            "project_sync job '{}' uploaded {} bytes but declared {}",
+            job_id, manifest.uploaded_bytes, manifest.declared_bytes
+        )));
+    }
+    if fs::metadata(spool_path(&state, &job_id)).await.is_err() {
+        return Err(ApiError::Conflict(format!(
+            "project_sync job '{}' has no persisted spool payload",
+            job_id
+        )));
+    }
+
+    manifest.status = ProjectSyncJobStatus::Queued;
+    manifest.error = None;
+    manifest.updated_at_ms = now_epoch_ms();
+    write_manifest(&state, &manifest).await?;
+
+    let worker_state = state.clone();
+    let worker_job_id = job_id.clone();
+    tokio::spawn(async move {
+        run_project_sync_job(worker_state, worker_job_id).await;
+    });
+
+    Ok(PrettyJson(manifest_to_response(&manifest)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/project_sync/jobs/{job_id}",
+    tag = "project_sync",
+    params(
+        ("job_id" = String, Path, description = "Project sync job id")
+    ),
+    responses(
+        (status = 200, description = "Project sync job status", body = ProjectSyncJobResponse),
+        (status = 404, description = "Job not found", body = ErrorResponse)
+    )
+)]
+pub async fn get_project_sync_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(job_id): AxumPath<String>,
+) -> ApiResult<PrettyJson<ProjectSyncJobResponse>> {
+    let manifest = read_manifest(&state, &job_id).await?;
+    Ok(PrettyJson(manifest_to_response(&manifest)))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/project_sync/jobs/{job_id}",
+    tag = "project_sync",
+    params(
+        ("job_id" = String, Path, description = "Project sync job id")
+    ),
+    responses(
+        (status = 200, description = "Project sync job cancelled", body = ProjectSyncJobResponse),
+        (status = 404, description = "Job not found", body = ErrorResponse),
+        (status = 409, description = "Job cannot be cancelled", body = ErrorResponse)
+    )
+)]
+pub async fn cancel_project_sync_job(
+    State(state): State<Arc<AppState>>,
+    AxumPath(job_id): AxumPath<String>,
+) -> ApiResult<PrettyJson<ProjectSyncJobResponse>> {
+    let lock = job_lock(&job_id);
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(&state, &job_id).await?;
+
+    if is_terminal_status(manifest.status) {
+        return Ok(PrettyJson(manifest_to_response(&manifest)));
+    }
+    if manifest.status == ProjectSyncJobStatus::Running
+        || manifest.status == ProjectSyncJobStatus::Uploading
+    {
+        manifest.status = ProjectSyncJobStatus::Cancelling;
+        manifest.error = Some("Cancellation requested by client".to_string());
+        manifest.updated_at_ms = now_epoch_ms();
+        write_manifest(&state, &manifest).await?;
+        return Ok(PrettyJson(manifest_to_response(&manifest)));
+    }
+    if manifest.status == ProjectSyncJobStatus::Cancelling {
+        return Ok(PrettyJson(manifest_to_response(&manifest)));
+    }
+
+    persist_terminal_project_sync_manifest(
+        &state,
+        &mut manifest,
+        ProjectSyncJobStatus::Cancelled,
+        Some("Cancelled by client".to_string()),
+    )
+    .await?;
+    Ok(PrettyJson(manifest_to_response(&manifest)))
+}
+
+async fn run_project_sync_job(state: Arc<AppState>, job_id: String) {
+    if let Err(error) = run_project_sync_job_inner(state.clone(), &job_id).await {
+        let lock = job_lock(&job_id);
+        let _guard = lock.lock().await;
+        match read_manifest(&state, &job_id).await {
+            Ok(mut manifest) if !is_terminal_status(manifest.status) => {
+                if let Err(release_error) = persist_terminal_project_sync_manifest(
+                    &state,
+                    &mut manifest,
+                    ProjectSyncJobStatus::Failed,
+                    Some(error.to_string()),
+                )
+                .await
+                {
+                    tracing::error!(
+                        job_id = %job_id,
+                        error = %release_error,
+                        "project_sync.worker.failed_to_release_reserved_bytes"
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(read_error) => {
+                tracing::error!(
+                    job_id = %job_id,
+                    error = %read_error,
+                    "project_sync.worker.failed_to_update_manifest"
+                );
+            }
+        }
+    }
+}
+
+async fn run_project_sync_job_inner(state: Arc<AppState>, job_id: &str) -> ApiResult<()> {
+    {
+        let lock = job_lock(job_id);
+        let _guard = lock.lock().await;
+        let manifest = read_manifest(&state, job_id).await?;
+        if is_cancellation_requested(manifest.status) {
+            return Ok(());
+        }
+        if manifest.status != ProjectSyncJobStatus::Queued {
+            return Err(ApiError::Conflict(format!(
+                "project_sync job '{}' worker expected queued status, got {:?}",
+                job_id, manifest.status
+            )));
+        }
+        update_manifest_status(&state, job_id, ProjectSyncJobStatus::Running, None).await?;
+    }
+
+    let manifest = read_manifest(&state, job_id).await?;
+    let spool = spool_path(&state, job_id);
+    let source_paths = collect_project_sync_source_paths(&spool).await?;
+    let path_str = state
+        .index_path(&manifest.index_name)
+        .to_string_lossy()
+        .to_string();
+    let index_lock = get_index_write_lock(&state, &manifest.index_name);
+    let _index_guard = index_lock.lock().await;
+    let mut snapshot: Option<PathBuf> = None;
+    let process_result: ApiResult<()> = async {
+        ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+        run_preflight_repair_locked(&path_str)
+            .await
+            .map_err(|error| {
+                ApiError::Internal(format!("Index/DB sync preflight repair failed: {}", error))
+            })?;
+        ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+        snapshot =
+            Some(create_project_sync_snapshot(state.clone(), &manifest.index_name, job_id).await?);
+        ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+        let deleted_existing = delete_existing_source_paths_after_repair_locked(
+            state.clone(),
+            &manifest.index_name,
+            &source_paths,
+        )
+        .await?;
+        tracing::info!(
+            job_id = %job_id,
+            index = %manifest.index_name,
+            deleted_existing = deleted_existing,
+            source_paths = source_paths.len(),
+            "project_sync.replace.deleted_existing"
+        );
+        ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+        process_spool_batches_locked(state.clone(), job_id, &manifest.index_name, &spool).await?;
+        ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+        run_project_sync_postflight_locked(&path_str).await?;
+        Ok(())
+    }
+    .await;
+
+    if let Err(error) = process_result {
+        if snapshot.is_none() {
+            let cancellation_requested =
+                match project_sync_cancellation_requested(&state, job_id).await {
+                    Ok(value) => value,
+                    Err(status_error) => {
+                        tracing::warn!(
+                            job_id = %job_id,
+                            error = %status_error,
+                            "project_sync.cancel_check.failed_before_snapshot"
+                        );
+                        false
+                    }
+                };
+            let status = if cancellation_requested {
+                ProjectSyncJobStatus::Cancelled
+            } else {
+                ProjectSyncJobStatus::Failed
+            };
+            let message = if cancellation_requested {
+                "Cancelled by client".to_string()
+            } else {
+                error.to_string()
+            };
+            finish_project_sync_job(&state, job_id, status, Some(message)).await?;
+            return Ok(());
+        }
+
+        let snapshot_path = snapshot
+            .as_ref()
+            .ok_or_else(|| ApiError::Internal("project_sync snapshot missing".to_string()))?;
+        if let Err(rollback_error) =
+            restore_project_sync_snapshot_locked(state.clone(), &manifest.index_name, snapshot_path)
+                .await
+        {
+            let dirty_result = mark_project_sync_dirty(
+                &state,
+                &manifest.index_name,
+                job_id,
+                &error.to_string(),
+                &rollback_error,
+            )
+            .await;
+            let message = match dirty_result {
+                Ok(()) => format!(
+                    "{}; rollback failed: {}; index marked dirty",
+                    error, rollback_error
+                ),
+                Err(dirty_error) => format!(
+                    "{}; rollback failed: {}; failed to persist dirty marker: {}",
+                    error, rollback_error, dirty_error
+                ),
+            };
+            finish_project_sync_job(&state, job_id, ProjectSyncJobStatus::Failed, Some(message))
+                .await?;
+            return Ok(());
+        }
+
+        if let Err(cleanup_error) = remove_project_sync_snapshot(snapshot_path).await {
+            tracing::warn!(
+                job_id = %job_id,
+                error = %cleanup_error,
+                "project_sync.rollback.snapshot_cleanup_failed"
+            );
+        }
+
+        let cancellation_requested = match project_sync_cancellation_requested(&state, job_id).await
+        {
+            Ok(value) => value,
+            Err(status_error) => {
+                tracing::warn!(
+                    job_id = %job_id,
+                    error = %status_error,
+                    "project_sync.cancel_check.failed_after_rollback"
+                );
+                false
+            }
+        };
+        let status = if cancellation_requested {
+            ProjectSyncJobStatus::Cancelled
+        } else {
+            ProjectSyncJobStatus::Failed
+        };
+        let message = if cancellation_requested {
+            "Cancelled by client".to_string()
+        } else {
+            error.to_string()
+        };
+        finish_project_sync_job(&state, job_id, status, Some(message)).await?;
+        return Ok(());
+    }
+
+    let snapshot_path = snapshot.ok_or_else(|| {
+        ApiError::Internal("project_sync snapshot missing after successful processing".to_string())
+    })?;
+    if let Err(cleanup_error) = remove_project_sync_snapshot(&snapshot_path).await {
+        tracing::warn!(
+            job_id = %job_id,
+            error = %cleanup_error,
+            "project_sync.snapshot.cleanup_failed"
+        );
+    }
+
+    finish_project_sync_job(&state, job_id, ProjectSyncJobStatus::Completed, None).await?;
+    Ok(())
+}
+
+fn parse_project_sync_record(line: &str) -> ApiResult<ProjectSyncUploadRecord> {
+    let record: ProjectSyncUploadRecord = serde_json::from_str(line)
+        .map_err(|error| ApiError::BadRequest(format!("Invalid NDJSON record: {}", error)))?;
+    if record.path.is_empty() {
+        return Err(ApiError::BadRequest(
+            "project_sync record path cannot be empty".to_string(),
+        ));
+    }
+    Ok(record)
+}
+
+fn build_project_sync_metadata(record: &ProjectSyncUploadRecord) -> ApiResult<serde_json::Value> {
+    let mut object = match record.metadata.clone() {
+        Some(serde_json::Value::Object(object)) => object,
+        Some(_) => {
+            return Err(ApiError::BadRequest(
+                "project_sync record metadata must be a JSON object".to_string(),
+            ))
+        }
+        None => serde_json::Map::new(),
+    };
+    object.insert(
+        "source_path".to_string(),
+        serde_json::Value::String(record.path.clone()),
+    );
+    if let Some(language) = &record.language {
+        object.insert(
+            "language".to_string(),
+            serde_json::Value::String(language.clone()),
+        );
+    }
+    object
+        .entry("source".to_string())
+        .or_insert_with(|| serde_json::Value::String("project_sync".to_string()));
+    Ok(serde_json::Value::Object(object))
+}
+
+async fn finish_project_sync_job(
+    state: &Arc<AppState>,
+    job_id: &str,
+    status: ProjectSyncJobStatus,
+    error: Option<String>,
+) -> ApiResult<()> {
+    let lock = job_lock(job_id);
+    let _guard = lock.lock().await;
+    let mut manifest = read_manifest(state, job_id).await?;
+    persist_terminal_project_sync_manifest(state, &mut manifest, status, error).await
+}
+
+async fn ensure_project_sync_job_not_cancelled(state: &AppState, job_id: &str) -> ApiResult<()> {
+    let manifest = read_manifest(state, job_id).await?;
+    if is_cancellation_requested(manifest.status) {
+        return Err(ApiError::Conflict(format!(
+            "project_sync job '{}' was cancelled",
+            job_id
+        )));
+    }
+    Ok(())
+}
+
+async fn project_sync_cancellation_requested(state: &AppState, job_id: &str) -> ApiResult<bool> {
+    let manifest = read_manifest(state, job_id).await?;
+    Ok(is_cancellation_requested(manifest.status))
+}
+
+async fn process_spool_batches_locked(
+    state: Arc<AppState>,
+    job_id: &str,
+    index_name: &str,
+    spool: &Path,
+) -> ApiResult<()> {
+    let file = fs::File::open(spool)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to open spool file: {}", error)))?;
+    let mut lines = BufReader::new(file).lines();
+    let batch_size = max_batch_documents();
+    let mut documents: Vec<String> = Vec::with_capacity(batch_size);
+    let mut metadata: Vec<serde_json::Value> = Vec::with_capacity(batch_size);
+    let mut processed_records: usize = 0;
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|error| ApiError::BadRequest(format!("Failed to read spool line: {}", error)))?
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record = parse_project_sync_record(&line)?;
+        let project_metadata = build_project_sync_metadata(&record)?;
+        documents.push(record.content);
+        metadata.push(project_metadata);
+        processed_records += 1;
+
+        if documents.len() >= batch_size {
+            process_project_sync_batch_locked(
+                state.clone(),
+                job_id,
+                index_name,
+                documents,
+                metadata,
+            )
+            .await?;
+            documents = Vec::with_capacity(batch_size);
+            metadata = Vec::with_capacity(batch_size);
+        }
+    }
+
+    if !documents.is_empty() {
+        process_project_sync_batch_locked(state, job_id, index_name, documents, metadata).await?;
+    }
+    if processed_records == 0 {
+        return Err(ApiError::BadRequest(
+            "project_sync upload contains no records".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn process_project_sync_batch_locked(
+    state: Arc<AppState>,
+    job_id: &str,
+    index_name: &str,
+    documents: Vec<String>,
+    metadata: Vec<serde_json::Value>,
+) -> ApiResult<()> {
+    ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+    let request = UpdateWithEncodingRequest {
+        documents,
+        metadata,
+        pool_factor: None,
+    };
+    let prepared = prepare_update_with_encoding_batch(state.clone(), request).await?;
+    ensure_project_sync_job_not_cancelled(&state, job_id).await?;
+    commit_embeddings_batch_after_repair_locked(
+        index_name,
+        prepared.embeddings,
+        prepared.metadata,
+        &state,
+    )
+    .await
+    .map_err(ApiError::Internal)?;
+    Ok(())
+}
+
+async fn collect_project_sync_source_paths(spool: &Path) -> ApiResult<Vec<String>> {
+    let file = fs::File::open(spool)
+        .await
+        .map_err(|error| ApiError::Internal(format!("Failed to open spool file: {}", error)))?;
+    let mut lines = BufReader::new(file).lines();
+    let mut seen_paths: HashSet<String> = HashSet::new();
+    let mut source_paths: Vec<String> = Vec::new();
+    let mut processed_records: usize = 0;
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|error| ApiError::BadRequest(format!("Failed to read spool line: {}", error)))?
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record = parse_project_sync_record(&line)?;
+        processed_records += 1;
+        if !seen_paths.insert(record.path.clone()) {
+            return Err(ApiError::BadRequest(format!(
+                "project_sync upload contains duplicate path '{}'",
+                record.path
+            )));
+        }
+        source_paths.push(record.path);
+    }
+
+    if processed_records == 0 {
+        return Err(ApiError::BadRequest(
+            "project_sync upload contains no records".to_string(),
+        ));
+    }
+    Ok(source_paths)
+}
+
+async fn create_project_sync_snapshot(
+    state: Arc<AppState>,
+    index_name: &str,
+    job_id: &str,
+) -> ApiResult<PathBuf> {
+    let index_path = state.index_path(index_name);
+    let snapshot = snapshot_path(&state, job_id);
+    let snapshot_for_task = snapshot.clone();
+    task::spawn_blocking(move || -> Result<(), String> {
+        remove_dir_if_exists_blocking(&snapshot_for_task)?;
+        copy_dir_recursive_blocking(&index_path, &snapshot_for_task)
+    })
+    .await
+    .map_err(|error| ApiError::Internal(format!("Snapshot task failed: {}", error)))?
+    .map_err(|error| {
+        ApiError::Internal(format!("Failed to create project_sync snapshot: {}", error))
+    })?;
+    Ok(snapshot)
+}
+
+async fn remove_project_sync_snapshot(snapshot: &Path) -> Result<(), String> {
+    let snapshot_path = snapshot.to_path_buf();
+    task::spawn_blocking(move || remove_dir_if_exists_blocking(&snapshot_path))
+        .await
+        .map_err(|error| format!("Snapshot cleanup task failed: {}", error))?
+}
+
+async fn restore_project_sync_snapshot_locked(
+    state: Arc<AppState>,
+    index_name: &str,
+    snapshot: &Path,
+) -> Result<(), String> {
+    let index_path = state.index_path(index_name);
+    let snapshot_path = snapshot.to_path_buf();
+    let index_name_owned = index_name.to_string();
+    state.unload_index(index_name);
+
+    task::spawn_blocking(move || {
+        restore_project_sync_snapshot_blocking(&snapshot_path, &index_path)
+    })
+    .await
+    .map_err(|error| format!("Snapshot restore task failed: {}", error))??;
+
+    if state
+        .index_path(&index_name_owned)
+        .join("metadata.json")
+        .exists()
+    {
+        state
+            .reload_index(&index_name_owned)
+            .map_err(|error| format!("Failed to reload restored index: {}", error))?;
+    }
+    Ok(())
+}
+
+fn restore_project_sync_snapshot_blocking(
+    snapshot: &Path,
+    index_path: &Path,
+) -> Result<(), String> {
+    let parent = index_path.parent().ok_or_else(|| {
+        format!(
+            "Failed to resolve parent directory for restored index '{}'",
+            index_path.display()
+        )
+    })?;
+    let index_name = index_path.file_name().ok_or_else(|| {
+        format!(
+            "Failed to resolve index directory name for '{}'",
+            index_path.display()
+        )
+    })?;
+    let staging_path = parent.join(format!(".{}.restore-staging", index_name.to_string_lossy()));
+    let backup_path = parent.join(format!(".{}.restore-backup", index_name.to_string_lossy()));
+
+    remove_dir_if_exists_blocking(&staging_path)?;
+    remove_dir_if_exists_blocking(&backup_path)?;
+    copy_dir_recursive_blocking(snapshot, &staging_path)?;
+
+    if index_path.exists() {
+        if let Err(error) = std_fs::rename(index_path, &backup_path) {
+            remove_dir_if_exists_blocking(&staging_path)?;
+            return Err(format!(
+                "Failed to move live index '{}' to backup '{}': {}",
+                index_path.display(),
+                backup_path.display(),
+                error
+            ));
+        }
+    }
+
+    if let Err(error) = std_fs::rename(&staging_path, index_path) {
+        if backup_path.exists() {
+            std_fs::rename(&backup_path, index_path).map_err(|restore_error| {
+                format!(
+                    "Failed to promote staging '{}' to '{}': {}; backup restore also failed: {}",
+                    staging_path.display(),
+                    index_path.display(),
+                    error,
+                    restore_error
+                )
+            })?;
+        }
+        remove_dir_if_exists_blocking(&staging_path)?;
+        return Err(format!(
+            "Failed to promote staging '{}' to '{}': {}",
+            staging_path.display(),
+            index_path.display(),
+            error
+        ));
+    }
+
+    if let Err(error) = remove_dir_if_exists_blocking(&backup_path) {
+        tracing::warn!(
+            backup_path = %backup_path.display(),
+            error = %error,
+            "project_sync.restore.backup_cleanup_failed"
+        );
+    }
+    Ok(())
+}
+
+async fn mark_project_sync_dirty(
+    state: &AppState,
+    index_name: &str,
+    job_id: &str,
+    operation_error: &str,
+    rollback_error: &str,
+) -> ApiResult<()> {
+    let marker_path = dirty_marker_path(state, index_name, job_id);
+    let marker_dir = marker_path.parent().ok_or_else(|| {
+        ApiError::Internal("Failed to resolve project_sync dirty marker directory".to_string())
+    })?;
+    fs::create_dir_all(marker_dir).await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to create project_sync dirty marker directory: {}",
+            error
+        ))
+    })?;
+    let payload = serde_json::json!({
+        "index_name": index_name,
+        "job_id": job_id,
+        "operation_error": operation_error,
+        "rollback_error": rollback_error,
+        "created_at_ms": now_epoch_ms()
+    });
+    let bytes = serde_json::to_vec_pretty(&payload).map_err(|error| {
+        ApiError::Internal(format!("Failed to serialize dirty marker: {}", error))
+    })?;
+    fs::write(&marker_path, bytes).await.map_err(|error| {
+        ApiError::Internal(format!(
+            "Failed to write project_sync dirty marker '{}': {}",
+            marker_path.display(),
+            error
+        ))
+    })?;
+    tracing::error!(
+        index = %index_name,
+        job_id = %job_id,
+        operation_error = %operation_error,
+        rollback_error = %rollback_error,
+        "project_sync.index_dirty"
+    );
+    Ok(())
+}
+
+async fn delete_existing_source_paths_after_repair_locked(
+    state: Arc<AppState>,
+    index_name: &str,
+    source_paths: &[String],
+) -> ApiResult<usize> {
+    if source_paths.is_empty() {
+        return Ok(0);
+    }
+
+    let path_str = state.index_path(index_name).to_string_lossy().to_string();
+    let index_name_owned = index_name.to_string();
+    let paths: Vec<String> = source_paths.to_vec();
+    let state_clone = state.clone();
+
+    task::spawn_blocking(move || -> Result<usize, String> {
+        if !filtering::exists(&path_str) {
+            return Ok(0);
+        }
+
+        if !filtering::has_column(&path_str, "source_path")
+            .map_err(|error| format!("Failed to inspect source_path metadata column: {}", error))?
+        {
+            return Ok(0);
+        }
+
+        let mut doc_ids: Vec<i64> = Vec::new();
+        for path_chunk in paths.chunks(500) {
+            let (condition, parameters) = build_source_path_condition(path_chunk);
+            match filtering::where_condition(&path_str, &condition, &parameters) {
+                Ok(mut chunk_ids) => doc_ids.append(&mut chunk_ids),
+                Err(error) => {
+                    return Err(format!(
+                        "Failed to find existing source_path documents: {}",
+                        error
+                    ));
+                }
+            }
+        }
+        doc_ids.sort_unstable();
+        doc_ids.dedup();
+        if doc_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let mut index = MmapIndex::load(&path_str)
+            .map_err(|error| format!("Failed to load index: {}", error))?;
+        let deleted = index.delete(&doc_ids).map_err(|error| {
+            format!("Failed to delete existing source_path documents: {}", error)
+        })?;
+        index.reload().map_err(|error| {
+            format!("Failed to reload index after source_path delete: {}", error)
+        })?;
+        state_clone
+            .reload_index(&index_name_owned)
+            .map_err(|error| {
+                format!("Failed to reload state after source_path delete: {}", error)
+            })?;
+        Ok(deleted)
+    })
+    .await
+    .map_err(|error| ApiError::Internal(format!("Source path delete task failed: {}", error)))?
+    .map_err(ApiError::Internal)
+}
+
+fn build_source_path_condition(source_paths: &[String]) -> (String, Vec<serde_json::Value>) {
+    if source_paths.len() == 1 {
+        return (
+            "\"source_path\" = ?".to_string(),
+            vec![serde_json::Value::String(source_paths[0].clone())],
+        );
+    }
+
+    let placeholders = std::iter::repeat_n("?", source_paths.len())
+        .collect::<Vec<&str>>()
+        .join(", ");
+    let parameters = source_paths
+        .iter()
+        .map(|path| serde_json::Value::String(path.clone()))
+        .collect::<Vec<serde_json::Value>>();
+    (format!("\"source_path\" IN ({})", placeholders), parameters)
+}
+
+fn copy_dir_recursive_blocking(source: &Path, destination: &Path) -> Result<(), String> {
+    if !source.exists() {
+        return Err(format!(
+            "Snapshot source directory '{}' does not exist",
+            source.display()
+        ));
+    }
+    std_fs::create_dir_all(destination).map_err(|error| {
+        format!(
+            "Failed to create snapshot directory '{}': {}",
+            destination.display(),
+            error
+        )
+    })?;
+
+    for entry_result in std_fs::read_dir(source)
+        .map_err(|error| format!("Failed to read directory '{}': {}", source.display(), error))?
+    {
+        let entry = entry_result.map_err(|error| {
+            format!(
+                "Failed to read directory entry '{}': {}",
+                source.display(),
+                error
+            )
+        })?;
+        let entry_type = entry.file_type().map_err(|error| {
+            format!(
+                "Failed to inspect directory entry '{}': {}",
+                entry.path().display(),
+                error
+            )
+        })?;
+        let target = destination.join(entry.file_name());
+        if entry_type.is_dir() {
+            copy_dir_recursive_blocking(&entry.path(), &target)?;
+        } else if entry_type.is_file() {
+            std_fs::copy(entry.path(), &target).map_err(|error| {
+                format!(
+                    "Failed to copy '{}' to '{}': {}",
+                    entry.path().display(),
+                    target.display(),
+                    error
+                )
+            })?;
+        } else {
+            return Err(format!(
+                "Unsupported file type in snapshot source '{}'",
+                entry.path().display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn remove_dir_if_exists_blocking(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    if path.is_file() {
+        return std_fs::remove_file(path)
+            .map_err(|error| format!("Failed to remove file '{}': {}", path.display(), error));
+    }
+    std_fs::remove_dir_all(path)
+        .map_err(|error| format!("Failed to remove directory '{}': {}", path.display(), error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{ApiConfig, AppState};
+    use axum::body::{Body, Bytes};
+    use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+    use axum::http::{HeaderMap, HeaderValue};
+    use futures_util::stream;
+    use next_plaid::filtering;
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+
+    #[cfg(feature = "model")]
+    fn build_test_state(index_dir: PathBuf) -> AppState {
+        AppState::with_model_pool(
+            ApiConfig {
+                index_dir,
+                default_top_k: 10,
+            },
+            None,
+            None,
+        )
+    }
+
+    #[cfg(not(feature = "model"))]
+    fn build_test_state(index_dir: PathBuf) -> AppState {
+        AppState::new(ApiConfig {
+            index_dir,
+            default_top_k: 10,
+        })
+    }
+
+    fn write_metadata_file(index_path: &Path, num_documents: usize) {
+        let metadata = json!({
+            "num_chunks": 0,
+            "nbits": 4,
+            "num_partitions": 1,
+            "num_embeddings": 0,
+            "avg_doclen": 0.0,
+            "num_documents": num_documents,
+            "embedding_dim": 0,
+            "next_plaid_compatible": true
+        });
+        std_fs::create_dir_all(index_path).expect("index path should exist");
+        std_fs::write(
+            index_path.join("metadata.json"),
+            serde_json::to_vec(&metadata).expect("metadata should serialize"),
+        )
+        .expect("metadata file should persist");
+    }
+
+    #[test]
+    fn source_path_condition_uses_in_clause_for_multiple_paths() {
+        let (condition, parameters) =
+            build_source_path_condition(&["src/lib.rs".to_string(), "src/main.rs".to_string()]);
+
+        assert_eq!(condition, "\"source_path\" IN (?, ?)");
+        assert_eq!(
+            parameters,
+            vec![
+                serde_json::Value::String("src/lib.rs".to_string()),
+                serde_json::Value::String("src/main.rs".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn source_path_delete_skips_legacy_metadata_without_source_path() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = Arc::new(build_test_state(temp_dir.path().to_path_buf()));
+        let index_path = state.index_path("idx");
+        let index_path_str = index_path
+            .to_str()
+            .expect("index path should be valid UTF-8");
+        filtering::create(index_path_str, &[json!({"name": "src/lib.rs"})], &[0])
+            .expect("legacy metadata should exist");
+
+        let deleted = delete_existing_source_paths_after_repair_locked(
+            state,
+            "idx",
+            &["src/lib.rs".to_string()],
+        )
+        .await
+        .expect("legacy metadata should be skipped");
+
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn dirty_marker_path_sanitizes_index_name() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = build_test_state(temp_dir.path().to_path_buf());
+        let marker = dirty_marker_path(&state, "repo/name:prod", "job-1");
+
+        assert!(
+            marker.ends_with("_dirty/repo_name_prod-job-1.json"),
+            "unexpected marker path: {}",
+            marker.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn recovery_restores_snapshot_for_interrupted_running_job() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = Arc::new(build_test_state(temp_dir.path().to_path_buf()));
+        let index_dir = state.index_path("idx");
+        fs::create_dir_all(&index_dir)
+            .await
+            .expect("index dir should exist");
+        fs::write(
+            index_dir.join("config.json"),
+            br#"{"nbits":4,"batch_size":50000,"start_from_scratch":999}"#,
+        )
+        .await
+        .expect("config should exist");
+        fs::write(index_dir.join("state.txt"), b"current")
+            .await
+            .expect("current state should exist");
+
+        let snapshot_dir = snapshot_path(&state, "job-running");
+        fs::create_dir_all(&snapshot_dir)
+            .await
+            .expect("snapshot dir should exist");
+        fs::write(
+            snapshot_dir.join("config.json"),
+            br#"{"nbits":4,"batch_size":50000,"start_from_scratch":999}"#,
+        )
+        .await
+        .expect("snapshot config should exist");
+        fs::write(snapshot_dir.join("state.txt"), b"snapshot")
+            .await
+            .expect("snapshot state should exist");
+
+        let manifest = ProjectSyncJobManifest {
+            job_id: "job-running".to_string(),
+            index_name: "idx".to_string(),
+            status: ProjectSyncJobStatus::Running,
+            declared_bytes: 7,
+            uploaded_bytes: 7,
+            content_type: PROJECT_SYNC_CONTENT_TYPE.to_string(),
+            reserved_bytes: true,
+            error: None,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+        write_manifest(&state, &manifest)
+            .await
+            .expect("manifest should persist");
+        fs::write(spool_path(&state, "job-running"), b"content")
+            .await
+            .expect("spool should persist");
+
+        recover_project_sync_jobs(state.clone())
+            .await
+            .expect("recovery should restore snapshot");
+
+        let recovered_manifest = read_manifest(&state, "job-running")
+            .await
+            .expect("manifest should still exist");
+        assert_eq!(recovered_manifest.status, ProjectSyncJobStatus::Failed);
+        assert!(recovered_manifest
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("rolled back from snapshot"));
+        assert_eq!(pending_ingest_bytes(&state), 0);
+
+        let recovered_state = fs::read_to_string(index_dir.join("state.txt"))
+            .await
+            .expect("restored state should exist");
+        assert_eq!(recovered_state, "snapshot");
+        assert!(!snapshot_path(&state, "job-running").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_project_sync_snapshot_blocking_preserves_live_index_on_snapshot_copy_failure() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let root = temp_dir.path();
+        let index_path = root.join("idx");
+        let snapshot_path = root.join("snapshot");
+        let unsupported_path = snapshot_path.join("unsupported-link");
+
+        write_metadata_file(&index_path, 1);
+        std_fs::write(index_path.join("state.txt"), b"live").expect("live state should exist");
+
+        write_metadata_file(&snapshot_path, 1);
+        std_fs::write(snapshot_path.join("state.txt"), b"snapshot")
+            .expect("snapshot state should exist");
+        std::os::unix::fs::symlink(index_path.join("state.txt"), &unsupported_path)
+            .expect("symlink should exist");
+
+        let error = restore_project_sync_snapshot_blocking(&snapshot_path, &index_path)
+            .expect_err("snapshot copy should fail for unsupported file type");
+
+        assert!(
+            error.contains("Unsupported file type in snapshot source"),
+            "unexpected error: {}",
+            error
+        );
+
+        let live_state = std_fs::read_to_string(index_path.join("state.txt"))
+            .expect("live index should remain readable");
+        assert_eq!(live_state, "live");
+    }
+
+    #[tokio::test]
+    async fn project_sync_postflight_repairs_count_mismatch() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let index_dir = temp_dir.path().join("idx");
+        let index_path = index_dir
+            .to_str()
+            .expect("index path should be valid UTF-8")
+            .to_string();
+        write_metadata_file(&index_dir, 1);
+        filtering::create(
+            &index_path,
+            &[json!({ "kind": "doc-0" }), json!({ "kind": "doc-1" })],
+            &[0, 1],
+        )
+        .expect("metadata db should persist");
+
+        let repair_applied = run_project_sync_postflight_locked(&index_path)
+            .await
+            .expect("postflight should repair mismatch");
+        let after_check = verify_index_db_sync_locked(&index_path)
+            .await
+            .expect("verify should succeed");
+
+        assert!(repair_applied);
+        assert!(after_check.in_sync);
+        assert_eq!(after_check.index_count, 1);
+        assert_eq!(after_check.db_count, 1);
+    }
+
+    #[test]
+    fn job_lock_rebuilds_expired_entry() {
+        let job_id = format!("job-lock-{}", uuid::Uuid::new_v4());
+        let first_lock = job_lock(&job_id);
+        let first_weak = Arc::downgrade(&first_lock);
+
+        drop(first_lock);
+        assert!(first_weak.upgrade().is_none());
+
+        let second_lock = job_lock(&job_id);
+        let locks = JOB_LOCKS
+            .get()
+            .expect("job lock registry should be initialized");
+        let guard = locks
+            .lock()
+            .expect("job lock registry should not be poisoned");
+        let stored_lock = guard
+            .get(&job_id)
+            .and_then(Weak::upgrade)
+            .expect("job lock entry should be rebuilt");
+
+        assert!(Arc::ptr_eq(&second_lock, &stored_lock));
+    }
+
+    #[tokio::test]
+    async fn upload_timeout_resets_manifest_to_created_and_cleans_spool() {
+        let temp_dir = TempDir::new().expect("temp dir should exist");
+        let state = Arc::new(build_test_state(temp_dir.path().to_path_buf()));
+        let job_id = "job-upload-timeout";
+        let declared_bytes = 10_u64;
+        let manifest = ProjectSyncJobManifest {
+            job_id: job_id.to_string(),
+            index_name: "idx".to_string(),
+            status: ProjectSyncJobStatus::Created,
+            declared_bytes,
+            uploaded_bytes: 0,
+            content_type: PROJECT_SYNC_CONTENT_TYPE.to_string(),
+            reserved_bytes: true,
+            error: None,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+        };
+        reserve_pending_ingest_bytes(&state, declared_bytes);
+        write_manifest(&state, &manifest)
+            .await
+            .expect("manifest should persist");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static(PROJECT_SYNC_CONTENT_TYPE),
+        );
+        headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&declared_bytes.to_string())
+                .expect("content-length header should be valid"),
+        );
+
+        let body = Body::from_stream(stream::unfold(0_u8, |step| async move {
+            match step {
+                0 => Some((Ok::<Bytes, std::io::Error>(Bytes::from_static(b"12345")), 1)),
+                1 => {
+                    tokio::time::sleep(Duration::from_millis(80)).await;
+                    Some((Ok::<Bytes, std::io::Error>(Bytes::from_static(b"67890")), 2))
+                }
+                _ => None,
+            }
+        }));
+
+        let result = upload_project_sync_job_with_idle_timeout(
+            state.clone(),
+            job_id,
+            headers,
+            body,
+            Duration::from_millis(50),
+        )
+        .await;
+
+        match result {
+            Err(ApiError::RequestTimeout(message)) => {
+                assert!(
+                    message.contains("timed out"),
+                    "unexpected timeout message: {}",
+                    message
+                );
+            }
+            _ => panic!("expected request timeout"),
+        }
+
+        let manifest = read_manifest(&state, job_id)
+            .await
+            .expect("manifest should still exist");
+        assert_eq!(manifest.status, ProjectSyncJobStatus::Created);
+        assert_eq!(manifest.uploaded_bytes, 0);
+        assert!(manifest.reserved_bytes);
+        assert_eq!(pending_ingest_bytes(&state), declared_bytes);
+        assert!(manifest
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("timed out"));
+        assert!(!spool_path(&state, job_id).exists());
+        assert!(!temp_spool_path(&state, job_id).exists());
+    }
+}

--- a/next-plaid-api/src/main.rs
+++ b/next-plaid-api/src/main.rs
@@ -80,6 +80,7 @@ use state::{ApiConfig, AppState};
         (name = "health", description = "Health check endpoints"),
         (name = "indices", description = "Index management operations"),
         (name = "documents", description = "Document upload and deletion"),
+        (name = "project_sync", description = "MCP project sync staged upload operations"),
         (name = "search", description = "Search operations"),
         (name = "metadata", description = "Metadata management and filtering"),
         (name = "encoding", description = "Text encoding operations (requires --model)"),
@@ -96,6 +97,11 @@ use state::{ApiConfig, AppState};
         handlers::documents::update_index,
         handlers::documents::update_index_config,
         handlers::documents::update_index_with_encoding,
+        handlers::project_sync::create_project_sync_job,
+        handlers::project_sync::upload_project_sync_job,
+        handlers::project_sync::finalize_project_sync_job,
+        handlers::project_sync::get_project_sync_job,
+        handlers::project_sync::cancel_project_sync_job,
         handlers::search::search,
         handlers::search::search_filtered,
         handlers::search::search_with_encoding,
@@ -151,6 +157,10 @@ use state::{ApiConfig, AppState};
         models::SearchWithEncodingRequest,
         models::FilteredSearchWithEncodingRequest,
         models::UpdateWithEncodingRequest,
+        models::ProjectSyncCreateJobRequest,
+        models::ProjectSyncCreateJobResponse,
+        models::ProjectSyncJobStatus,
+        models::ProjectSyncJobResponse,
         models::RerankRequest,
         models::RerankWithEncodingRequest,
         models::RerankResult,
@@ -418,6 +428,53 @@ fn build_router(state: Arc<AppState>) -> Router {
         .layer(ConcurrencyLimitLayer::new(concurrency_limit))
         .with_state(state.clone());
 
+    let project_sync_router = Router::new()
+        .without_v07_checks()
+        .route(
+            "/indices/{name}/project_sync/jobs",
+            post(handlers::create_project_sync_job),
+        )
+        .route(
+            "/project_sync/jobs/{job_id}/finalize",
+            post(handlers::finalize_project_sync_job),
+        )
+        .route(
+            "/project_sync/jobs/{job_id}",
+            get(handlers::get_project_sync_job).delete(handlers::cancel_project_sync_job),
+        )
+        .layer(middleware::from_fn(tracing_middleware::trace_request))
+        .layer(TraceLayer::new_for_http())
+        .layer(TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(300),
+        ))
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        )
+        .layer(ConcurrencyLimitLayer::new(concurrency_limit))
+        .with_state(state.clone());
+
+    let project_sync_upload_router = Router::new()
+        .without_v07_checks()
+        .route(
+            "/project_sync/jobs/{job_id}/upload",
+            put(handlers::upload_project_sync_job),
+        )
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        )
+        .layer(ConcurrencyLimitLayer::new(concurrency_limit))
+        .layer(DefaultBodyLimit::max(
+            handlers::project_sync::max_ingest_request_bytes() as usize,
+        ))
+        .with_state(state.clone());
+
     // API router with rate limiting - use without_v07_checks to allow :param syntax
     let api_router = Router::new()
         .without_v07_checks()
@@ -499,6 +556,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .merge(update_router)
         .merge(encode_router)
         .merge(delete_router)
+        .merge(project_sync_router)
+        .merge(project_sync_upload_router)
         .merge(api_router)
 }
 
@@ -848,6 +907,12 @@ Examples:
         }
         Arc::new(AppState::new(config))
     };
+
+    if let Err(error) = handlers::project_sync::recover_project_sync_jobs(state.clone()).await {
+        tracing::error!(error = %error, "project_sync.recovery.failed");
+        eprintln!("Error: project_sync recovery failed: {}", error);
+        std::process::exit(1);
+    }
 
     // Build router
     let app = build_router(state);

--- a/next-plaid-api/src/models.rs
+++ b/next-plaid-api/src/models.rs
@@ -786,6 +786,76 @@ pub struct UpdateWithEncodingRequest {
 }
 
 // =============================================================================
+// Project Sync
+// =============================================================================
+
+/// Request to create a staged project sync job for MCP project uploads.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectSyncCreateJobRequest {
+    /// Exact byte size of the later upload body.
+    #[schema(example = 4096)]
+    pub declared_bytes: u64,
+    /// Content type of the later upload body.
+    #[schema(example = "application/x-ndjson")]
+    pub content_type: String,
+}
+
+/// Response returned after accepting a project sync job.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ProjectSyncCreateJobResponse {
+    /// Server-assigned project sync job identifier.
+    #[schema(example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")]
+    pub job_id: String,
+    /// Initial job status.
+    pub status: ProjectSyncJobStatus,
+    /// Reserved byte budget for this job.
+    #[schema(example = 4096)]
+    pub declared_bytes: u64,
+}
+
+/// Public project sync job lifecycle.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectSyncJobStatus {
+    Created,
+    Uploading,
+    Uploaded,
+    Queued,
+    Running,
+    Cancelling,
+    Completed,
+    Failed,
+    Cancelled,
+    Expired,
+}
+
+/// Response describing current project sync job state.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ProjectSyncJobResponse {
+    /// Job identifier.
+    #[schema(example = "f47ac10b-58cc-4372-a567-0e02b2c3d479")]
+    pub job_id: String,
+    /// Target index name.
+    #[schema(example = "project_1234abcd")]
+    pub index_name: String,
+    /// Current job status.
+    pub status: ProjectSyncJobStatus,
+    /// Reserved byte budget declared during create-job.
+    #[schema(example = 4096)]
+    pub declared_bytes: u64,
+    /// Bytes currently written to spool.
+    #[schema(example = 4096)]
+    pub uploaded_bytes: u64,
+    /// Upload content type.
+    #[schema(example = "application/x-ndjson")]
+    pub content_type: String,
+    /// Optional server-side error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+// =============================================================================
 // Reranking
 // =============================================================================
 

--- a/next-plaid-api/tests/integration_tests.rs
+++ b/next-plaid-api/tests/integration_tests.rs
@@ -2,10 +2,12 @@
 //!
 //! These tests create real indices and test all API endpoints.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{
+    extract::DefaultBodyLimit,
     http::StatusCode,
     routing::{get, post, put},
     Json, Router,
@@ -15,15 +17,20 @@ use ndarray_rand::rand_distr::Uniform;
 use ndarray_rand::RandomExt;
 use serde_json::{json, Value};
 use tempfile::TempDir;
-use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::{
+    cors::{Any, CorsLayer},
+    timeout::TimeoutLayer,
+};
 
 // Import from the API crate
 use next_plaid_api::{
     handlers,
     models::{
         CheckMetadataResponse, CreateIndexResponse, GetMetadataResponse, IndexInfoResponse,
+        ProjectSyncCreateJobResponse, ProjectSyncJobResponse, ProjectSyncJobStatus,
         QueryMetadataResponse, RerankResponse, SearchResponse,
     },
     state::{ApiConfig, AppState},
@@ -41,6 +48,10 @@ struct TestFixture {
 impl TestFixture {
     /// Create a new test fixture with a temporary index directory.
     async fn new() -> Self {
+        Self::new_with_project_sync_timeout(Duration::from_secs(300)).await
+    }
+
+    async fn new_with_project_sync_timeout(project_sync_timeout: Duration) -> Self {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
         let config = ApiConfig {
@@ -54,7 +65,7 @@ impl TestFixture {
         let state = Arc::new(AppState::new(config));
 
         // Build router
-        let app = build_test_router(state);
+        let app = build_test_router_with_project_sync_timeout(state, project_sync_timeout);
 
         // Find available port
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -174,6 +185,123 @@ impl TestFixture {
         }
     }
 
+    async fn wait_for_project_sync_terminal_status(
+        &self,
+        job_id: &str,
+        max_wait_ms: u64,
+    ) -> ProjectSyncJobResponse {
+        let start = std::time::Instant::now();
+        loop {
+            let resp = self
+                .client
+                .get(self.url(&format!("/project_sync/jobs/{}", job_id)))
+                .send()
+                .await;
+
+            if let Ok(resp) = resp {
+                if resp.status().is_success() {
+                    if let Ok(job) = resp.json::<ProjectSyncJobResponse>().await {
+                        if job.status == ProjectSyncJobStatus::Completed
+                            || job.status == ProjectSyncJobStatus::Failed
+                            || job.status == ProjectSyncJobStatus::Cancelled
+                            || job.status == ProjectSyncJobStatus::Expired
+                        {
+                            return job;
+                        }
+                    }
+                }
+            }
+
+            if start.elapsed().as_millis() as u64 > max_wait_ms {
+                panic!(
+                    "Timeout waiting for project_sync job '{}' to reach terminal state",
+                    job_id
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn wait_for_project_sync_status(
+        &self,
+        job_id: &str,
+        expected_status: ProjectSyncJobStatus,
+        max_wait_ms: u64,
+    ) -> ProjectSyncJobResponse {
+        let start = std::time::Instant::now();
+        loop {
+            let resp = self
+                .client
+                .get(self.url(&format!("/project_sync/jobs/{}", job_id)))
+                .send()
+                .await;
+
+            if let Ok(resp) = resp {
+                if resp.status().is_success() {
+                    if let Ok(job) = resp.json::<ProjectSyncJobResponse>().await {
+                        if job.status == expected_status {
+                            return job;
+                        }
+                    }
+                }
+            }
+
+            if start.elapsed().as_millis() as u64 > max_wait_ms {
+                panic!(
+                    "Timeout waiting for project_sync job '{}' to reach status {:?}",
+                    job_id, expected_status
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    async fn open_raw_http_connection(&self) -> TcpStream {
+        let url = reqwest::Url::parse(&self.base_url).expect("base URL should be valid");
+        let host = url.host_str().expect("base URL should include host");
+        let port = url
+            .port_or_known_default()
+            .expect("base URL should include port");
+        TcpStream::connect((host, port))
+            .await
+            .expect("raw TCP connection should open")
+    }
+
+    fn raw_http_authority(&self) -> String {
+        let url = reqwest::Url::parse(&self.base_url).expect("base URL should be valid");
+        let host = url.host_str().expect("base URL should include host");
+        let port = url
+            .port_or_known_default()
+            .expect("base URL should include port");
+        format!("{}:{}", host, port)
+    }
+
+    fn project_sync_job_dir(&self, job_id: &str) -> PathBuf {
+        self._temp_dir
+            .path()
+            .join("_project_sync_jobs")
+            .join(job_id)
+    }
+
+    async fn read_project_sync_manifest(&self, job_id: &str) -> Value {
+        let path = self.project_sync_job_dir(job_id).join("manifest.json");
+        let bytes = tokio::fs::read(path)
+            .await
+            .expect("project_sync manifest should exist");
+        serde_json::from_slice(&bytes).expect("project_sync manifest should deserialize")
+    }
+
+    async fn write_project_sync_manifest(&self, job_id: &str, manifest: &Value) {
+        let manifest_bytes =
+            serde_json::to_vec_pretty(manifest).expect("project_sync manifest should serialize");
+        tokio::fs::write(
+            self.project_sync_job_dir(job_id).join("manifest.json"),
+            manifest_bytes,
+        )
+        .await
+        .expect("project_sync manifest should persist");
+    }
+
     /// Helper to create and populate an index in one step.
     /// This is the new workflow: 1) declare index, 2) update with documents (async).
     /// Returns the IndexInfoResponse after the background task completes.
@@ -264,8 +392,44 @@ fn rate_limit_error(_err: tower_governor::GovernorError) -> axum::http::Response
         .unwrap()
 }
 
+const TEST_PROJECT_SYNC_MAX_INGEST_REQUEST_BYTES: usize = 100 * 1024 * 1024;
+
 /// Build the test router (same as main but without tracing).
-fn build_test_router(state: Arc<AppState>) -> Router {
+fn build_project_sync_control_test_router(project_sync_timeout: Duration) -> Router<Arc<AppState>> {
+    Router::new()
+        .route(
+            "/indices/{name}/project_sync/jobs",
+            post(handlers::create_project_sync_job),
+        )
+        .route(
+            "/project_sync/jobs/{job_id}/finalize",
+            post(handlers::finalize_project_sync_job),
+        )
+        .route(
+            "/project_sync/jobs/{job_id}",
+            get(handlers::get_project_sync_job).delete(handlers::cancel_project_sync_job),
+        )
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            project_sync_timeout,
+        ))
+}
+
+fn build_project_sync_upload_test_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route(
+            "/project_sync/jobs/{job_id}/upload",
+            put(handlers::upload_project_sync_job),
+        )
+        .layer(DefaultBodyLimit::max(
+            TEST_PROJECT_SYNC_MAX_INGEST_REQUEST_BYTES,
+        ))
+}
+
+fn build_test_router_with_project_sync_timeout(
+    state: Arc<AppState>,
+    project_sync_timeout: Duration,
+) -> Router {
     // Index management routes
     let index_routes = Router::new()
         .route(
@@ -320,6 +484,8 @@ fn build_test_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .nest("/indices", indices_router)
+        .merge(build_project_sync_control_test_router(project_sync_timeout))
+        .merge(build_project_sync_upload_test_router())
         .merge(rerank_route)
         .layer(
             CorsLayer::new()
@@ -406,6 +572,18 @@ fn build_rate_limited_test_router(
         // Rate limiting layer
         .layer(governor_layer)
         .with_state(state)
+}
+
+fn build_project_sync_ndjson_payload(path: &str, content: &str) -> String {
+    let record = json!({
+        "path": path,
+        "content": content,
+        "language": "rust"
+    });
+    format!(
+        "{}\n",
+        serde_json::to_string(&record).expect("project_sync record should serialize")
+    )
 }
 
 /// Test fixture for rate limiting tests with configurable rate limits.
@@ -1447,6 +1625,813 @@ async fn test_rate_limiting() {
     assert_eq!(body["status"], "healthy", "Expected healthy status");
 }
 
+#[tokio::test]
+async fn test_project_sync_create_upload_cancel_status() {
+    let fixture = TestFixture::new().await;
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": "project_sync_cancel_test" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload = concat!(
+        "{\"path\":\"src/main.rs\",\"content\":\"fn main() {}\",\"language\":\"rust\",",
+        "\"metadata\":{\"module\":\"main\"}}\n"
+    )
+    .to_string();
+    let declared_bytes = payload.len() as u64;
+
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_cancel_test/project_sync/jobs"))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+    assert_eq!(create_job_body.status, ProjectSyncJobStatus::Created);
+
+    let upload_resp = fixture
+        .client
+        .put(fixture.url(&format!(
+            "/project_sync/jobs/{}/upload",
+            create_job_body.job_id
+        )))
+        .header("content-type", "application/x-ndjson")
+        .body(payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(upload_resp.status(), reqwest::StatusCode::OK);
+    let upload_body: ProjectSyncJobResponse = upload_resp.json().await.unwrap();
+    assert_eq!(upload_body.status, ProjectSyncJobStatus::Uploaded);
+    assert_eq!(upload_body.uploaded_bytes, declared_bytes);
+
+    let get_resp = fixture
+        .client
+        .get(fixture.url(&format!("/project_sync/jobs/{}", create_job_body.job_id)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get_resp.status(), reqwest::StatusCode::OK);
+    let get_body: ProjectSyncJobResponse = get_resp.json().await.unwrap();
+    assert_eq!(get_body.status, ProjectSyncJobStatus::Uploaded);
+
+    let job_dir = fixture.project_sync_job_dir(&create_job_body.job_id);
+    assert!(job_dir.join("spool.ndjson").exists());
+
+    let replay_upload_resp = fixture
+        .client
+        .put(fixture.url(&format!(
+            "/project_sync/jobs/{}/upload",
+            create_job_body.job_id
+        )))
+        .header("content-type", "application/x-ndjson")
+        .body(
+            "{\"path\":\"src/other.rs\",\"content\":\"fn other() {}\",\"language\":\"rust\"}\n"
+                .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replay_upload_resp.status(), reqwest::StatusCode::CONFLICT);
+    assert!(job_dir.join("spool.ndjson").exists());
+
+    let cancel_resp = fixture
+        .client
+        .delete(fixture.url(&format!("/project_sync/jobs/{}", create_job_body.job_id)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cancel_resp.status(), reqwest::StatusCode::OK);
+    let cancel_body: ProjectSyncJobResponse = cancel_resp.json().await.unwrap();
+    assert_eq!(cancel_body.status, ProjectSyncJobStatus::Cancelled);
+    assert_eq!(cancel_body.error.as_deref(), Some("Cancelled by client"));
+
+    let cancel_again_resp = fixture
+        .client
+        .delete(fixture.url(&format!("/project_sync/jobs/{}", create_job_body.job_id)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cancel_again_resp.status(), reqwest::StatusCode::OK);
+    let cancel_again_body: ProjectSyncJobResponse = cancel_again_resp.json().await.unwrap();
+    assert_eq!(cancel_again_body.status, ProjectSyncJobStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn test_project_sync_upload_route_is_not_wrapped_by_control_timeout() {
+    let fixture = TestFixture::new_with_project_sync_timeout(Duration::from_millis(50)).await;
+    let index_name = "project_sync_upload_timeout_split_test";
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": index_name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload = build_project_sync_ndjson_payload("src/main.rs", "fn main() {}\n");
+    let declared_bytes = payload.len() as u64;
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+    let split_at = payload.len() / 2;
+    let first_chunk = &payload[..split_at];
+    let second_chunk = &payload[split_at..];
+    let mut stream = fixture.open_raw_http_connection().await;
+    let request = format!(
+        concat!(
+            "PUT /project_sync/jobs/{}/upload HTTP/1.1\r\n",
+            "Host: {}\r\n",
+            "Content-Type: application/x-ndjson\r\n",
+            "Content-Length: {}\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "{}"
+        ),
+        create_job_body.job_id,
+        fixture.raw_http_authority(),
+        declared_bytes,
+        first_chunk
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+    fixture
+        .wait_for_project_sync_status(
+            &create_job_body.job_id,
+            ProjectSyncJobStatus::Uploading,
+            5_000,
+        )
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    stream.write_all(second_chunk.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut response_bytes: Vec<u8> = Vec::new();
+    stream.read_to_end(&mut response_bytes).await.unwrap();
+    let response_text = String::from_utf8_lossy(&response_bytes);
+    assert!(
+        response_text.starts_with("HTTP/1.1 200"),
+        "unexpected upload response: {}",
+        response_text
+    );
+
+    let uploaded_job = fixture
+        .wait_for_project_sync_status(
+            &create_job_body.job_id,
+            ProjectSyncJobStatus::Uploaded,
+            5_000,
+        )
+        .await;
+    assert_eq!(uploaded_job.uploaded_bytes, declared_bytes);
+}
+
+#[tokio::test]
+async fn test_project_sync_create_job_rejects_sha256_field() {
+    let fixture = TestFixture::new().await;
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": "project_sync_sha256_reject_test" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_sha256_reject_test/project_sync/jobs"))
+        .json(&json!({
+            "declared_bytes": 10,
+            "content_type": "application/x-ndjson",
+            "sha256": "abc"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let body: Value = create_job_resp.json().await.unwrap();
+    assert_eq!(body["code"], "BAD_REQUEST");
+    assert!(body["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("unknown field `sha256`"));
+}
+
+#[tokio::test]
+async fn test_project_sync_upload_can_be_cancelled_mid_stream() {
+    let fixture = TestFixture::new().await;
+    let index_name = "project_sync_cancel_mid_upload_test";
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": index_name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let declared_bytes = 100_u64 * 1024 * 1024;
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+    let mut reserved_job_ids_count: usize = 0;
+    for _ in 0..9 {
+        let reserve_resp = fixture
+            .client
+            .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+            .json(&json!({
+                "declared_bytes": declared_bytes,
+                "content_type": "application/x-ndjson"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(reserve_resp.status(), reqwest::StatusCode::OK);
+        let _: ProjectSyncCreateJobResponse = reserve_resp.json().await.unwrap();
+        reserved_job_ids_count += 1;
+    }
+    assert_eq!(reserved_job_ids_count, 9);
+
+    let mut stream = fixture.open_raw_http_connection().await;
+    let first_chunk = "a".repeat(1024);
+    let request = format!(
+        concat!(
+            "PUT /project_sync/jobs/{}/upload HTTP/1.1\r\n",
+            "Host: {}\r\n",
+            "Content-Type: application/x-ndjson\r\n",
+            "Content-Length: {}\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "{}"
+        ),
+        create_job_body.job_id,
+        fixture.raw_http_authority(),
+        declared_bytes,
+        first_chunk
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    fixture
+        .wait_for_project_sync_status(
+            &create_job_body.job_id,
+            ProjectSyncJobStatus::Uploading,
+            5_000,
+        )
+        .await;
+
+    let cancel_resp = fixture
+        .client
+        .delete(fixture.url(&format!("/project_sync/jobs/{}", create_job_body.job_id)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cancel_resp.status(), reqwest::StatusCode::OK);
+    let cancel_body: ProjectSyncJobResponse = cancel_resp.json().await.unwrap();
+    assert_eq!(cancel_body.status, ProjectSyncJobStatus::Cancelling);
+    assert_eq!(
+        cancel_body.error.as_deref(),
+        Some("Cancellation requested by client")
+    );
+
+    stream.shutdown().await.unwrap();
+    let mut response_bytes: Vec<u8> = Vec::new();
+    stream.read_to_end(&mut response_bytes).await.unwrap();
+    let response_text = String::from_utf8_lossy(&response_bytes);
+    assert!(
+        response_text.starts_with("HTTP/1.1 409"),
+        "unexpected upload response: {}",
+        response_text
+    );
+
+    let terminal_job = fixture
+        .wait_for_project_sync_terminal_status(&create_job_body.job_id, 10_000)
+        .await;
+    assert_eq!(terminal_job.status, ProjectSyncJobStatus::Cancelled);
+    assert_eq!(terminal_job.error.as_deref(), Some("Cancelled by client"));
+
+    let manifest = fixture
+        .read_project_sync_manifest(&create_job_body.job_id)
+        .await;
+    assert_eq!(manifest["status"], "cancelled");
+    assert_eq!(manifest["reserved_bytes"], false);
+
+    let job_dir = fixture.project_sync_job_dir(&create_job_body.job_id);
+    assert!(!job_dir.join("spool.ndjson").exists());
+    assert!(!job_dir.join("spool.ndjson.tmp").exists());
+
+    let finalize_resp = fixture
+        .client
+        .post(fixture.url(&format!(
+            "/project_sync/jobs/{}/finalize",
+            create_job_body.job_id
+        )))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(finalize_resp.status(), reqwest::StatusCode::CONFLICT);
+
+    let released_capacity_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(released_capacity_resp.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_project_sync_finalize_reaches_terminal_status_without_model() {
+    let fixture = TestFixture::new().await;
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": "project_sync_finalize_test" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload = concat!(
+        "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 42 }\",",
+        "\"language\":\"rust\",\"metadata\":{\"kind\":\"function\"}}\n"
+    )
+    .to_string();
+    let declared_bytes = payload.len() as u64;
+
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_finalize_test/project_sync/jobs"))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+    let upload_resp = fixture
+        .client
+        .put(fixture.url(&format!(
+            "/project_sync/jobs/{}/upload",
+            create_job_body.job_id
+        )))
+        .header("content-type", "application/x-ndjson")
+        .body(payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(upload_resp.status(), reqwest::StatusCode::OK);
+
+    let finalize_resp = fixture
+        .client
+        .post(fixture.url(&format!(
+            "/project_sync/jobs/{}/finalize",
+            create_job_body.job_id
+        )))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(finalize_resp.status(), reqwest::StatusCode::OK);
+    let finalize_body: ProjectSyncJobResponse = finalize_resp.json().await.unwrap();
+    assert_eq!(finalize_body.status, ProjectSyncJobStatus::Queued);
+
+    let terminal_job = fixture
+        .wait_for_project_sync_terminal_status(&create_job_body.job_id, 10_000)
+        .await;
+    assert_eq!(terminal_job.status, ProjectSyncJobStatus::Failed);
+    assert!(
+        terminal_job
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Model"),
+        "Expected model-related failure, got {:?}",
+        terminal_job.error
+    );
+
+    let job_dir = fixture.project_sync_job_dir(&create_job_body.job_id);
+    assert!(!job_dir.join("spool.ndjson").exists());
+    assert!(!job_dir.join("spool.ndjson.tmp").exists());
+
+    let status_resp = fixture
+        .client
+        .get(fixture.url(&format!("/project_sync/jobs/{}", create_job_body.job_id)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(status_resp.status(), reqwest::StatusCode::OK);
+    let status_body: ProjectSyncJobResponse = status_resp.json().await.unwrap();
+    assert_eq!(status_body.status, ProjectSyncJobStatus::Failed);
+}
+
+#[tokio::test]
+async fn test_project_sync_rejects_duplicate_paths_before_replace() {
+    let fixture = TestFixture::new().await;
+    let index_name = "project_sync_duplicate_path_test";
+
+    let documents: Vec<Value> = vec![
+        json!({"embeddings": [[1.0, 0.0, 0.0, 0.0]]}),
+        json!({"embeddings": [[0.0, 1.0, 0.0, 0.0]]}),
+    ];
+    let metadata: Vec<Value> = vec![
+        json!({"source_path": "src/lib.rs", "version": 1}),
+        json!({"source_path": "src/main.rs", "version": 1}),
+    ];
+    fixture
+        .create_and_populate_index(index_name, documents, metadata, None)
+        .await;
+
+    let payload = concat!(
+        "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 40 }\",\"language\":\"rust\"}\n",
+        "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 41 }\",\"language\":\"rust\"}\n"
+    )
+    .to_string();
+    let declared_bytes = payload.len() as u64;
+
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+    let upload_resp = fixture
+        .client
+        .put(fixture.url(&format!(
+            "/project_sync/jobs/{}/upload",
+            create_job_body.job_id
+        )))
+        .header("content-type", "application/x-ndjson")
+        .body(payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(upload_resp.status(), reqwest::StatusCode::OK);
+
+    let finalize_resp = fixture
+        .client
+        .post(fixture.url(&format!(
+            "/project_sync/jobs/{}/finalize",
+            create_job_body.job_id
+        )))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(finalize_resp.status(), reqwest::StatusCode::OK);
+
+    let terminal_job = fixture
+        .wait_for_project_sync_terminal_status(&create_job_body.job_id, 10_000)
+        .await;
+    assert_eq!(terminal_job.status, ProjectSyncJobStatus::Failed);
+    assert!(terminal_job
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("duplicate path 'src/lib.rs'"));
+
+    fixture
+        .wait_for_exact_doc_count(index_name, 2, 10_000)
+        .await;
+    fixture.wait_for_metadata_count(index_name, 2, 10_000).await;
+
+    let lib_query_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/metadata/query", index_name)))
+        .json(&json!({
+            "condition": "source_path = ?",
+            "parameters": ["src/lib.rs"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(lib_query_resp.status().is_success());
+    let lib_query_body: QueryMetadataResponse = lib_query_resp.json().await.unwrap();
+    assert_eq!(lib_query_body.count, 1);
+
+    let job_dir = fixture.project_sync_job_dir(&create_job_body.job_id);
+    assert!(!job_dir.join("spool.ndjson").exists());
+    assert!(!job_dir.join("spool.ndjson.tmp").exists());
+    assert!(!job_dir.join("index_snapshot").exists());
+    assert!(!fixture
+        ._temp_dir
+        .path()
+        .join("_project_sync_jobs")
+        .join("_dirty")
+        .exists());
+}
+
+#[tokio::test]
+async fn test_project_sync_admission_limits() {
+    let fixture = TestFixture::new().await;
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": "project_sync_limits_test" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let too_large_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_limits_test/project_sync/jobs"))
+        .json(&json!({
+            "declared_bytes": (100_u64 * 1024 * 1024) + 1,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        too_large_resp.status(),
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE
+    );
+    let too_large_body: Value = too_large_resp.json().await.unwrap();
+    assert_eq!(
+        too_large_body["details"]["max_ingest_request_bytes"],
+        100_u64 * 1024 * 1024
+    );
+
+    let mut reserved_job_ids: Vec<String> = Vec::new();
+    for _ in 0..10 {
+        let create_resp = fixture
+            .client
+            .post(fixture.url("/indices/project_sync_limits_test/project_sync/jobs"))
+            .json(&json!({
+                "declared_bytes": 100_u64 * 1024 * 1024,
+                "content_type": "application/x-ndjson"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), reqwest::StatusCode::OK);
+        let create_body: ProjectSyncCreateJobResponse = create_resp.json().await.unwrap();
+        reserved_job_ids.push(create_body.job_id);
+    }
+
+    let backlog_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_limits_test/project_sync/jobs"))
+        .json(&json!({
+            "declared_bytes": 100_u64 * 1024 * 1024,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        backlog_resp.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE
+    );
+    assert_eq!(
+        backlog_resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .expect("retry-after header should exist"),
+        "5"
+    );
+    let backlog_body: Value = backlog_resp.json().await.unwrap();
+    assert_eq!(
+        backlog_body["details"]["required_bytes"],
+        100_u64 * 1024 * 1024
+    );
+    assert_eq!(
+        backlog_body["details"]["pending_ingest_bytes"],
+        10_u64 * 100_u64 * 1024 * 1024
+    );
+    assert_eq!(
+        backlog_body["details"]["max_pending_ingest_bytes"],
+        1024_u64 * 1024 * 1024
+    );
+    assert_eq!(backlog_body["details"]["retry_after_seconds_hint"], 5);
+
+    for job_id in reserved_job_ids {
+        let cancel_resp = fixture
+            .client
+            .delete(fixture.url(&format!("/project_sync/jobs/{}", job_id)))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(cancel_resp.status(), reqwest::StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn test_project_sync_expired_jobs_release_pending_budget() {
+    let fixture = TestFixture::new().await;
+    let index_name = "project_sync_expiry_test";
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": index_name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let declared_bytes = 100_u64 * 1024 * 1024;
+    let mut created_job_ids: Vec<String> = Vec::new();
+    for _ in 0..10 {
+        let create_resp = fixture
+            .client
+            .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+            .json(&json!({
+                "declared_bytes": declared_bytes,
+                "content_type": "application/x-ndjson"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), reqwest::StatusCode::OK);
+        let create_body: ProjectSyncCreateJobResponse = create_resp.json().await.unwrap();
+        created_job_ids.push(create_body.job_id);
+    }
+
+    let mut stale_manifest = fixture
+        .read_project_sync_manifest(&created_job_ids[0])
+        .await;
+    stale_manifest["updated_at_ms"] = json!(1_u64);
+    fixture
+        .write_project_sync_manifest(&created_job_ids[0], &stale_manifest)
+        .await;
+
+    let create_after_expiry_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_after_expiry_resp.status(), reqwest::StatusCode::OK);
+
+    let expired_manifest = fixture
+        .read_project_sync_manifest(&created_job_ids[0])
+        .await;
+    assert_eq!(expired_manifest["status"], "expired");
+    assert_eq!(expired_manifest["reserved_bytes"], false);
+}
+
+#[tokio::test]
+async fn test_project_sync_expired_upload_cannot_revive_job() {
+    let fixture = TestFixture::new().await;
+    let index_name = "project_sync_expired_upload_test";
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({ "name": index_name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload = build_project_sync_ndjson_payload("src/lib.rs", "pub fn value() -> u32 { 1 }\n");
+    let declared_bytes = payload.len() as u64;
+    let create_job_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+    let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+    let split_at = payload.len() / 2;
+    let first_chunk = &payload[..split_at];
+    let second_chunk = &payload[split_at..];
+    let mut stream = fixture.open_raw_http_connection().await;
+    let request = format!(
+        concat!(
+            "PUT /project_sync/jobs/{}/upload HTTP/1.1\r\n",
+            "Host: {}\r\n",
+            "Content-Type: application/x-ndjson\r\n",
+            "Content-Length: {}\r\n",
+            "Connection: close\r\n",
+            "\r\n",
+            "{}"
+        ),
+        create_job_body.job_id,
+        fixture.raw_http_authority(),
+        declared_bytes,
+        first_chunk
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+    fixture
+        .wait_for_project_sync_status(
+            &create_job_body.job_id,
+            ProjectSyncJobStatus::Uploading,
+            5_000,
+        )
+        .await;
+
+    let mut stale_manifest = fixture
+        .read_project_sync_manifest(&create_job_body.job_id)
+        .await;
+    stale_manifest["updated_at_ms"] = json!(1_u64);
+    fixture
+        .write_project_sync_manifest(&create_job_body.job_id, &stale_manifest)
+        .await;
+
+    let sweep_resp = fixture
+        .client
+        .post(fixture.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+        .json(&json!({
+            "declared_bytes": declared_bytes,
+            "content_type": "application/x-ndjson"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(sweep_resp.status(), reqwest::StatusCode::OK);
+
+    let expired_manifest = fixture
+        .read_project_sync_manifest(&create_job_body.job_id)
+        .await;
+    assert_eq!(expired_manifest["status"], "expired");
+    assert_eq!(expired_manifest["reserved_bytes"], false);
+
+    stream.write_all(second_chunk.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut response_bytes: Vec<u8> = Vec::new();
+    stream.read_to_end(&mut response_bytes).await.unwrap();
+    let response_text = String::from_utf8_lossy(&response_bytes);
+    assert!(
+        response_text.starts_with("HTTP/1.1 409"),
+        "unexpected upload response: {}",
+        response_text
+    );
+
+    let final_manifest = fixture
+        .read_project_sync_manifest(&create_job_body.job_id)
+        .await;
+    assert_eq!(final_manifest["status"], "expired");
+    assert_eq!(final_manifest["reserved_bytes"], false);
+    let job_dir = fixture.project_sync_job_dir(&create_job_body.job_id);
+    assert!(!job_dir.join("spool.ndjson").exists());
+    assert!(!job_dir.join("spool.ndjson.tmp").exists());
+}
+
 // =============================================================================
 // Model/Encoding Tests (requires "model" feature)
 // =============================================================================
@@ -1536,6 +2521,154 @@ impl ModelTestFixture {
         format!("{}{}", self.base_url, path)
     }
 
+    async fn wait_for_exact_doc_count(&self, name: &str, expected_docs: usize, max_wait_ms: u64) {
+        let start = std::time::Instant::now();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        loop {
+            let resp = self
+                .client
+                .get(self.url(&format!("/indices/{}", name)))
+                .send()
+                .await;
+
+            if let Ok(resp) = resp {
+                if resp.status().is_success() {
+                    if let Ok(info) = resp.json::<IndexInfoResponse>().await {
+                        if info.num_documents == expected_docs {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if start.elapsed().as_millis() as u64 > max_wait_ms {
+                panic!(
+                    "Timeout waiting for index '{}' to have exactly {} documents",
+                    name, expected_docs
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn wait_for_metadata_count(&self, name: &str, expected_docs: usize, max_wait_ms: u64) {
+        let start = std::time::Instant::now();
+        loop {
+            let resp = self
+                .client
+                .get(self.url(&format!("/indices/{}/metadata/count", name)))
+                .send()
+                .await;
+
+            if let Ok(resp) = resp {
+                if resp.status().is_success() {
+                    if let Ok(body) = resp.json::<Value>().await {
+                        if body["count"].as_u64() == Some(expected_docs as u64) {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if start.elapsed().as_millis() as u64 > max_wait_ms {
+                panic!(
+                    "Timeout waiting for index '{}' metadata count to reach {}",
+                    name, expected_docs
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn wait_for_project_sync_terminal_status(
+        &self,
+        job_id: &str,
+        max_wait_ms: u64,
+    ) -> ProjectSyncJobResponse {
+        let start = std::time::Instant::now();
+        loop {
+            let resp = self
+                .client
+                .get(self.url(&format!("/project_sync/jobs/{}", job_id)))
+                .send()
+                .await;
+
+            if let Ok(resp) = resp {
+                if resp.status().is_success() {
+                    if let Ok(job) = resp.json::<ProjectSyncJobResponse>().await {
+                        if job.status == ProjectSyncJobStatus::Completed
+                            || job.status == ProjectSyncJobStatus::Failed
+                            || job.status == ProjectSyncJobStatus::Cancelled
+                            || job.status == ProjectSyncJobStatus::Expired
+                        {
+                            return job;
+                        }
+                    }
+                }
+            }
+
+            if start.elapsed().as_millis() as u64 > max_wait_ms {
+                panic!(
+                    "Timeout waiting for project_sync job '{}' to reach terminal state",
+                    job_id
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn run_project_sync_job(
+        &self,
+        index_name: &str,
+        payload: &str,
+    ) -> ProjectSyncJobResponse {
+        let declared_bytes = payload.len() as u64;
+
+        let create_job_resp = self
+            .client
+            .post(self.url(&format!("/indices/{}/project_sync/jobs", index_name)))
+            .json(&json!({
+                "declared_bytes": declared_bytes,
+                "content_type": "application/x-ndjson"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(create_job_resp.status(), reqwest::StatusCode::OK);
+        let create_job_body: ProjectSyncCreateJobResponse = create_job_resp.json().await.unwrap();
+
+        let upload_resp = self
+            .client
+            .put(self.url(&format!(
+                "/project_sync/jobs/{}/upload",
+                create_job_body.job_id
+            )))
+            .header("content-type", "application/x-ndjson")
+            .body(payload.to_string())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(upload_resp.status(), reqwest::StatusCode::OK);
+        let upload_body: ProjectSyncJobResponse = upload_resp.json().await.unwrap();
+        assert_eq!(upload_body.status, ProjectSyncJobStatus::Uploaded);
+
+        let finalize_resp = self
+            .client
+            .post(self.url(&format!(
+                "/project_sync/jobs/{}/finalize",
+                create_job_body.job_id
+            )))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(finalize_resp.status(), reqwest::StatusCode::OK);
+        let finalize_body: ProjectSyncJobResponse = finalize_resp.json().await.unwrap();
+        assert_eq!(finalize_body.status, ProjectSyncJobStatus::Queued);
+
+        self.wait_for_project_sync_terminal_status(&create_job_body.job_id, 30_000)
+            .await
+    }
+
     /// Export the ONNX model by running the Python export script.
     fn export_model(workspace_root: &std::path::Path) -> Result<(), String> {
         let onnx_python_dir = workspace_root.join("onnx/python");
@@ -1593,6 +2726,14 @@ impl ModelTestFixture {
 /// Build a test router with model-based encoding routes.
 #[cfg(feature = "model")]
 fn build_model_test_router(state: Arc<AppState>) -> Router {
+    build_model_test_router_with_project_sync_timeout(state, Duration::from_secs(300))
+}
+
+#[cfg(feature = "model")]
+fn build_model_test_router_with_project_sync_timeout(
+    state: Arc<AppState>,
+    project_sync_timeout: Duration,
+) -> Router {
     // Index management routes
     let index_routes = Router::new()
         .route(
@@ -1647,12 +2788,18 @@ fn build_model_test_router(state: Arc<AppState>) -> Router {
             post(handlers::rerank_with_encoding),
         );
 
+    let project_sync_index_routes = Router::new().route(
+        "/{name}/project_sync/jobs",
+        post(handlers::create_project_sync_job),
+    );
+
     // Combine all routes under /indices
     let indices_router = Router::new()
         .merge(index_routes)
         .merge(document_routes)
         .merge(search_routes)
-        .merge(metadata_routes);
+        .merge(metadata_routes)
+        .merge(project_sync_index_routes);
 
     // Health check
     let health_handler = |state: axum::extract::State<Arc<AppState>>| async move {
@@ -1665,6 +2812,8 @@ fn build_model_test_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .nest("/indices", indices_router)
+        .merge(build_project_sync_control_test_router(project_sync_timeout))
+        .merge(build_project_sync_upload_test_router())
         .merge(encode_route)
         .layer(
             CorsLayer::new()
@@ -1673,6 +2822,252 @@ fn build_model_test_router(state: Arc<AppState>) -> Router {
                 .allow_headers(Any),
         )
         .with_state(state)
+}
+
+/// Test project_sync end-to-end with a loaded model.
+#[cfg(feature = "model")]
+#[tokio::test]
+async fn test_project_sync_completes_with_model() {
+    let Some(fixture) = ModelTestFixture::maybe_new().await else {
+        return;
+    };
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({
+            "name": "project_sync_model_complete_test",
+            "config": {"nbits": 4, "start_from_scratch": 50}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload = concat!(
+        "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 42 }\",\"language\":\"rust\",\"metadata\":{\"kind\":\"library\"}}\n",
+        "{\"path\":\"src/main.rs\",\"content\":\"fn main() { println!(\\\"hi\\\"); }\",\"language\":\"rust\",\"metadata\":{\"kind\":\"binary\"}}\n"
+    );
+
+    let terminal_job = fixture
+        .run_project_sync_job("project_sync_model_complete_test", payload)
+        .await;
+    assert_eq!(terminal_job.status, ProjectSyncJobStatus::Completed);
+    assert!(terminal_job.error.is_none(), "{:?}", terminal_job.error);
+
+    fixture
+        .wait_for_exact_doc_count("project_sync_model_complete_test", 2, 30_000)
+        .await;
+    fixture
+        .wait_for_metadata_count("project_sync_model_complete_test", 2, 30_000)
+        .await;
+
+    let resp = fixture
+        .client
+        .get(fixture.url("/indices/project_sync_model_complete_test"))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let body: IndexInfoResponse = resp.json().await.unwrap();
+    assert_eq!(body.num_documents, 2);
+    assert_eq!(body.metadata_count, Some(2));
+}
+
+/// Test project_sync replaces rows by source_path instead of duplicating them.
+#[cfg(feature = "model")]
+#[tokio::test]
+async fn test_project_sync_replaces_existing_source_path() {
+    let Some(fixture) = ModelTestFixture::maybe_new().await else {
+        return;
+    };
+
+    let create_index_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({
+            "name": "project_sync_replace_test",
+            "config": {"nbits": 4, "start_from_scratch": 50}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_index_resp.status(), reqwest::StatusCode::OK);
+
+    let payload_v1 = concat!(
+        "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 41 }\",\"language\":\"rust\",\"metadata\":{\"version\":1}}\n",
+        "{\"path\":\"src/main.rs\",\"content\":\"fn main() { println!(\\\"old\\\"); }\",\"language\":\"rust\",\"metadata\":{\"version\":1}}\n"
+    );
+    let terminal_job_v1 = fixture
+        .run_project_sync_job("project_sync_replace_test", payload_v1)
+        .await;
+    assert_eq!(terminal_job_v1.status, ProjectSyncJobStatus::Completed);
+
+    fixture
+        .wait_for_exact_doc_count("project_sync_replace_test", 2, 30_000)
+        .await;
+    fixture
+        .wait_for_metadata_count("project_sync_replace_test", 2, 30_000)
+        .await;
+
+    let payload_v2 = "{\"path\":\"src/lib.rs\",\"content\":\"pub fn answer() -> i32 { 42 }\",\"language\":\"rust\",\"metadata\":{\"version\":2}}\n";
+    let terminal_job_v2 = fixture
+        .run_project_sync_job("project_sync_replace_test", payload_v2)
+        .await;
+    assert_eq!(terminal_job_v2.status, ProjectSyncJobStatus::Completed);
+
+    fixture
+        .wait_for_exact_doc_count("project_sync_replace_test", 2, 30_000)
+        .await;
+    fixture
+        .wait_for_metadata_count("project_sync_replace_test", 2, 30_000)
+        .await;
+
+    let lib_query_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_replace_test/metadata/query"))
+        .json(&json!({
+            "condition": "source_path = ?",
+            "parameters": ["src/lib.rs"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(lib_query_resp.status().is_success());
+    let lib_query_body: QueryMetadataResponse = lib_query_resp.json().await.unwrap();
+    assert_eq!(lib_query_body.count, 1);
+    assert_eq!(lib_query_body.document_ids.len(), 1);
+
+    let lib_meta_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_replace_test/metadata/get"))
+        .json(&json!({
+            "document_ids": lib_query_body.document_ids
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(lib_meta_resp.status().is_success());
+    let lib_meta_body: GetMetadataResponse = lib_meta_resp.json().await.unwrap();
+    assert_eq!(lib_meta_body.count, 1);
+    assert_eq!(lib_meta_body.metadata[0]["source_path"], "src/lib.rs");
+    assert_eq!(lib_meta_body.metadata[0]["version"], 2);
+    assert_eq!(lib_meta_body.metadata[0]["source"], "project_sync");
+
+    let main_query_resp = fixture
+        .client
+        .post(fixture.url("/indices/project_sync_replace_test/metadata/query"))
+        .json(&json!({
+            "condition": "source_path = ?",
+            "parameters": ["src/main.rs"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(main_query_resp.status().is_success());
+    let main_query_body: QueryMetadataResponse = main_query_resp.json().await.unwrap();
+    assert_eq!(main_query_body.count, 1);
+}
+
+/// Test project_sync and update_with_encoding produce the same document and metadata counts.
+#[cfg(feature = "model")]
+#[tokio::test]
+async fn test_project_sync_matches_update_with_encoding_counts() {
+    let Some(fixture) = ModelTestFixture::maybe_new().await else {
+        return;
+    };
+
+    let direct_create_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({
+            "name": "update_with_encoding_consistency_test",
+            "config": {"nbits": 4, "start_from_scratch": 50}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(direct_create_resp.status(), reqwest::StatusCode::OK);
+
+    let documents = vec![
+        "pub fn build_pool() -> Pool { Pool::new() }",
+        "fn main() { println!(\"server started\"); }",
+        "pub fn parse_config(raw: &str) -> Config { Config::from(raw) }",
+    ];
+    let metadata = vec![
+        json!({"source_path": "src/db.rs", "language": "rust", "source": "project_sync"}),
+        json!({"source_path": "src/main.rs", "language": "rust", "source": "project_sync"}),
+        json!({"source_path": "src/config.rs", "language": "rust", "source": "project_sync"}),
+    ];
+
+    let direct_update_resp = fixture
+        .client
+        .post(fixture.url("/indices/update_with_encoding_consistency_test/update_with_encoding"))
+        .json(&json!({
+            "documents": documents,
+            "metadata": metadata
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(direct_update_resp.status(), reqwest::StatusCode::ACCEPTED);
+    fixture
+        .wait_for_exact_doc_count("update_with_encoding_consistency_test", 3, 30_000)
+        .await;
+    fixture
+        .wait_for_metadata_count("update_with_encoding_consistency_test", 3, 30_000)
+        .await;
+
+    let sync_create_resp = fixture
+        .client
+        .post(fixture.url("/indices"))
+        .json(&json!({
+            "name": "project_sync_consistency_test",
+            "config": {"nbits": 4, "start_from_scratch": 50}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(sync_create_resp.status(), reqwest::StatusCode::OK);
+
+    let sync_payload = concat!(
+        "{\"path\":\"src/db.rs\",\"content\":\"pub fn build_pool() -> Pool { Pool::new() }\",\"language\":\"rust\"}\n",
+        "{\"path\":\"src/main.rs\",\"content\":\"fn main() { println!(\\\"server started\\\"); }\",\"language\":\"rust\"}\n",
+        "{\"path\":\"src/config.rs\",\"content\":\"pub fn parse_config(raw: &str) -> Config { Config::from(raw) }\",\"language\":\"rust\"}\n"
+    );
+    let terminal_job = fixture
+        .run_project_sync_job("project_sync_consistency_test", sync_payload)
+        .await;
+    assert_eq!(terminal_job.status, ProjectSyncJobStatus::Completed);
+
+    fixture
+        .wait_for_exact_doc_count("project_sync_consistency_test", 3, 30_000)
+        .await;
+    fixture
+        .wait_for_metadata_count("project_sync_consistency_test", 3, 30_000)
+        .await;
+
+    let direct_info_resp = fixture
+        .client
+        .get(fixture.url("/indices/update_with_encoding_consistency_test"))
+        .send()
+        .await
+        .unwrap();
+    assert!(direct_info_resp.status().is_success());
+    let direct_info: IndexInfoResponse = direct_info_resp.json().await.unwrap();
+
+    let sync_info_resp = fixture
+        .client
+        .get(fixture.url("/indices/project_sync_consistency_test"))
+        .send()
+        .await
+        .unwrap();
+    assert!(sync_info_resp.status().is_success());
+    let sync_info: IndexInfoResponse = sync_info_resp.json().await.unwrap();
+
+    assert_eq!(sync_info.num_documents, direct_info.num_documents);
+    assert_eq!(sync_info.metadata_count, direct_info.metadata_count);
+    assert_eq!(sync_info.num_embeddings, direct_info.num_embeddings);
 }
 
 /// Test update_with_encoding: create an index and add documents using text encoding.

--- a/next-plaid/src/filtering.rs
+++ b/next-plaid/src/filtering.rs
@@ -501,6 +501,26 @@ fn get_schema_columns(conn: &Connection) -> Result<HashSet<String>> {
     Ok(columns)
 }
 
+/// Check whether a metadata column exists for an index.
+pub fn has_column(index_path: &str, column_name: &str) -> Result<bool> {
+    if !is_valid_column_name(column_name) {
+        return Err(Error::Filtering(format!(
+            "Invalid column name '{}'. Column names must start with a letter or \
+             underscore, followed by letters, digits, or underscores.",
+            column_name
+        )));
+    }
+
+    let db_path = get_db_path(index_path);
+    if !db_path.exists() {
+        return Ok(false);
+    }
+
+    let conn = open_db(&db_path)?;
+    let columns = get_schema_columns(&conn)?;
+    Ok(columns.contains(column_name))
+}
+
 /// Validate a SQL WHERE condition against the allowed grammar and schema.
 ///
 /// This function performs security validation on user-provided SQL conditions:
@@ -1665,6 +1685,27 @@ mod tests {
 
         // Verify count
         assert_eq!(count(path).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_has_column_reports_metadata_schema() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+
+        let metadata = vec![json!({"name": "Alice"})];
+        let doc_ids = vec![0];
+        create(path, &metadata, &doc_ids).unwrap();
+
+        assert!(has_column(path, "name").unwrap());
+        assert!(!has_column(path, "source_path").unwrap());
+    }
+
+    #[test]
+    fn test_has_column_returns_false_without_metadata_db() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+
+        assert!(!has_column(path, "source_path").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add staged project sync job endpoints for MCP uploads
- enforce declared byte admission limits and backlog budgeting with retry hints
- harden replace workflow with snapshot rollback, recovery, and postflight index/metadata repair

## Validation
- `cargo fmt --all --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -- --check`
- `cargo clippy --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -p next-plaid-api --all-targets --features "openblas model" -- -D warnings`
- `cargo test --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -p next-plaid-api --lib --features model project_sync -- --nocapture`
- `cargo test --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -p next-plaid-api --test integration_tests --features model test_project_sync_create_upload_cancel_status -- --nocapture`
- `TMPDIR=/home/anton/.cache/next-plaid-pr-project-sync-tmp CARGO_TARGET_DIR=/home/anton/.cache/next-plaid-pr-project-sync-target cargo test --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -p next-plaid-api --test integration_tests test_project_sync_admission_limits -- --nocapture`
- `TMPDIR=/home/anton/.cache/next-plaid-pr-project-sync-tmp CARGO_TARGET_DIR=/home/anton/.cache/next-plaid-pr-project-sync-target cargo test --manifest-path /tmp/next-plaid-pr-project-sync/Cargo.toml -p next-plaid-api --test integration_tests test_project_sync_finalize_reaches_terminal_status_without_model -- --nocapture`

Implemented entirely by Codex.