### PR TITLE
Add --install-hermes / --uninstall-hermes flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Each (project, model) pair has its own index directory, so switching models neve
 | Claude Code | `colgrep --install-claude-code` |
 | OpenCode    | `colgrep --install-opencode`    |
 | Codex       | `colgrep --install-codex`       |
+| Hermes      | `colgrep --install-hermes`      |
 
-> Restart your agent after installing. Claude Code has full hooks support. OpenCode and Codex integrations are basic for now, PRs welcome.
+> Restart your agent after installing. Claude Code has full hooks support. OpenCode, Codex, and Hermes integrations are basic for now, PRs welcome.
 
 ### How it works
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -330,6 +330,7 @@ Config stored at `~/.config/colgrep/config.json`.
 | Claude Code | `colgrep --install-claude-code` | `colgrep --uninstall-claude-code` |
 | OpenCode    | `colgrep --install-opencode`    | `colgrep --uninstall-opencode`    |
 | Codex       | `colgrep --install-codex`       | `colgrep --uninstall-codex`       |
+| Hermes      | `colgrep --install-hermes`      | `colgrep --uninstall-hermes`      |
 
 > Restart your agent after installing.
 

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -390,6 +390,14 @@ pub struct Cli {
     #[arg(long = "uninstall-codex")]
     pub uninstall_codex: bool,
 
+    /// Install colgrep for Hermes
+    #[arg(long = "install-hermes")]
+    pub install_hermes: bool,
+
+    /// Uninstall colgrep from Hermes
+    #[arg(long = "uninstall-hermes")]
+    pub uninstall_hermes: bool,
+
     /// Completely uninstall colgrep: remove from all AI tools, clear all indexes, and remove all data
     #[arg(long = "uninstall")]
     pub uninstall: bool,

--- a/colgrep/src/install/hermes.rs
+++ b/colgrep/src/install/hermes.rs
@@ -1,0 +1,97 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::fs;
+use std::path::PathBuf;
+
+use super::SKILL_MD;
+
+const COLGREP_MARKER_START: &str = "<!-- COLGREP_START -->";
+const COLGREP_MARKER_END: &str = "<!-- COLGREP_END -->";
+
+fn get_hermes_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".hermes"))
+}
+
+fn get_agents_md_path() -> Result<PathBuf> {
+    Ok(get_hermes_dir()?.join("AGENTS.md"))
+}
+
+fn add_to_agents_md() -> Result<()> {
+    let hermes_dir = get_hermes_dir()?;
+    fs::create_dir_all(&hermes_dir)?;
+
+    let agents_path = get_agents_md_path()?;
+    let mut content = if agents_path.exists() {
+        fs::read_to_string(&agents_path)?
+    } else {
+        String::from("# Hermes Agent Tools\n\n")
+    };
+
+    if let (Some(start), Some(end)) = (
+        content.find(COLGREP_MARKER_START),
+        content.find(COLGREP_MARKER_END),
+    ) {
+        let end_pos = end + COLGREP_MARKER_END.len();
+        content = format!("{}{}", &content[..start], &content[end_pos..]);
+    }
+
+    let colgrep_section = format!(
+        "{}\n{}\n{}\n",
+        COLGREP_MARKER_START, SKILL_MD, COLGREP_MARKER_END
+    );
+    content.push_str(&colgrep_section);
+    fs::write(&agents_path, content)?;
+    Ok(())
+}
+
+fn remove_from_agents_md() -> Result<()> {
+    let agents_path = get_agents_md_path()?;
+    if !agents_path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(&agents_path)?;
+    if let (Some(start), Some(end)) = (
+        content.find(COLGREP_MARKER_START),
+        content.find(COLGREP_MARKER_END),
+    ) {
+        let end_pos = end + COLGREP_MARKER_END.len();
+        let new_content = format!("{}{}", &content[..start], &content[end_pos..]);
+        let cleaned = new_content.trim().to_string();
+        if cleaned.is_empty() || cleaned == "# Hermes Agent Tools" {
+            fs::remove_file(&agents_path)?;
+        } else {
+            fs::write(&agents_path, format!("{}\n", cleaned))?;
+        }
+    }
+    Ok(())
+}
+
+pub fn install_hermes() -> Result<()> {
+    println!("Installing colgrep for Hermes...");
+    add_to_agents_md()?;
+    let agents_path = get_agents_md_path()?;
+    println!(
+        "{} Added colgrep instructions to {}",
+        "✓".green(),
+        agents_path.display()
+    );
+    println!();
+    println!("{}", "═".repeat(70).cyan());
+    println!(
+        "  {} {}",
+        "✓".green().bold(),
+        "COLGREP INSTALLED FOR HERMES".green().bold()
+    );
+    println!("  Restart Hermes sessions to pick up the AGENTS.md update.");
+    println!("  To uninstall: {}", "colgrep --uninstall-hermes".green());
+    println!("{}", "═".repeat(70).cyan());
+    Ok(())
+}
+
+pub fn uninstall_hermes() -> Result<()> {
+    println!("Uninstalling colgrep from Hermes...");
+    remove_from_agents_md()?;
+    println!("{} Removed colgrep from ~/.hermes/AGENTS.md", "✓".green());
+    Ok(())
+}

