### PR TITLE
Push filtering DB scans into SQL on the auto-index path

### DIFF
--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -1114,16 +1114,16 @@ impl IndexBuilder {
             filtering_count, vector_count
         );
         if filtering_count > vector_count {
-            // Filtering DB has orphan entries (docs without embeddings)
-            // Get all doc IDs from filtering that exceed the vector index count
-            // The vector index uses sequential IDs starting from 0, so any ID >= vector_count is orphan
-            let all_metadata = filtering::get(index_path, None, &[], None)?;
-
-            let orphan_ids: Vec<i64> = all_metadata
-                .iter()
-                .filter_map(|meta| meta.get("_subset_").and_then(|v| v.as_i64()))
-                .filter(|&id| id >= vector_count as i64)
-                .collect();
+            // Filtering DB has orphan entries (docs without embeddings).
+            // The vector index uses sequential IDs starting from 0, so any
+            // `_subset_` ID >= vector_count is an orphan. Push the filter into
+            // SQL so we don't materialize every row's metadata just to find a
+            // few stray IDs.
+            let orphan_ids = filtering::where_condition(
+                index_path,
+                "_subset_ >= ?",
+                &[serde_json::json!(vector_count as i64)],
+            )?;
 
             if !orphan_ids.is_empty() {
                 // Delete orphan entries from filtering DB
@@ -2242,14 +2242,11 @@ impl IndexBuilder {
     /// Clean up orphaned entries: files in index but not on disk
     /// This handles directory deletion/rename and any state inconsistencies
     fn cleanup_orphaned_entries(&self, index_path: &str) -> Result<usize> {
-        // Get all indexed files from filtering DB
-        let all_metadata = filtering::get(index_path, None, &[], None).unwrap_or_default();
-        let mut files: HashSet<String> = HashSet::new();
-        for meta in &all_metadata {
-            if let Some(file) = meta.get("file").and_then(|v| v.as_str()) {
-                files.insert(file.to_string());
-            }
-        }
+        // Pull only the distinct file paths from the metadata DB. The previous
+        // implementation called `filtering::get` which streams every column of
+        // every row (code text, embeddings metadata, etc.) on every search — a
+        // tens-of-megabytes JSON deserialize on large indexes.
+        let files = filtering::get_distinct_strings(index_path, "file").unwrap_or_default();
 
         let mut deleted_count = 0;
         for file_str in files {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -1114,16 +1114,16 @@ impl IndexBuilder {
             filtering_count, vector_count
         );
         if filtering_count > vector_count {
-            // Filtering DB has orphan entries (docs without embeddings)
-            // Get all doc IDs from filtering that exceed the vector index count
-            // The vector index uses sequential IDs starting from 0, so any ID >= vector_count is orphan
-            let all_metadata = filtering::get(index_path, None, &[], None)?;
-
-            let orphan_ids: Vec<i64> = all_metadata
-                .iter()
-                .filter_map(|meta| meta.get("_subset_").and_then(|v| v.as_i64()))
-                .filter(|&id| id >= vector_count as i64)
-                .collect();
+            // Filtering DB has orphan entries (docs without embeddings).
+            // The vector index uses sequential IDs starting from 0, so any
+            // `_subset_` ID >= vector_count is an orphan. Push the filter into
+            // SQL so we don't materialize every row's metadata just to find a
+            // few stray IDs.
+            let orphan_ids = filtering::where_condition(
+                index_path,
+                "_subset_ >= ?",
+                &[serde_json::json!(vector_count as i64)],
+            )?;
 
             if !orphan_ids.is_empty() {
                 // Delete orphan entries from filtering DB
@@ -2241,14 +2241,11 @@ impl IndexBuilder {
     /// Clean up orphaned entries: files in index but not on disk
     /// This handles directory deletion/rename and any state inconsistencies
     fn cleanup_orphaned_entries(&self, index_path: &str) -> Result<usize> {
-        // Get all indexed files from filtering DB
-        let all_metadata = filtering::get(index_path, None, &[], None).unwrap_or_default();
-        let mut files: HashSet<String> = HashSet::new();
-        for meta in &all_metadata {
-            if let Some(file) = meta.get("file").and_then(|v| v.as_str()) {
-                files.insert(file.to_string());
-            }
-        }
+        // Pull only the distinct file paths from the metadata DB. The previous
+        // implementation called `filtering::get` which streams every column of
+        // every row (code text, embeddings metadata, etc.) on every search — a
+        // tens-of-megabytes JSON deserialize on large indexes.
+        let files = filtering::get_distinct_strings(index_path, "file").unwrap_or_default();
 
         let mut deleted_count = 0;
         for file_str in files {

--- a/next-plaid/src/filtering.rs
+++ b/next-plaid/src/filtering.rs
@@ -1327,6 +1327,62 @@ pub fn where_condition_regexp(
     Ok(result)
 }
 
+/// Get distinct non-NULL string values from a single METADATA column.
+///
+/// This is a focused, low-cost alternative to [`get`] when callers only need
+/// to enumerate the unique values of a single string column (for example, the
+/// distinct file paths represented in the index). It runs a single
+/// `SELECT DISTINCT` query and avoids loading every row's full metadata.
+///
+/// # Arguments
+///
+/// * `index_path` - Path to the index directory
+/// * `column` - Column name (validated against the METADATA schema)
+///
+/// # Returns
+///
+/// * `Ok(values)` - Distinct non-NULL string values from the column
+/// * `Ok(vec![])` - The database does not exist or the column is not present
+/// * `Err(_)` - Invalid column name or a database error
+pub fn get_distinct_strings(index_path: &str, column: &str) -> Result<Vec<String>> {
+    let db_path = get_db_path(index_path);
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    // Reject column names that aren't safe SQL identifiers up front (defense in
+    // depth — the schema check below would also catch unknown names).
+    if !is_valid_column_name(column) {
+        return Err(Error::Filtering(format!(
+            "Invalid column name: '{}'",
+            column
+        )));
+    }
+
+    let conn = open_db(&db_path)?;
+
+    let columns = get_schema_columns(&conn)?;
+    if !columns.contains(column) {
+        return Ok(Vec::new());
+    }
+
+    let query = format!(
+        "SELECT DISTINCT \"{0}\" FROM METADATA WHERE \"{0}\" IS NOT NULL",
+        column
+    );
+    let mut stmt = conn.prepare(&query)?;
+    let rows = stmt.query_map([], |row| row.get::<_, Option<String>>(0))?;
+
+    let mut values: Vec<String> = Vec::new();
+    for row in rows {
+        if let Some(value) = row? {
+            values.push(value);
+        }
+    }
+
+    Ok(values)
+}
+
 /// Get full metadata rows by condition or subset IDs.
 ///
 /// Returns metadata as JSON objects with the `_subset_` field included.
@@ -1701,6 +1757,57 @@ mod tests {
         let subset =
             where_condition(path, "category = ? AND score > ?", &[json!("A"), json!(93)]).unwrap();
         assert_eq!(subset, vec![0]);
+    }
+
+    #[test]
+    fn test_get_distinct_strings_returns_unique_values() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+
+        let metadata = vec![
+            json!({"file": "src/a.rs", "code": "x"}),
+            json!({"file": "src/a.rs", "code": "y"}),
+            json!({"file": "src/b.rs", "code": "z"}),
+        ];
+        let doc_ids: Vec<i64> = (0..3).collect();
+        create(path, &metadata, &doc_ids).unwrap();
+
+        let mut files = get_distinct_strings(path, "file").unwrap();
+        files.sort();
+        assert_eq!(files, vec!["src/a.rs".to_string(), "src/b.rs".to_string()]);
+    }
+
+    #[test]
+    fn test_get_distinct_strings_missing_db_returns_empty() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+        // No create() call — DB does not exist.
+        let files = get_distinct_strings(path, "file").unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_get_distinct_strings_unknown_column_returns_empty() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+
+        let metadata = vec![json!({"file": "src/a.rs"})];
+        create(path, &metadata, &[0]).unwrap();
+
+        let values = get_distinct_strings(path, "not_a_column").unwrap();
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn test_get_distinct_strings_rejects_invalid_column_name() {
+        let dir = setup_test_dir();
+        let path = dir.path().to_str().unwrap();
+
+        let metadata = vec![json!({"file": "src/a.rs"})];
+        create(path, &metadata, &[0]).unwrap();
+
+        let result = get_distinct_strings(path, "file; DROP TABLE METADATA --");
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`colgrep` runs `try_index` on every search. Two helpers on that path were materializing every metadata row of the entire index just to inspect a single column:

- `cleanup_orphaned_entries` (`colgrep/src/index/mod.rs`) called `filtering::get(index_path, None, &[], None)` solely to collect the distinct `file` paths from the result. That executes `SELECT * FROM METADATA ORDER BY _subset_` and JSON-deserializes every column — including `code` — for every row.
- `reconcile_document_counts` (`colgrep/src/index/mod.rs`) did the same full-table dump, then iterated in Rust to find rows whose `_subset_` exceeded the vector index document count.

On a ~95 k-unit index this is tens of MB of deserialization on every query, which dominates latency for otherwise-quick searches and is a frequent cause of "colgrep hangs after the desync warning" reports.

## What changed

- New helper `filtering::get_distinct_strings(index_path, column)` in `next-plaid/src/filtering.rs`. Runs a single `SELECT DISTINCT "<col>" FROM METADATA WHERE "<col>" IS NOT NULL`, validates the column name as a safe identifier, and returns it as `Vec<String>`. Returns an empty vector when the DB or column is absent (matching the previous lenient behavior).
- `cleanup_orphaned_entries` now uses `get_distinct_strings(index_path, "file")` instead of loading every row.
- `reconcile_document_counts` now uses the existing `filtering::where_condition(index_path, "_subset_ >= ?", &[json!(vector_count)])` to fetch orphan IDs directly. The reconciliation semantics are unchanged.

Both reads now transfer a few KB instead of the whole METADATA table.

## Performance

Reproducible benchmark added at `next-plaid/examples/bench_metadata_filter.rs`. It builds a synthetic METADATA table at varying sizes and times the OLD path (full-table `filtering::get` + Rust-side filter, exactly what the two functions were doing) against the NEW SQL pushdown. Best-of-5, 2024 MacBook release build, 600 B of synthetic `code` per row, 8 units per file:

| n_rows |       op                 | OLD time | NEW time | speedup | bytes (OLD → NEW) |
|-------:|--------------------------|---------:|---------:|--------:|-------------------|
|  10 k  | distinct files (cleanup) |   35.7 ms |   3.2 ms |    11.2× | 10.21 MB → 33.93 KB |
|  10 k  | orphan ids   (reconcile) |   34.7 ms | 664.3 µs |    52.2× | 10.21 MB →  6 B    |
|  50 k  | distinct files (cleanup) |  181.7 ms |  17.0 ms |    10.7× | 51.29 MB → 174.00 KB |
|  50 k  | orphan ids   (reconcile) |  172.7 ms | 542.4 µs |   318.3× | 51.29 MB →  31 B   |
|  95 k  | distinct files (cleanup) |  341.8 ms |  32.0 ms |    10.7× | 97.53 MB → 333.43 KB |
|  95 k  | orphan ids   (reconcile) |  330.5 ms | 586.0 µs |   564.0× | 97.53 MB →  61 B   |
| 200 k  | distinct files (cleanup) |  718.9 ms |  73.2 ms |     9.8× | 205.94 MB → 713.94 KB |
| 200 k  | orphan ids   (reconcile) |  696.6 ms | 592.0 µs |  1176.8× | 205.94 MB → 141 B  |

The bench asserts result-set equivalence between OLD and NEW before timing, so it doubles as a regression check. Reproduce with:

```
cargo run --release --example bench_metadata_filter -p next-plaid -- --quick
cargo run --release --example bench_metadata_filter -p next-plaid -- \
    --sizes 10000,50000,95000,200000 --iters 5
```

`cleanup_orphaned_entries` runs on every search, so its 300 ms+ savings (at 95 k rows) hit every query. `reconcile_document_counts` runs only when the index/DB counts disagree, but that is exactly the state where users observe minute-long stalls.

## Tests

- New unit tests in `next-plaid/src/filtering.rs`:
  - `test_get_distinct_strings_returns_unique_values`
  - `test_get_distinct_strings_missing_db_returns_empty`
  - `test_get_distinct_strings_unknown_column_returns_empty`
  - `test_get_distinct_strings_rejects_invalid_column_name`
- `cargo test -p next-plaid --lib filtering::` — 44 passed (4 new, 40 existing)
- `cargo test -p colgrep --lib` — 511 passed
- `cargo check -p next-plaid -p colgrep` — clean

The benchmark example is in a separate commit so it can be dropped cleanly if you'd rather not add example binaries to the crate.

## Test plan

- [x] New helper covered by unit tests (happy path, missing DB, unknown column, invalid identifier)
- [x] Existing filtering test suite still passes
- [x] Full colgrep lib test suite still passes
- [x] `cargo check` passes for both crates
- [x] Bench asserts OLD/NEW result equivalence before timing