### PR TITLE
Consolidate agent install flags into --install-agent / --uninstall-agent, add Droid support

### DIFF
--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -331,6 +331,7 @@ Config stored at `~/.config/colgrep/config.json`.
 | OpenCode    | `colgrep --install-agent opencode`   | `colgrep --uninstall-agent opencode`   |
 | Codex       | `colgrep --install-agent codex`      | `colgrep --uninstall-agent codex`      |
 | Hermes      | `colgrep --install-agent hermes`     | `colgrep --uninstall-agent hermes`     |
+| Droid       | `colgrep --install-agent droid`      | `colgrep --uninstall-agent droid`      |
 
 > Restart your agent after installing.
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -325,12 +325,12 @@ Config stored at `~/.config/colgrep/config.json`.
 
 ## Agent Integrations
 
-| Agent       | Install                         | Uninstall                         |
-| ----------- | ------------------------------- | --------------------------------- |
-| Claude Code | `colgrep --install-claude-code` | `colgrep --uninstall-claude-code` |
-| OpenCode    | `colgrep --install-opencode`    | `colgrep --uninstall-opencode`    |
-| Codex       | `colgrep --install-codex`       | `colgrep --uninstall-codex`       |
-| Hermes      | `colgrep --install-hermes`      | `colgrep --uninstall-hermes`      |
+| Agent       | Install                              | Uninstall                              |
+| ----------- | ------------------------------------ | -------------------------------------- |
+| Claude Code | `colgrep --install-agent claude`     | `colgrep --uninstall-agent claude`     |
+| OpenCode    | `colgrep --install-agent opencode`   | `colgrep --uninstall-agent opencode`   |
+| Codex       | `colgrep --install-agent codex`      | `colgrep --uninstall-agent codex`      |
+| Hermes      | `colgrep --install-agent hermes`     | `colgrep --uninstall-agent hermes`     |
 
 > Restart your agent after installing.
 

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use colgrep::install::Agent;
 
 pub const MAIN_HELP: &str = "\
 EXAMPLES:
@@ -366,36 +367,36 @@ pub struct Cli {
     #[arg(long, value_name = "FLOAT")]
     pub alpha: Option<f32>,
 
-    /// Install colgrep as a plugin for Claude Code
-    #[arg(long = "install-claude-code")]
+    /// Install colgrep for an AI coding agent
+    #[arg(long = "install-agent", value_name = "AGENT")]
+    pub install_agent: Option<Agent>,
+
+    /// Uninstall colgrep from an AI coding agent
+    #[arg(long = "uninstall-agent", value_name = "AGENT")]
+    pub uninstall_agent: Option<Agent>,
+
+    #[arg(long = "install-claude-code", hide = true)]
     pub install_claude_code: bool,
 
-    /// Uninstall colgrep plugin from Claude Code
-    #[arg(long = "uninstall-claude-code")]
+    #[arg(long = "uninstall-claude-code", hide = true)]
     pub uninstall_claude_code: bool,
 
-    /// Install colgrep for OpenCode
-    #[arg(long = "install-opencode")]
+    #[arg(long = "install-opencode", hide = true)]
     pub install_opencode: bool,
 
-    /// Uninstall colgrep from OpenCode
-    #[arg(long = "uninstall-opencode")]
+    #[arg(long = "uninstall-opencode", hide = true)]
     pub uninstall_opencode: bool,
 
-    /// Install colgrep for Codex
-    #[arg(long = "install-codex")]
+    #[arg(long = "install-codex", hide = true)]
     pub install_codex: bool,
 
-    /// Uninstall colgrep from Codex
-    #[arg(long = "uninstall-codex")]
+    #[arg(long = "uninstall-codex", hide = true)]
     pub uninstall_codex: bool,
 
-    /// Install colgrep for Hermes
-    #[arg(long = "install-hermes")]
+    #[arg(long = "install-hermes", hide = true)]
     pub install_hermes: bool,
 
-    /// Uninstall colgrep from Hermes
-    #[arg(long = "uninstall-hermes")]
+    #[arg(long = "uninstall-hermes", hide = true)]
     pub uninstall_hermes: bool,
 
     /// Completely uninstall colgrep: remove from all AI tools, clear all indexes, and remove all data

--- a/colgrep/src/install/claude_code.rs
+++ b/colgrep/src/install/claude_code.rs
@@ -403,7 +403,7 @@ fn print_install_success() {
     println!("    • Index updates automatically when files change");
     println!();
     println!("  {}", "To uninstall:".cyan().bold());
-    println!("    {}", "colgrep --uninstall-claude-code".green());
+    println!("    {}", "colgrep --uninstall-agent claude".green());
     println!();
     println!("{}", border.yellow());
     println!();

--- a/colgrep/src/install/codex.rs
+++ b/colgrep/src/install/codex.rs
@@ -141,7 +141,7 @@ fn print_codex_success() {
     println!("    {}", "Example: \"find error handling logic\"".white());
     println!();
     println!("  {}", "To uninstall:".cyan().bold());
-    println!("    {}", "colgrep --uninstall-codex".green());
+    println!("    {}", "colgrep --uninstall-agent codex".green());
     println!();
     println!("{}", "═".repeat(70).cyan());
 }

--- a/colgrep/src/install/droid.rs
+++ b/colgrep/src/install/droid.rs
@@ -56,7 +56,10 @@ pub fn install_droid() -> Result<()> {
         "COLGREP INSTALLED FOR DROID (FACTORY)".green().bold()
     );
     println!("  Restart Droid sessions to pick up the new skill.");
-    println!("  To uninstall: {}", "colgrep --uninstall-agent droid".green());
+    println!(
+        "  To uninstall: {}",
+        "colgrep --uninstall-agent droid".green()
+    );
     println!("{}", "═".repeat(70).cyan());
     Ok(())
 }

--- a/colgrep/src/install/droid.rs
+++ b/colgrep/src/install/droid.rs
@@ -1,0 +1,72 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use std::fs;
+use std::path::PathBuf;
+
+use super::SKILL_MD;
+
+fn get_skill_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    Ok(home.join(".factory").join("skills").join("colgrep"))
+}
+
+fn get_skill_md_path() -> Result<PathBuf> {
+    Ok(get_skill_dir()?.join("SKILL.md"))
+}
+
+fn create_skill() -> Result<()> {
+    let skill_dir = get_skill_dir()?;
+    fs::create_dir_all(&skill_dir)?;
+
+    let frontmatter = "\
+---
+name: colgrep
+description: Semantic code search - finds code by meaning, not just text. Use as the PRIMARY search tool instead of Grep/Glob.
+---
+
+";
+
+    let skill_content = format!("{}{}", frontmatter, SKILL_MD);
+    fs::write(get_skill_md_path()?, skill_content)?;
+    Ok(())
+}
+
+fn remove_skill() -> Result<()> {
+    let skill_dir = get_skill_dir()?;
+    if skill_dir.exists() {
+        fs::remove_dir_all(&skill_dir)?;
+    }
+    Ok(())
+}
+
+pub fn install_droid() -> Result<()> {
+    println!("Installing colgrep for Droid (Factory)...");
+    create_skill()?;
+    let skill_path = get_skill_md_path()?;
+    println!(
+        "{} Created colgrep skill at {}",
+        "✓".green(),
+        skill_path.display()
+    );
+    println!();
+    println!("{}", "═".repeat(70).cyan());
+    println!(
+        "  {} {}",
+        "✓".green().bold(),
+        "COLGREP INSTALLED FOR DROID (FACTORY)".green().bold()
+    );
+    println!("  Restart Droid sessions to pick up the new skill.");
+    println!("  To uninstall: {}", "colgrep --uninstall-agent droid".green());
+    println!("{}", "═".repeat(70).cyan());
+    Ok(())
+}
+
+pub fn uninstall_droid() -> Result<()> {
+    println!("Uninstalling colgrep from Droid (Factory)...");
+    remove_skill()?;
+    println!(
+        "{} Removed colgrep skill from ~/.factory/skills/colgrep/",
+        "✓".green()
+    );
+    Ok(())
+}

--- a/colgrep/src/install/hermes.rs
+++ b/colgrep/src/install/hermes.rs
@@ -84,7 +84,10 @@ pub fn install_hermes() -> Result<()> {
         "COLGREP INSTALLED FOR HERMES".green().bold()
     );
     println!("  Restart Hermes sessions to pick up the AGENTS.md update.");
-    println!("  To uninstall: {}", "colgrep --uninstall-agent hermes".green());
+    println!(
+        "  To uninstall: {}",
+        "colgrep --uninstall-agent hermes".green()
+    );
     println!("{}", "═".repeat(70).cyan());
     Ok(())
 }

--- a/colgrep/src/install/hermes.rs
+++ b/colgrep/src/install/hermes.rs
@@ -84,7 +84,7 @@ pub fn install_hermes() -> Result<()> {
         "COLGREP INSTALLED FOR HERMES".green().bold()
     );
     println!("  Restart Hermes sessions to pick up the AGENTS.md update.");