--- a/colgrep/src/install/mod.rs
+++ b/colgrep/src/install/mod.rs
@@ -1,10 +1,12 @@
 mod claude_code;
 mod codex;
+mod hermes;
 mod opencode;
 mod uninstall;
 
 pub use claude_code::{install_claude_code, uninstall_claude_code};
 pub use codex::{install_codex, uninstall_codex};
+pub use hermes::{install_hermes, uninstall_hermes};
 pub use opencode::{install_opencode, uninstall_opencode};
 pub use uninstall::uninstall_all;
 

--- a/colgrep/src/install/uninstall.rs
+++ b/colgrep/src/install/uninstall.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use std::fs;
 use std::path::PathBuf;
 
-use super::{uninstall_claude_code, uninstall_codex, uninstall_opencode};
+use super::{uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode};
 
 /// Get the colgrep data directory (contains indices and config)
 fn get_colgrep_data_dir() -> Result<PathBuf> {
@@ -33,10 +33,11 @@ fn get_hf_cache_dir() -> Result<PathBuf> {
 /// 1. Uninstalls from Claude Code (if installed)
 /// 2. Uninstalls from Codex (if installed)
 /// 3. Uninstalls from OpenCode (if installed)
-/// 4. Removes all indexes
-/// 5. Removes config and data directory
-/// 6. Removes ONNX runtime cache
-/// 7. Shows instructions for removing the binary
+/// 4. Uninstalls from Hermes (if installed)
+/// 5. Removes all indexes
+/// 6. Removes config and data directory
+/// 7. Removes ONNX runtime cache
+/// 8. Shows instructions for removing the binary
 pub fn uninstall_all() -> Result<()> {
     println!();
     println!("{}", "Completely uninstalling colgrep...".yellow().bold());
@@ -96,6 +97,17 @@ fn uninstall_ai_tools() {
         Err(_) => {
             println!(
                 "  {} OpenCode: not installed or already removed",
+                "-".dimmed()
+            );
+        }
+    }
+
+    // Hermes
+    match uninstall_hermes() {
+        Ok(()) => {}
+        Err(_) => {
+            println!(
+                "  {} Hermes: not installed or already removed",
                 "-".dimmed()
             );
         }

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -35,8 +35,8 @@ pub use parser::{
 
 // Install commands for AI coding tools
 pub use install::{
-    install_claude_code, install_codex, install_opencode, uninstall_all, uninstall_claude_code,
-    uninstall_codex, uninstall_opencode,
+    install_claude_code, install_codex, install_hermes, install_opencode, uninstall_all,
+    uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode,
 };
 
 // Signal handling

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -11,8 +11,8 @@ use rayon::ThreadPoolBuilder;
 
 use colgrep::{
     acceleration::{apply_acceleration_mode, env_acceleration_mode, AccelerationMode},
-    install_claude_code, install_codex, install_opencode, setup_signal_handler, uninstall_all,
-    uninstall_claude_code, uninstall_codex, uninstall_opencode,
+    install_claude_code, install_codex, install_hermes, install_opencode, setup_signal_handler,
+    uninstall_all, uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode,
 };
 
 use cli::{Cli, Commands};
@@ -63,6 +63,14 @@ fn main() -> Result<()> {
 
     if cli.uninstall_codex {
         return uninstall_codex();
+    }
+
+    if cli.install_hermes {
+        return install_hermes();
+    }
+
+    if cli.uninstall_hermes {
+        return uninstall_hermes();
     }
 
     if cli.uninstall {


### PR DESCRIPTION
## Summary
- add `--install-hermes` and `--uninstall-hermes` CLI flags alongside existing Claude/OpenCode/Codex integrations
- wire a Hermes installer module that writes/removes a marked ColGREP section in `~/.hermes/AGENTS.md`
- include Hermes cleanup in `--uninstall` and document the new flags in README tables

## Test plan
- [x] `cargo fmt`
- [x] `cargo check` in `colgrep/`

Made with [Cursor](https://cursor.com)