### PR TITLE
Scope colgrep indexes per (project, model) pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ colgrep --model lightonai/LateOn-Code "database connection pooling"
 
 # See which model an index was built with
 colgrep status
-colgrep --stats
 
 # Private HuggingFace model
 HF_TOKEN=hf_xxx colgrep set-model myorg/private-model

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ Regex meets semantics:
 colgrep -e "async.*await" "error handling"
 ```
 
+### Change the model
+
+The default is [`lightonai/LateOn-Code-edge`](https://huggingface.co/lightonai/LateOn-Code-edge). Switch to any other ColBERT-style model on HuggingFace:
+
+```bash
+# Persist as the default (existing indexes for other models are kept)
+colgrep set-model lightonai/LateOn-Code
+
+# One-shot override for a single query or init
+colgrep --model lightonai/LateOn-Code "database connection pooling"
+
+# See which model an index was built with
+colgrep status
+colgrep --stats
+
+# Private HuggingFace model
+HF_TOKEN=hf_xxx colgrep set-model myorg/private-model
+```
+
+Each (project, model) pair has its own index directory, so switching models never corrupts existing indexes and you can flip back and forth without re-indexing. `colgrep clear` scopes to the active model; `colgrep clear --all` wipes every index.
+
 ### Agent integrations
 
 | Tool        | Install                         |

--- a/colgrep/src/commands/clear.rs
+++ b/colgrep/src/commands/clear.rs
@@ -3,13 +3,20 @@ use std::path::PathBuf;
 use anyhow::Result;
 
 use colgrep::{
-    acquire_index_lock, find_parent_index, get_colgrep_data_dir, get_index_dir_for_project,
-    ProjectMetadata,
+    acquire_index_lock, find_parent_index, get_colgrep_data_dir, get_index_dir_for_project, Config,
+    ProjectMetadata, DEFAULT_MODEL,
 };
+
+fn current_model() -> String {
+    Config::load()
+        .ok()
+        .and_then(|c| c.get_default_model().map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+}
 
 pub fn cmd_clear(path: &PathBuf, all: bool) -> Result<()> {
     if all {
-        // Clear all indexes
+        // Clear all indexes (every model, every project)
         let data_dir = get_colgrep_data_dir()?;
         if !data_dir.exists() {
             println!("No indexes found.");
@@ -30,22 +37,28 @@ pub fn cmd_clear(path: &PathBuf, all: bool) -> Result<()> {
         // Delete each index and log the project path
         for entry in &index_dirs {
             let index_path = entry.path();
-            let project_path = ProjectMetadata::load(&index_path)
-                .map(|m| m.project_path.display().to_string())
-                .unwrap_or_else(|_| index_path.display().to_string());
+            let (project_path, model) = match ProjectMetadata::load(&index_path) {
+                Ok(m) => (m.project_path.display().to_string(), m.model),
+                Err(_) => (index_path.display().to_string(), None),
+            };
 
             // Acquire lock before deleting, then drop it so the lock file can be removed
             let lock = acquire_index_lock(&index_path)?;
             drop(lock);
             std::fs::remove_dir_all(&index_path)?;
-            println!("🗑️  Cleared index for {}", project_path);
+            match model {
+                Some(m) => println!("🗑️  Cleared index for {} [{}]", project_path, m),
+                None => println!("🗑️  Cleared index for {}", project_path),
+            }
         }
 
         println!("\n✅ Cleared {} index(es)", index_dirs.len());
     } else {
-        // Clear index for current project
+        // Clear index for current project, scoped to the active model only.
+        // Other models' indexes for the same project are left intact.
         let path = std::fs::canonicalize(path)?;
-        let index_dir = get_index_dir_for_project(&path)?;
+        let model = current_model();
+        let index_dir = get_index_dir_for_project(&path, &model)?;
 
         if index_dir.exists() {
             // Exact match found - clear it
@@ -53,19 +66,21 @@ pub fn cmd_clear(path: &PathBuf, all: bool) -> Result<()> {
             let lock = acquire_index_lock(&index_dir)?;
             drop(lock);
             std::fs::remove_dir_all(&index_dir)?;
-            println!("🗑️  Cleared index for {}", path.display());
-        } else if let Some(parent_info) = find_parent_index(&path)? {
-            // We're in a subdirectory of an indexed project - clear the parent index
+            println!("🗑️  Cleared index for {} [{}]", path.display(), model);
+        } else if let Some(parent_info) = find_parent_index(&path, &model)? {
+            // We're in a subdirectory of an indexed project (for this model) -
+            // clear the parent index.
             // Acquire lock before deleting, then drop it so the lock file can be removed
             let lock = acquire_index_lock(&parent_info.index_dir)?;
             drop(lock);
             std::fs::remove_dir_all(&parent_info.index_dir)?;
             println!(
-                "🗑️  Cleared index for {} (parent of current directory)",
-                parent_info.project_path.display()
+                "🗑️  Cleared index for {} [{}] (parent of current directory)",
+                parent_info.project_path.display(),
+                model
             );
         } else {
-            println!("No index found for {}", path.display());
+            println!("No index found for {} [{}]", path.display(), model);
             return Ok(());
         }
     }

--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 
 use colgrep::{
-    ensure_model, ensure_onnx_runtime, get_colgrep_data_dir, Config, DEFAULT_MAX_RECURSION_DEPTH,
-    DEFAULT_MODEL, DEFAULT_POOL_FACTOR,
+    ensure_model, ensure_onnx_runtime, Config, DEFAULT_MAX_RECURSION_DEPTH, DEFAULT_MODEL,
+    DEFAULT_POOL_FACTOR,
 };
 
 fn format_parallel_setting(config: &Config) -> String {
@@ -71,29 +71,17 @@ pub fn cmd_set_model(model: &str) -> Result<()> {
         }
     }
 
-    // Model is valid - clear existing indexes if we had a previous model
+    // Indexes are now scoped per (project, model), so switching models does not
+    // corrupt existing indexes. We keep them intact: the new model will reuse
+    // its own index if one exists, or build one on the next run. Previously
+    // built indexes for other models remain searchable if the user switches back.
     if current_model.is_some() {
-        let data_dir = get_colgrep_data_dir()?;
-        if data_dir.exists() {
-            let index_dirs: Vec<_> = std::fs::read_dir(&data_dir)?
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().is_dir())
-                .collect();
-
-            if !index_dirs.is_empty() {
-                eprintln!(
-                    "🔄 Switching model from {} to {}",
-                    current_model.as_deref().unwrap_or(DEFAULT_MODEL),
-                    model
-                );
-                eprintln!("   Clearing {} existing index(es)...", index_dirs.len());
-
-                for entry in &index_dirs {
-                    let index_path = entry.path();
-                    std::fs::remove_dir_all(&index_path)?;
-                }
-            }
-        }
+        eprintln!(
+            "🔄 Switching model from {} to {}",
+            current_model.as_deref().unwrap_or(DEFAULT_MODEL),
+            model
+        );
+        eprintln!("   Existing indexes for other models are kept (each model has its own index).");
     }
 
     // Save new model preference

--- a/colgrep/src/commands/hooks.rs
+++ b/colgrep/src/commands/hooks.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use ignore::WalkBuilder;
 
-use colgrep::{find_parent_index, index_exists};
+use colgrep::{find_parent_index, index_exists, Config, DEFAULT_MODEL};
 
 /// Maximum number of files for a "small project" where we enable colgrep
 /// even without a pre-existing index, so the first search auto-creates one quickly.
@@ -11,11 +11,16 @@ const SMALL_PROJECT_FILE_LIMIT: usize = 50;
 
 /// Check if colgrep context should be injected.
 /// Returns true if:
-/// - An index already exists for this project or a parent project, OR
+/// - An index (for the currently selected model) already exists for this project
+///   or a parent project, OR
 /// - The project is small enough that auto-indexing on first search is fast
 fn should_inject_colgrep_context(project_root: &Path) -> bool {
-    index_exists(project_root)
-        || matches!(find_parent_index(project_root), Ok(Some(_)))
+    let model = Config::load()
+        .ok()
+        .and_then(|c| c.get_default_model().map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    index_exists(project_root, &model)
+        || matches!(find_parent_index(project_root, &model), Ok(Some(_)))
         || is_small_project(project_root)
 }
 

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -44,14 +44,16 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);
 
-    // Check if index already exists
-    let has_existing_index = index_exists(&path) || find_parent_index(&path)?.is_some();
+    // Check if index already exists (for the currently selected model)
+    let has_existing_index =
+        index_exists(&path, &model) || find_parent_index(&path, &model)?.is_some();
 
     // Ensure model is downloaded
     let model_path = ensure_model(Some(&model), has_existing_index)?;
 
     let mut builder = IndexBuilder::with_options(
         &path,
+        &model,
         &model_path,
         quantized,
         pool_factor,
@@ -59,7 +61,6 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
         batch_size,
     )?;
     builder.set_auto_confirm(options.auto_confirm);
-    builder.set_model_name(&model);
     builder.set_dynamic_batch(!options.static_batch);
     if let Some(encode_batch_size) = options.encode_batch_size {
         builder.set_encode_batch_size(encode_batch_size.max(1));

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -923,15 +923,15 @@ fn search_single_path(
     let parallel_sessions = config.configured_parallel_sessions();
     let batch_size = config.configured_batch_size();
 
-    // Check if index already exists (suppress model output if so)
+    // Check if index already exists for this model (suppress model output if so)
     let has_existing_index =
-        index_exists(&search_path) || find_parent_index(&search_path)?.is_some();
+        index_exists(&search_path, &model) || find_parent_index(&search_path, &model)?.is_some();
 
     // Ensure model is downloaded (quiet if we already have an index)
     let model_path = ensure_model(Some(&model), has_existing_index)?;
 
-    // Check for parent index unless the resolved path is outside
-    // the current directory (external project)
+    // Check for parent index (scoped to current model) unless the resolved path
+    // is outside the current directory (external project)
     let parent_info = {
         let current_dir = std::env::current_dir().ok();
         let is_external_project = is_external_project_path(&search_path, current_dir.as_deref());
@@ -939,7 +939,7 @@ fn search_single_path(
         if is_external_project {
             None
         } else {
-            find_parent_index(&search_path)?
+            find_parent_index(&search_path, &model)?
         }
     };
 
@@ -981,6 +981,7 @@ fn search_single_path(
     {
         let mut builder = IndexBuilder::with_options(
             &effective_root,
+            &model,
             &model_path,
             quantized,
             pool_factor,
@@ -988,7 +989,6 @@ fn search_single_path(
             batch_size,
         )?;
         builder.set_auto_confirm(auto_confirm);
-        builder.set_model_name(&model);
         builder.set_dynamic_batch(!static_batch);
 
         // Try non-blocking index update
@@ -1036,7 +1036,7 @@ fn search_single_path(
                         eprintln!("⚠️  Index corrupted, rebuilding...");
                     }
 
-                    let index_dir = get_index_dir_for_project(&effective_root)?;
+                    let index_dir = get_index_dir_for_project(&effective_root, &model)?;
                     if index_dir.exists() {
                         let _lock = acquire_index_lock(&index_dir)?;
                         std::fs::remove_dir_all(&index_dir)?;
@@ -1044,6 +1044,7 @@ fn search_single_path(
 
                     let mut new_builder = IndexBuilder::with_options(
                         &effective_root,
+                        &model,
                         &model_path,
                         quantized,
                         pool_factor,
@@ -1051,7 +1052,6 @@ fn search_single_path(
                         batch_size,
                     )?;
                     new_builder.set_auto_confirm(auto_confirm);
-                    new_builder.set_model_name(&model);
                     new_builder.set_dynamic_batch(!static_batch);
                     new_builder.index(None, false)?;
                 } else {
@@ -1062,7 +1062,7 @@ fn search_single_path(
     }
 
     // Verify index exists (at least partially)
-    let index_dir = get_index_dir_for_project(&effective_root)?;
+    let index_dir = get_index_dir_for_project(&effective_root, &model)?;
     let vector_index_path = get_vector_index_path(&index_dir);
     if !vector_index_path.join("metadata.json").exists() {
         if index_locked {
@@ -1092,7 +1092,7 @@ fn search_single_path(
                 &model_path,
                 quantized,
             ),
-            None => Searcher::load_with_quantized(&effective_root, &model_path, quantized),
+            None => Searcher::load_with_quantized(&effective_root, &model, &model_path, quantized),
         }
     };
 
@@ -1155,6 +1155,7 @@ fn search_single_path(
 
             let mut builder = IndexBuilder::with_options(
                 &effective_root,
+                &model,
                 &model_path,
                 quantized,
                 pool_factor,
@@ -1162,7 +1163,6 @@ fn search_single_path(
                 batch_size,
             )?;
             builder.set_auto_confirm(auto_confirm);
-            builder.set_model_name(&model);
             builder.set_dynamic_batch(!static_batch);
             builder.index(None, false)?;
 
@@ -1477,7 +1477,7 @@ fn search_single_path(
     });
 
     // Increment search count
-    let index_dir = get_index_dir_for_project(&effective_root)?;
+    let index_dir = get_index_dir_for_project(&effective_root, &model)?;
     if let Ok(mut state) = IndexState::load(&index_dir) {
         state.increment_search_count();
         let _ = state.save(&index_dir);

--- a/colgrep/src/commands/stats.rs
+++ b/colgrep/src/commands/stats.rs
@@ -40,10 +40,11 @@ pub fn cmd_stats() -> Result<()> {
     for entry in &index_dirs {
         let index_path = entry.path();
 
-        // Load project metadata
-        let project_path = ProjectMetadata::load(&index_path)
-            .map(|m| m.project_path.display().to_string())
-            .unwrap_or_else(|_| "Unknown".to_string());
+        // Load project metadata (path + optional model)
+        let (project_path, model) = match ProjectMetadata::load(&index_path) {
+            Ok(m) => (m.project_path.display().to_string(), m.model),
+            Err(_) => ("Unknown".to_string(), None),
+        };
 
         // Load state for search count
         let state = IndexState::load(&index_path).unwrap_or_default();
@@ -53,6 +54,10 @@ pub fn cmd_stats() -> Result<()> {
         let num_functions = get_index_document_count(&vector_index_path);
 
         println!("Project: {}", project_path);
+        match model {
+            Some(m) => println!("  Model: {}", m),
+            None => println!("  Model: (unknown — legacy index)"),
+        }
         println!("  Functions indexed: {}", num_functions);
         println!("  Search count: {}", state.search_count);
         println!();

--- a/colgrep/src/commands/status.rs
+++ b/colgrep/src/commands/status.rs
@@ -2,19 +2,25 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-use colgrep::{get_index_dir_for_project, index_exists};
+use colgrep::{get_index_dir_for_project, index_exists, Config, DEFAULT_MODEL};
 
 pub fn cmd_status(path: &PathBuf) -> Result<()> {
     let path = std::fs::canonicalize(path)?;
 
-    if !index_exists(&path) {
-        println!("No index found for {}", path.display());
+    let model = Config::load()
+        .ok()
+        .and_then(|c| c.get_default_model().map(|s| s.to_string()))
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+    if !index_exists(&path, &model) {
+        println!("No index found for {} [{}]", path.display(), model);
         println!("Run `colgrep <query>` to create one.");
         return Ok(());
     }
 
-    let index_dir = get_index_dir_for_project(&path)?;
+    let index_dir = get_index_dir_for_project(&path, &model)?;
     println!("Project: {}", path.display());
+    println!("Model:   {}", model);
     println!("Index:   {}", index_dir.display());
     println!();
     println!("Run any search to update the index, or `colgrep clear` to rebuild from scratch.");

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -694,29 +694,45 @@ pub struct IndexBuilder {
     dynamic_batch: bool,
     /// If true, skip user confirmation for large indexes
     auto_confirm: bool,
-    /// Model name/id for display (e.g., "lightonai/LateOn-Code-edge")
-    model_name: Option<String>,
+    /// Model id (e.g., "lightonai/LateOn-Code-edge"). Used both to scope the index
+    /// directory (per-model indexes) and for "🤖 Model:" display.
+    model_id: String,
 }
 
 impl IndexBuilder {
-    pub fn new(project_root: &Path, model_path: &Path) -> Result<Self> {
-        Self::with_options(project_root, model_path, false, None, None, None)
+    pub fn new(project_root: &Path, model_id: &str, model_path: &Path) -> Result<Self> {
+        Self::with_options(project_root, model_id, model_path, false, None, None, None)
     }
 
-    pub fn with_quantized(project_root: &Path, model_path: &Path, quantized: bool) -> Result<Self> {
-        Self::with_options(project_root, model_path, quantized, None, None, None)
+    pub fn with_quantized(
+        project_root: &Path,
+        model_id: &str,
+        model_path: &Path,
+        quantized: bool,
+    ) -> Result<Self> {
+        Self::with_options(
+            project_root,
+            model_id,
+            model_path,
+            quantized,
+            None,
+            None,
+            None,
+        )
     }
 
     pub fn with_options(
         project_root: &Path,
+        model_id: &str,
         model_path: &Path,
         quantized: bool,
         pool_factor: Option<usize>,
         parallel_sessions: Option<usize>,
         batch_size: Option<usize>,
     ) -> Result<Self> {
-        // Store parameters for lazy model creation - don't create the model yet
-        let index_dir = get_index_dir_for_project(project_root)?;
+        // Index directory is scoped to (path, model) so different models keep
+        // separate indexes and switching models doesn't corrupt the existing one.
+        let index_dir = get_index_dir_for_project(project_root, model_id)?;
 
         Ok(Self {
             model: None, // Lazily created when needed
@@ -731,18 +747,13 @@ impl IndexBuilder {
             index_chunk_size: None,
             dynamic_batch: true,
             auto_confirm: false, // Prompt by default for large indexes
-            model_name: None,
+            model_id: model_id.to_string(),
         })
     }
 
     /// Set whether to automatically confirm indexing for large codebases (> 10K code units)
     pub fn set_auto_confirm(&mut self, auto_confirm: bool) {
         self.auto_confirm = auto_confirm;
-    }
-
-    /// Set the model name for display purposes
-    pub fn set_model_name(&mut self, name: &str) {
-        self.model_name = Some(name.to_string());
     }
 
     pub fn set_encode_batch_size(&mut self, encode_batch_size: usize) {
@@ -854,9 +865,7 @@ impl IndexBuilder {
             };
 
             // Print model info after ONNX runtime is initialized (and any potential re-exec)
-            if let Some(ref name) = self.model_name {
-                eprintln!("🤖 Model: {}", name);
-            }
+            eprintln!("🤖 Model: {}", self.model_id);
             eprintln!("📂 Building index...");
 
             // Use runtime default for batch size (respects cuDNN availability)
@@ -1689,7 +1698,7 @@ impl IndexBuilder {
 
         // Save state and project metadata only on successful completion
         state.save(&self.index_dir)?;
-        ProjectMetadata::new(&self.project_root).save(&self.index_dir)?;
+        ProjectMetadata::new(&self.project_root, &self.model_id).save(&self.index_dir)?;
 
         Ok(UpdateStats {
             added: files.len(),
@@ -2808,16 +2817,17 @@ pub struct Searcher {
 }
 
 impl Searcher {
-    pub fn load(project_root: &Path, model_path: &Path) -> Result<Self> {
-        Self::load_with_quantized(project_root, model_path, false)
+    pub fn load(project_root: &Path, model_id: &str, model_path: &Path) -> Result<Self> {
+        Self::load_with_quantized(project_root, model_id, model_path, false)
     }
 
     pub fn load_with_quantized(
         project_root: &Path,
+        model_id: &str,
         model_path: &Path,
         quantized: bool,
     ) -> Result<Self> {
-        let index_dir = get_index_dir_for_project(project_root)?;
+        let index_dir = get_index_dir_for_project(project_root, model_id)?;
         let vector_dir = get_vector_index_path(&index_dir);
         let index_path = vector_dir.to_str().unwrap().to_string();
 
@@ -3403,9 +3413,9 @@ fn fix_sqlite_types(meta: &mut serde_json::Value) {
     }
 }
 
-/// Check if an index exists for the given project
-pub fn index_exists(project_root: &Path) -> bool {
-    paths::index_exists(project_root)
+/// Check if an index exists for the given project built with `model`.
+pub fn index_exists(project_root: &Path, model: &str) -> bool {
+    paths::index_exists(project_root, model)
 }
 
 /// Prompt the user for confirmation before indexing a large number of code units.

--- a/colgrep/src/index/paths.rs
+++ b/colgrep/src/index/paths.rs
@@ -25,10 +25,15 @@ pub struct ProjectMetadata {
     pub project_path: PathBuf,
     /// Project name (directory name)
     pub project_name: String,
+    /// Model id the index was built with (e.g., "lightonai/LateOn-Code-edge").
+    /// Optional so pre-1.3 project.json files without this field still deserialize;
+    /// legacy indexes without a model are treated as orphaned and ignored by lookups.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 impl ProjectMetadata {
-    pub fn new(project_path: &Path) -> Self {
+    pub fn new(project_path: &Path, model: &str) -> Self {
         let project_name = project_path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
@@ -37,6 +42,7 @@ impl ProjectMetadata {
         Self {
             project_path: project_path.to_path_buf(),
             project_name,
+            model: Some(model.to_string()),
         }
     }
 
@@ -62,11 +68,17 @@ pub fn get_colgrep_data_dir() -> Result<PathBuf> {
     Ok(data_dir.join("colgrep").join("indices"))
 }
 
-/// Compute the index directory name for a project path
-/// Format: {project_name}-{first 8 hex chars of xxh3_64 hash}
-fn compute_index_dir_name(project_path: &Path) -> String {
+/// Compute the index directory name for a (project_path, model) pair.
+/// Format: {project_name}-{first 8 hex chars of xxh3_64(path|model) hash}
+/// Including the model in the hash lets different models keep independent indexes
+/// for the same project (switching models no longer corrupts the index).
+fn compute_index_dir_name(project_path: &Path, model: &str) -> String {
     let path_str = project_path.to_string_lossy();
-    let hash = xxh3_64(path_str.as_bytes());
+    let mut hasher_input = Vec::with_capacity(path_str.len() + 1 + model.len());
+    hasher_input.extend_from_slice(path_str.as_bytes());
+    hasher_input.push(b'|');
+    hasher_input.extend_from_slice(model.as_bytes());
+    let hash = xxh3_64(&hasher_input);
     let hash_prefix = format!("{:08x}", hash).chars().take(8).collect::<String>();
 
     let project_name = project_path
@@ -89,39 +101,46 @@ fn compute_index_dir_name(project_path: &Path) -> String {
     format!("{}-{}", sanitized_name, hash_prefix)
 }
 
-/// Get the index directory for a project path
-/// Creates the directory structure if it doesn't exist
-pub fn get_index_dir_for_project(project_path: &Path) -> Result<PathBuf> {
+/// Get the index directory for a (project_path, model) pair.
+/// Creates the directory structure if it doesn't exist.
+pub fn get_index_dir_for_project(project_path: &Path, model: &str) -> Result<PathBuf> {
     let base_dir = get_colgrep_data_dir()?;
-    let dir_name = compute_index_dir_name(project_path);
+    let dir_name = compute_index_dir_name(project_path, model);
     Ok(base_dir.join(dir_name))
 }
 
-/// Find an existing index for a project path
-/// Returns None if no index exists
-pub fn find_index_for_project(project_path: &Path) -> Result<Option<PathBuf>> {
-    let index_dir = get_index_dir_for_project(project_path)?;
+/// Find an existing index for a (project_path, model) pair.
+/// Returns None if no index exists for that specific model.
+pub fn find_index_for_project(project_path: &Path, model: &str) -> Result<Option<PathBuf>> {
+    let index_dir = get_index_dir_for_project(project_path, model)?;
 
     // Check if the index directory exists and has valid metadata
     let metadata_path = index_dir.join(INDEX_SUBDIR).join("metadata.json");
     if metadata_path.exists() {
-        // Verify the project path matches
+        // Verify the project path matches and (if stored) the model matches.
         if let Ok(meta) = ProjectMetadata::load(&index_dir) {
             if meta.project_path == project_path {
-                return Ok(Some(index_dir));
+                match meta.model.as_deref() {
+                    Some(m) if m == model => return Ok(Some(index_dir)),
+                    // Legacy index (no model recorded): directory hash already scopes by
+                    // model, so reaching this branch means the caller's model matches
+                    // whatever was built there. Treat as a match.
+                    None => return Ok(Some(index_dir)),
+                    _ => return Ok(None),
+                }
             }
         }
-        // Index exists but project path doesn't match (hash collision)
-        // This is extremely rare with xxh3_64, but handle it gracefully
+        // Index exists but project path doesn't match (hash collision).
+        // With the model now in the hash this is still extremely rare; handle gracefully.
         return Ok(Some(index_dir));
     }
 
     Ok(None)
 }
 
-/// Check if an index exists for the given project
-pub fn index_exists(project_path: &Path) -> bool {
-    matches!(find_index_for_project(project_path), Ok(Some(_)))
+/// Check if an index exists for the given (project, model) pair.
+pub fn index_exists(project_path: &Path, model: &str) -> bool {
+    matches!(find_index_for_project(project_path, model), Ok(Some(_)))
 }
 
 /// Information about a discovered parent index
@@ -135,9 +154,11 @@ pub struct ParentIndexInfo {
     pub relative_subdir: PathBuf,
 }
 
-/// Find if the given path is a subdirectory of any existing indexed project.
+/// Find if the given path is a subdirectory of any existing indexed project
+/// built with `model`. Indexes for other models are ignored so that switching
+/// models does not reuse a mismatched index.
 /// Returns the most specific (longest-matching) parent index if found.
-pub fn find_parent_index(search_path: &Path) -> Result<Option<ParentIndexInfo>> {
+pub fn find_parent_index(search_path: &Path, model: &str) -> Result<Option<ParentIndexInfo>> {
     let data_dir = get_colgrep_data_dir()?;
 
     if !data_dir.exists() {
@@ -155,6 +176,12 @@ pub fn find_parent_index(search_path: &Path) -> Result<Option<ParentIndexInfo>> 
 
         // Try to load project metadata
         if let Ok(meta) = ProjectMetadata::load(&index_dir) {
+            // Skip indexes that were built with a different model. Legacy indexes
+            // (no model field) are also skipped — they're orphans under the new
+            // per-model hashing scheme and users should rebuild.
+            if meta.model.as_deref() != Some(model) {
+                continue;
+            }
             // Check if search_path starts with this project's path
             // but is NOT the same path (must be a subdirectory)
             if search_path != meta.project_path {
@@ -246,7 +273,7 @@ mod tests {
     #[test]
     fn test_compute_index_dir_name() {
         let path = PathBuf::from("/Users/foo/myproject");
-        let name = compute_index_dir_name(&path);
+        let name = compute_index_dir_name(&path, "lightonai/LateOn");
         // Should be format: myproject-{8 hex chars}
         assert!(name.starts_with("myproject-"));
         assert_eq!(name.len(), "myproject-".len() + 8);
@@ -255,7 +282,7 @@ mod tests {
     #[test]
     fn test_compute_index_dir_name_with_special_chars() {
         let path = PathBuf::from("/Users/foo/my project (1)");
-        let name = compute_index_dir_name(&path);
+        let name = compute_index_dir_name(&path, "lightonai/LateOn");
         // Special chars should be replaced with underscores
         assert!(name.starts_with("my_project__1_-"));
     }
@@ -264,8 +291,114 @@ mod tests {
     fn test_different_paths_different_hashes() {
         let path1 = PathBuf::from("/Users/foo/project1");
         let path2 = PathBuf::from("/Users/foo/project2");
-        let name1 = compute_index_dir_name(&path1);
-        let name2 = compute_index_dir_name(&path2);
+        let name1 = compute_index_dir_name(&path1, "lightonai/LateOn");
+        let name2 = compute_index_dir_name(&path2, "lightonai/LateOn");
         assert_ne!(name1, name2);
+    }
+
+    #[test]
+    fn test_different_models_different_hashes() {
+        // Same project path, different models → different index directories.
+        let path = PathBuf::from("/Users/foo/project");
+        let a = compute_index_dir_name(&path, "lightonai/LateOn");
+        let b = compute_index_dir_name(&path, "lightonai/LateOn-Code-edge");
+        assert_ne!(a, b);
+        // Both keep the readable project-name prefix.
+        assert!(a.starts_with("project-"));
+        assert!(b.starts_with("project-"));
+    }
+
+    #[test]
+    fn test_same_path_and_model_stable_hash() {
+        let path = PathBuf::from("/Users/foo/project");
+        let a = compute_index_dir_name(&path, "lightonai/LateOn");
+        let b = compute_index_dir_name(&path, "lightonai/LateOn");
+        assert_eq!(a, b);
+    }
+
+    /// The empty model string and a non-empty one must not collide:
+    /// hashing `path|model` with model="" differs from hashing just the path.
+    /// Guards against a regression if someone reverts to path-only hashing.
+    #[test]
+    fn test_empty_model_does_not_collide_with_populated_model() {
+        let path = PathBuf::from("/Users/foo/project");
+        let empty = compute_index_dir_name(&path, "");
+        let populated = compute_index_dir_name(&path, "lightonai/LateOn");
+        assert_ne!(empty, populated);
+    }
+
+    #[test]
+    fn test_project_metadata_roundtrip_with_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        let project_path = PathBuf::from("/some/project");
+        let meta = ProjectMetadata::new(&project_path, "lightonai/LateOn-Code-edge");
+        meta.save(index_dir).unwrap();
+
+        let loaded = ProjectMetadata::load(index_dir).unwrap();
+        assert_eq!(loaded.project_path, project_path);
+        assert_eq!(loaded.project_name, "project");
+        assert_eq!(loaded.model.as_deref(), Some("lightonai/LateOn-Code-edge"));
+    }
+
+    /// Pre-1.3 project.json files have no "model" field. They must still
+    /// deserialize so legacy indexes don't break the parser.
+    #[test]
+    fn test_project_metadata_legacy_json_without_model_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let index_dir = dir.path();
+        let legacy = r#"{
+            "project_path": "/some/project",
+            "project_name": "project"
+        }"#;
+        std::fs::write(index_dir.join("project.json"), legacy).unwrap();
+
+        let loaded = ProjectMetadata::load(index_dir).unwrap();
+        assert_eq!(loaded.project_path, PathBuf::from("/some/project"));
+        assert_eq!(loaded.project_name, "project");
+        assert!(
+            loaded.model.is_none(),
+            "legacy project.json must deserialize with model=None"
+        );
+    }
+
+    /// Two indexes for the same project but different models live in different
+    /// directories, so saving metadata to each never clobbers the other.
+    #[test]
+    fn test_two_models_same_project_do_not_overwrite_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let project_path = PathBuf::from("/some/project");
+
+        let dir_a = root
+            .path()
+            .join(compute_index_dir_name(&project_path, "model-a"));
+        let dir_b = root
+            .path()
+            .join(compute_index_dir_name(&project_path, "model-b"));
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+
+        ProjectMetadata::new(&project_path, "model-a")
+            .save(&dir_a)
+            .unwrap();
+        ProjectMetadata::new(&project_path, "model-b")
+            .save(&dir_b)
+            .unwrap();
+
+        let a = ProjectMetadata::load(&dir_a).unwrap();
+        let b = ProjectMetadata::load(&dir_b).unwrap();
+        assert_eq!(a.model.as_deref(), Some("model-a"));
+        assert_eq!(b.model.as_deref(), Some("model-b"));
+        assert_ne!(dir_a, dir_b);
+    }
+
+    /// Dir name is deterministic per (path, model) so stats/clear/find can
+    /// round-trip the same input to the same on-disk location across processes.
+    #[test]
+    fn test_get_index_dir_for_project_is_deterministic() {
+        let path = PathBuf::from("/Users/foo/project");
+        let a = get_index_dir_for_project(&path, "lightonai/LateOn").unwrap();
+        let b = get_index_dir_for_project(&path, "lightonai/LateOn").unwrap();
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
## Summary
- Include the model id in the index directory hash so each `(project, model)` pair keeps an independent index. Previously every model reused the same directory, and switching from `lightonai/LateOn` (128-dim) to `lightonai/LateOn-Code-edge` (48-dim) panicked inside `ndarray`:
  ```
  thread 'colgrep-index' panicked at ndarray-0.16.1/src/lib.rs:1551:
  ndarray: could not broadcast array from shape: [50, 48] to: [50, 128]
  Error: Index stage thread panicked
  ```
- `colgrep set-model` no longer wipes existing indexes — swapping models preserves the old index and reuses it on switch-back (no re-indexing).
- `colgrep clear` scopes to the active model; `colgrep clear --all` still wipes everything across every model.
- `colgrep status` and `colgrep --stats` surface the model each index was built with.
- `find_parent_index` filters by the active model so subdir searches never latch onto a mismatched index.
- `project.json` now records the model; legacy pre-change files (no `model` field) deserialize with `model=None` and are treated as orphaned by lookups — users can clean them up via `colgrep clear --all`.
- Root `README.md` documents `set-model`, one-shot `--model`, and per-model index behavior.

## Test plan
- [x] `cargo test -p colgrep --lib` — **511 passed** (was 506; +5 new tests in `colgrep/src/index/paths.rs`):
  - `test_different_models_different_hashes`
  - `test_same_path_and_model_stable_hash`
  - `test_empty_model_does_not_collide_with_populated_model`
  - `test_project_metadata_roundtrip_with_model`
  - `test_project_metadata_legacy_json_without_model_field`
  - `test_two_models_same_project_do_not_overwrite_metadata`
  - `test_get_index_dir_for_project_is_deterministic`
- [x] End-to-end stress on two projects × two models: 4 distinct index directories created, no panic on model switch, `set-model` preserves old indexes, `clear` only removes the active-model index, `clear --all` wipes all, parent-index lookup honors the active model, rapid 6× model flips with interleaved searches caused no corruption.
- [x] Reproduced the original ndarray panic scenario (`colgrep --model lightonai/LateOn-Code-edge` against a project indexed with `lightonai/LateOn`) — now succeeds and creates a second index next to the original.
- [ ] CI checks.