-    println!("  To uninstall: {}", "colgrep --uninstall-hermes".green());
+    println!("  To uninstall: {}", "colgrep --uninstall-agent hermes".green());
     println!("{}", "═".repeat(70).cyan());
     Ok(())
 }

--- a/colgrep/src/install/mod.rs
+++ b/colgrep/src/install/mod.rs
@@ -1,5 +1,6 @@
 mod claude_code;
 mod codex;
+mod droid;
 mod hermes;
 mod opencode;
 mod uninstall;
@@ -8,6 +9,7 @@ use clap::ValueEnum;
 
 pub use claude_code::{install_claude_code, uninstall_claude_code};
 pub use codex::{install_codex, uninstall_codex};
+pub use droid::{install_droid, uninstall_droid};
 pub use hermes::{install_hermes, uninstall_hermes};
 pub use opencode::{install_opencode, uninstall_opencode};
 pub use uninstall::uninstall_all;
@@ -20,6 +22,7 @@ pub enum Agent {
     Claude,
     Codex,
     Hermes,
+    Droid,
 }
 
 pub fn install_agent(agent: &Agent) -> Result<()> {
@@ -28,6 +31,7 @@ pub fn install_agent(agent: &Agent) -> Result<()> {
         Agent::Claude => install_claude_code(),
         Agent::Codex => install_codex(),
         Agent::Hermes => install_hermes(),
+        Agent::Droid => install_droid(),
     }
 }
 
@@ -37,6 +41,7 @@ pub fn uninstall_agent(agent: &Agent) -> Result<()> {
         Agent::Claude => uninstall_claude_code(),
         Agent::Codex => uninstall_codex(),
         Agent::Hermes => uninstall_hermes(),
+        Agent::Droid => uninstall_droid(),
     }
 }
 

--- a/colgrep/src/install/mod.rs
+++ b/colgrep/src/install/mod.rs
@@ -4,11 +4,41 @@ mod hermes;
 mod opencode;
 mod uninstall;
 
+use clap::ValueEnum;
+
 pub use claude_code::{install_claude_code, uninstall_claude_code};
 pub use codex::{install_codex, uninstall_codex};
 pub use hermes::{install_hermes, uninstall_hermes};
 pub use opencode::{install_opencode, uninstall_opencode};
 pub use uninstall::uninstall_all;
+
+use anyhow::Result;
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum Agent {
+    Opencode,
+    Claude,
+    Codex,
+    Hermes,
+}
+
+pub fn install_agent(agent: &Agent) -> Result<()> {
+    match agent {
+        Agent::Opencode => install_opencode(),
+        Agent::Claude => install_claude_code(),
+        Agent::Codex => install_codex(),
+        Agent::Hermes => install_hermes(),
+    }
+}
+
+pub fn uninstall_agent(agent: &Agent) -> Result<()> {
+    match agent {
+        Agent::Opencode => uninstall_opencode(),
+        Agent::Claude => uninstall_claude_code(),
+        Agent::Codex => uninstall_codex(),
+        Agent::Hermes => uninstall_hermes(),
+    }
+}
 
 /// Shared skill instructions for all AI coding tools
 pub const SKILL_MD: &str = include_str!("SKILL.md");

--- a/colgrep/src/install/opencode.rs
+++ b/colgrep/src/install/opencode.rs
@@ -140,7 +140,7 @@ fn print_opencode_success() {
     println!("    {}", "Example: \"find error handling logic\"".white());
     println!();
     println!("  {}", "To uninstall:".cyan().bold());
-    println!("    {}", "colgrep --uninstall-opencode".green());
+    println!("    {}", "colgrep --uninstall-agent opencode".green());
     println!();
     println!("{}", "═".repeat(70).cyan());
 }

--- a/colgrep/src/install/uninstall.rs
+++ b/colgrep/src/install/uninstall.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use std::fs;
 use std::path::PathBuf;
 
-use super::{uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode};
+use super::{uninstall_claude_code, uninstall_codex, uninstall_droid, uninstall_hermes, uninstall_opencode};
 
 /// Get the colgrep data directory (contains indices and config)
 fn get_colgrep_data_dir() -> Result<PathBuf> {
@@ -108,6 +108,17 @@ fn uninstall_ai_tools() {
         Err(_) => {
             println!(
                 "  {} Hermes: not installed or already removed",
+                "-".dimmed()
+            );
+        }
+    }
+
+    // Droid (Factory)
+    match uninstall_droid() {
+        Ok(()) => {}
+        Err(_) => {
+            println!(
+                "  {} Droid (Factory): not installed or already removed",
                 "-".dimmed()
             );
         }

--- a/colgrep/src/install/uninstall.rs
+++ b/colgrep/src/install/uninstall.rs
@@ -7,7 +7,9 @@ use colored::Colorize;
 use std::fs;
 use std::path::PathBuf;
 
-use super::{uninstall_claude_code, uninstall_codex, uninstall_droid, uninstall_hermes, uninstall_opencode};
+use super::{
+    uninstall_claude_code, uninstall_codex, uninstall_droid, uninstall_hermes, uninstall_opencode,
+};
 
 /// Get the colgrep data directory (contains indices and config)
 fn get_colgrep_data_dir() -> Result<PathBuf> {

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -35,8 +35,9 @@ pub use parser::{
 
 // Install commands for AI coding tools
 pub use install::{
-    install_claude_code, install_codex, install_hermes, install_opencode, uninstall_all,
-    uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode,
+    install_agent, install_claude_code, install_codex, install_hermes, install_opencode,
+    uninstall_agent, uninstall_all, uninstall_claude_code, uninstall_codex, uninstall_hermes,
+    uninstall_opencode, Agent,
 };
 
 // Signal handling

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -35,9 +35,9 @@ pub use parser::{
 
 // Install commands for AI coding tools
 pub use install::{
-    install_agent, install_claude_code, install_codex, install_hermes, install_opencode,
-    uninstall_agent, uninstall_all, uninstall_claude_code, uninstall_codex, uninstall_hermes,
-    uninstall_opencode, Agent,
+    install_agent, install_claude_code, install_codex, install_droid, install_hermes,
+    install_opencode, uninstall_agent, uninstall_all, uninstall_claude_code, uninstall_codex,
+    uninstall_droid, uninstall_hermes, uninstall_opencode, Agent,
 };
 
 // Signal handling

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -11,8 +11,9 @@ use rayon::ThreadPoolBuilder;
 
 use colgrep::{
     acceleration::{apply_acceleration_mode, env_acceleration_mode, AccelerationMode},
-    install_claude_code, install_codex, install_hermes, install_opencode, setup_signal_handler,
-    uninstall_all, uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_opencode,
+    install_agent, install_claude_code, install_codex, install_hermes, install_opencode,
+    setup_signal_handler, uninstall_agent, uninstall_all, uninstall_claude_code,
+    uninstall_codex, uninstall_hermes, uninstall_opencode,
 };
 
 use cli::{Cli, Commands};
@@ -41,6 +42,14 @@ fn main() -> Result<()> {
     apply_acceleration_mode(acceleration_mode);
 
     // Handle global flags before subcommands
+    if let Some(ref agent) = cli.install_agent {
+        return install_agent(agent);
+    }
+
+    if let Some(ref agent) = cli.uninstall_agent {
+        return uninstall_agent(agent);
+    }
+
     if cli.install_claude_code {
         return install_claude_code();
     }

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -12,8 +12,8 @@ use rayon::ThreadPoolBuilder;
 use colgrep::{
     acceleration::{apply_acceleration_mode, env_acceleration_mode, AccelerationMode},
     install_agent, install_claude_code, install_codex, install_hermes, install_opencode,
-    setup_signal_handler, uninstall_agent, uninstall_all, uninstall_claude_code,
-    uninstall_codex, uninstall_hermes, uninstall_opencode,
+    setup_signal_handler, uninstall_agent, uninstall_all, uninstall_claude_code, uninstall_codex,
+    uninstall_hermes, uninstall_opencode,
 };
 
 use cli::{Cli, Commands};


### PR DESCRIPTION
## Summary
### Unified `--install-agent` / `--uninstall-agent` flags
All agent install and uninstall flags now go through two value-accepting flags backed by a `clap::ValueEnum`. Invalid agent names are caught at parse time with a clear error listing valid options.
### Droid (Factory) integration
Installs colgrep as a proper Factory skill at `~/.factory/skills/colgrep/SKILL.md` with YAML frontmatter, following Droid's skill discovery model. The Droid auto-discovers and invokes the skill when code search is needed, and users can also trigger it with `/colgrep`. Uninstall removes the skill directory entirely.
### Backward compatibility
`--install-opencode`, `--install-claude-code`, `--install-codex`, `--install-hermes` and their uninstall counterparts all continue to work but are hidden from `--help`.
If required, I can clear the old code, but I wanted to avoid breaking existing flows