### PR TITLE
Improve ColGREP BM25: identifier-aware tokenizer + relative-score fusion

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -362,7 +362,7 @@ pub struct Cli {
     #[arg(long = "semantic-only")]
     pub no_fts: bool,
 
-    /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.65.
+    /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.60.
     #[arg(long, value_name = "FLOAT")]
     pub alpha: Option<f32>,
 
@@ -508,7 +508,7 @@ pub enum Commands {
         #[arg(long = "semantic-only")]
         no_fts: bool,
 
-        /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.65.
+        /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.60.
         #[arg(long, value_name = "FLOAT")]
         alpha: Option<f32>,
 

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -362,7 +362,7 @@ pub struct Cli {
     #[arg(long = "semantic-only")]
     pub no_fts: bool,
 
-    /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.75.
+    /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.65.
     #[arg(long, value_name = "FLOAT")]
     pub alpha: Option<f32>,
 
@@ -508,7 +508,7 @@ pub enum Commands {
         #[arg(long = "semantic-only")]
         no_fts: bool,
 
-        /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.75.
+        /// Hybrid search alpha: balance between keyword (0.0) and semantic (1.0). Default: 0.65.
         #[arg(long, value_name = "FLOAT")]
         alpha: Option<f32>,
 

--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -394,7 +394,7 @@ pub fn cmd_config(
     if let Some(a) = alpha {
         if a == 0.0 {
             config.clear_hybrid_alpha();
-            println!("✅ Reset hybrid alpha to 0.65 (default)");
+            println!("✅ Reset hybrid alpha to 0.60 (default)");
         } else {
             config.set_hybrid_alpha(a);
             println!("✅ Set hybrid alpha to {:.2}", config.get_hybrid_alpha());

--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -394,7 +394,7 @@ pub fn cmd_config(
     if let Some(a) = alpha {
         if a == 0.0 {
             config.clear_hybrid_alpha();
-            println!("✅ Reset hybrid alpha to 0.75 (default)");
+            println!("✅ Reset hybrid alpha to 0.65 (default)");
         } else {
             config.set_hybrid_alpha(a);
             println!("✅ Set hybrid alpha to {:.2}", config.get_hybrid_alpha());

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1340,7 +1340,7 @@ fn search_single_path(
         !config.use_hybrid_search()
     };
 
-    // CLI --alpha overrides config, config overrides default (0.75)
+    // CLI --alpha overrides config, config overrides default (0.65)
     let hybrid_alpha = alpha.unwrap_or_else(|| config.get_hybrid_alpha());
 
     // When no -e flag is provided, run BOTH semantic/hybrid search and text-pattern search

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1443,10 +1443,7 @@ fn search_single_path(
         // same file → same file occupied two top-K slots.
         use std::collections::hash_map::Entry;
         let mut merged: HashMap<PathBuf, colgrep::SearchResult> = HashMap::new();
-        for result in semantic_results
-            .into_iter()
-            .chain(hybrid_results.into_iter())
-        {
+        for result in semantic_results.into_iter().chain(hybrid_results) {
             let key = result.unit.file.clone();
             match merged.entry(key) {
                 Entry::Occupied(mut e) => {

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1340,7 +1340,7 @@ fn search_single_path(
         !config.use_hybrid_search()
     };
 
-    // CLI --alpha overrides config, config overrides default (0.65)
+    // CLI --alpha overrides config, config overrides default (0.55)
     let hybrid_alpha = alpha.unwrap_or_else(|| config.get_hybrid_alpha());
 
     // When no -e flag is provided, run BOTH semantic/hybrid search and text-pattern search
@@ -1413,13 +1413,17 @@ fn search_single_path(
                         Some(&hybrid_subset),
                     )?
                 } else {
+                    // Pass `None` so FTS5 is refetched *within* the subset.
+                    // Reusing the global `fts5_results` here would carry
+                    // BM25 hits from outside the subset; they'd get filtered
+                    // down to a tiny intersection, hurting recall.
                     searcher.search_hybrid_with_embedding(
                         &query_emb,
                         query,
                         search_top_k,
                         Some(&hybrid_subset),
                         hybrid_alpha,
-                        fts5_results.as_ref(),
+                        None,
                     )?
                 }
             } else {
@@ -1429,33 +1433,37 @@ fn search_single_path(
             vec![]
         };
 
-        // 3. Merge results: keep max score for each unique code unit (by file + line)
-        let mut merged: HashMap<(PathBuf, usize), colgrep::SearchResult> = HashMap::new();
-
-        for result in semantic_results {
-            let key = (result.unit.file.clone(), result.unit.line);
-            merged
-                .entry(key)
-                .and_modify(|existing| {
+        // 3. Merge results: one entry per file, span covers every matched
+        //    unit, score is the max across both calls.
+        //
+        // The previous `(file, line)` dedup was buggy: both
+        // `search_hybrid_with_embedding` calls run `collapse_by_file`
+        // internally, which sets `unit.line = min(line_i)` *across that
+        // call's candidate pool*. Two pools → two different mins for the
+        // same file → same file occupied two top-K slots.
+        use std::collections::hash_map::Entry;
+        let mut merged: HashMap<PathBuf, colgrep::SearchResult> = HashMap::new();
+        for result in semantic_results
+            .into_iter()
+            .chain(hybrid_results.into_iter())
+        {
+            let key = result.unit.file.clone();
+            match merged.entry(key) {
+                Entry::Occupied(mut e) => {
+                    let existing = e.get_mut();
+                    let new_start = existing.unit.line.min(result.unit.line);
+                    let new_end = existing.unit.end_line.max(result.unit.end_line);
                     if result.score > existing.score {
-                        *existing = result.clone();
+                        *existing = result;
                     }
-                })
-                .or_insert(result);
+                    existing.unit.line = new_start;
+                    existing.unit.end_line = new_end;
+                }
+                Entry::Vacant(e) => {
+                    e.insert(result);
+                }
+            }
         }
-
-        for result in hybrid_results {
-            let key = (result.unit.file.clone(), result.unit.line);
-            merged
-                .entry(key)
-                .and_modify(|existing| {
-                    if result.score > existing.score {
-                        *existing = result.clone();
-                    }
-                })
-                .or_insert(result);
-        }
-
         merged.into_values().collect::<Vec<_>>()
     };
 

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -14,7 +14,7 @@ use crate::display::{
     calc_display_ranges, find_representative_lines, group_results_by_file,
     print_highlighted_content, print_highlighted_ranges,
 };
-use crate::scoring::{compute_final_score, should_search_from_root};
+use crate::scoring::should_search_from_root;
 
 /// Pre-compiled pattern matcher for efficient repeated matching.
 /// Compiling regex is expensive (~microseconds), so we do it once and reuse.
@@ -1460,16 +1460,13 @@ fn search_single_path(
     };
 
     // Note: When -e is used, results are already filtered to units containing the pattern
-    // via filter_by_text_pattern_with_options() above, which supports -E, -F, -w flags
-
-    // Apply query boost and re-sort results
-    let mut results: Vec<_> = results
-        .into_iter()
-        .map(|mut r| {
-            r.score = compute_final_score(r.score, query, &r.unit, text_pattern);
-            r
-        })
-        .collect();
+    // via filter_by_text_pattern_with_options() above, which supports -E, -F, -w flags.
+    //
+    // The legacy `compute_final_score` test-name demotion was removed; the
+    // hybrid pipeline now applies `ranking::file_path_penalty` (a much more
+    // complete language-aware test/bench/example/compat penalty) inside
+    // `Searcher::search_hybrid_with_embedding`.
+    let mut results: Vec<_> = results;
     results.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -404,12 +404,21 @@ impl Config {
 
     /// Get hybrid search alpha (keyword vs semantic balance).
     ///
-    /// Defaults to 0.65 (semantic-leaning but with meaningful BM25 weight).
-    /// Tuned against the semble code-search benchmark with the identifier-aware
-    /// BM25 retriever and min-max score fusion; 0.65 is the peak of a fairly
-    /// broad plateau spanning roughly 0.55–0.75.
+    /// Defaults to 0.60. With the dedup + fts5-refetch fixes and the
+    /// path-stem / definition / file-coherence / file-collapse stack in
+    /// place, the plateau across alpha is broad (0.55–0.70 all land in
+    /// the 0.829–0.831 NDCG@10 band on the semble bench) and 0.60 is the
+    /// empirical peak.
+    ///
+    /// Overrideable at runtime via `COLGREP_ALPHA` env var (used by the
+    /// benchmark harness to grid-search without rebuilding).
     pub fn get_hybrid_alpha(&self) -> f32 {
-        self.hybrid_alpha.unwrap_or(0.65)
+        if let Ok(env_alpha) = std::env::var("COLGREP_ALPHA") {
+            if let Ok(v) = env_alpha.parse::<f32>() {
+                return v.clamp(0.0, 1.0);
+            }
+        }
+        self.hybrid_alpha.unwrap_or(0.60)
     }
 
     /// Set hybrid search alpha (0.0 = pure keyword, 1.0 = pure semantic).
@@ -417,7 +426,7 @@ impl Config {
         self.hybrid_alpha = Some(alpha.clamp(0.0, 1.0));
     }
 
-    /// Clear hybrid alpha setting (revert to default: 0.65).
+    /// Clear hybrid alpha setting (revert to default: 0.60).
     pub fn clear_hybrid_alpha(&mut self) {
         self.hybrid_alpha = None;
     }

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -403,9 +403,13 @@ impl Config {
     }
 
     /// Get hybrid search alpha (keyword vs semantic balance).
-    /// Defaults to 0.75 (favors semantic).
+    ///
+    /// Defaults to 0.65 (semantic-leaning but with meaningful BM25 weight).
+    /// Tuned against the semble code-search benchmark with the identifier-aware
+    /// BM25 retriever and min-max score fusion; 0.65 is the peak of a fairly
+    /// broad plateau spanning roughly 0.55–0.75.
     pub fn get_hybrid_alpha(&self) -> f32 {
-        self.hybrid_alpha.unwrap_or(0.75)
+        self.hybrid_alpha.unwrap_or(0.65)
     }
 
     /// Set hybrid search alpha (0.0 = pure keyword, 1.0 = pure semantic).
@@ -413,7 +417,7 @@ impl Config {
         self.hybrid_alpha = Some(alpha.clamp(0.0, 1.0));
     }
 
-    /// Clear hybrid alpha setting (revert to default: 0.75).
+    /// Clear hybrid alpha setting (revert to default: 0.65).
     pub fn clear_hybrid_alpha(&mut self) {
         self.hybrid_alpha = None;
     }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3402,6 +3402,17 @@ impl Searcher {
             })
             .collect();
 
+        // Boost candidates whose file-path stem matches a query token —
+        // queries like "interceptor manager" map almost surgically to
+        // `InterceptorManager.js`, and the path tells us so cheaply.
+        crate::ranking::apply_path_stem_boost(
+            &mut search_results,
+            query,
+            |r| r.unit.file.to_str().unwrap_or(""),
+            |r| r.score,
+            |r, s| r.score = s,
+        );
+
         // Boost units whose tree-sitter name matches a query token. Applied
         // before file-coherence so the symbol the user actually asked about
         // can lift its parent file above neighbours that merely reference it.

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3402,7 +3402,17 @@ impl Searcher {
             })
             .collect();
 
-        // Re-sort after the penalty multiplies scores, then truncate to top_k.
+        // Boost files that appear in multiple candidate units: the file with
+        // the most cumulative score in the pool gets `+0.2 * max_score` on
+        // its top-scoring unit; others get a proportional share.
+        crate::ranking::apply_file_coherence_boost(
+            &mut search_results,
+            |r| r.unit.file.to_str().unwrap_or(""),
+            |r| r.score,
+            |r, s| r.score = s,
+        );
+
+        // Re-sort after the penalty + boost multiplies scores, then truncate.
         search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         search_results.truncate(top_k);
 

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3402,6 +3402,26 @@ impl Searcher {
             })
             .collect();
 
+        // Boost units whose tree-sitter name matches a query token. Applied
+        // before file-coherence so the symbol the user actually asked about
+        // can lift its parent file above neighbours that merely reference it.
+        crate::ranking::apply_definition_boost(
+            &mut search_results,
+            query,
+            |r| r.unit.name.as_str(),
+            |r| {
+                matches!(
+                    r.unit.unit_type,
+                    crate::UnitType::Function
+                        | crate::UnitType::Method
+                        | crate::UnitType::Class
+                        | crate::UnitType::Constant
+                )
+            },
+            |r| r.score,
+            |r, s| r.score = s,
+        );
+
         // Boost files that appear in multiple candidate units: the file with
         // the most cumulative score in the pool gets `+0.2 * max_score` on
         // its top-scoring unit; others get a proportional share.
@@ -3412,7 +3432,7 @@ impl Searcher {
             |r, s| r.score = s,
         );
 
-        // Re-sort after the penalty + boost multiplies scores, then truncate.
+        // Re-sort after the penalty + boosts adjust scores, then truncate.
         search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         search_results.truncate(top_k);
 

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3292,8 +3292,11 @@ impl Searcher {
         alpha: f32,
     ) -> Result<Vec<SearchResult>> {
         let query_emb = self.encode_query(query)?;
-        let fts5 = self.fts5_search(query, top_k * 3, subset);
-        self.search_hybrid_with_embedding(&query_emb, query, top_k, subset, alpha, fts5.as_ref())
+        // Pass None so `search_hybrid_with_embedding` fetches FTS5 with its
+        // own `fetch_k` (≥200), matching the semantic-side over-fetch.
+        // Asymmetric pools (e.g. 200 semantic vs only 30 BM25) bias the
+        // min-max fusion toward the side with more candidates.
+        self.search_hybrid_with_embedding(&query_emb, query, top_k, subset, alpha, None)
     }
 
     /// Hybrid search using a pre-computed query embedding and optional cached
@@ -3398,11 +3401,25 @@ impl Searcher {
 
         let apply_penalty = crate::ranking::should_apply_path_penalty(query);
 
-        let mut search_results: Vec<SearchResult> = metadata
-            .into_iter()
+        // Index returned metadata rows by `_subset_` id so we can pair each
+        // row to its score safely. Using `Vec::zip` here was a bug: if any
+        // id in `fused_ids` had no METADATA row (stale FTS5 reference),
+        // every subsequent (meta, score) pair shifted by one — silently
+        // attaching the wrong score to the wrong unit.
+        let mut meta_by_id: std::collections::HashMap<i64, serde_json::Value> =
+            std::collections::HashMap::with_capacity(metadata.len());
+        for mut m in metadata {
+            if let Some(id) = m.get("_subset_").and_then(|v| v.as_i64()) {
+                fix_sqlite_types(&mut m);
+                meta_by_id.insert(id, m);
+            }
+        }
+
+        let mut search_results: Vec<SearchResult> = fused_ids
+            .iter()
             .zip(fused_scores.iter())
-            .filter_map(|(mut meta, &score)| {
-                fix_sqlite_types(&mut meta);
+            .filter_map(|(&id, &score)| {
+                let meta = meta_by_id.remove(&id)?;
                 serde_json::from_value::<CodeUnit>(meta).ok().map(|unit| {
                     let mut final_score = score;
                     if apply_penalty {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3330,6 +3330,7 @@ impl Searcher {
             .index
             .search(query_emb, &params, subset)
             .context("Semantic search failed")?;
+        trace_log(query, "semantic", &semantic.passage_ids, &semantic.scores, 20);
 
         let owned_fts5;
         let keyword = match fts5_results {
@@ -3378,6 +3379,10 @@ impl Searcher {
         // Fuse into the larger `fetch_k` pool (not `top_k`) so the path-noise
         // reranker can pull a strong-but-buried implementation file above
         // tests / examples that happened to rank higher in the raw fusion.
+        if let Some(kw) = keyword {
+            trace_log(query, "bm25", &kw.passage_ids, &kw.scores, 20);
+        }
+
         let (fused_ids, fused_scores) = if let Some(kw) = keyword {
             if kw.passage_ids.is_empty() {
                 (semantic.passage_ids, semantic.scores)
@@ -3394,6 +3399,7 @@ impl Searcher {
         } else {
             (semantic.passage_ids, semantic.scores)
         };
+        trace_log(query, "fused", &fused_ids, &fused_scores, 20);
 
         let metadata = filtering::get(&self.index_path, None, &[], Some(&fused_ids))
             .context("Failed to retrieve metadata")?;
@@ -3429,6 +3435,7 @@ impl Searcher {
                 })
             })
             .collect();
+        trace_log_results(query, "after_path_penalty", &search_results, 30);
 
         // Boost candidates whose file-path stem matches a query token —
         // queries like "interceptor manager" map almost surgically to
@@ -3440,6 +3447,7 @@ impl Searcher {
             |r| r.score,
             |r, s| r.score = s,
         );
+        trace_log_results(query, "after_path_stem_boost", &search_results, 30);
 
         // Boost units whose tree-sitter name matches a query token. Applied
         // before file-coherence so the symbol the user actually asked about
@@ -3460,6 +3468,7 @@ impl Searcher {
             |r| r.score,
             |r, s| r.score = s,
         );
+        trace_log_results(query, "after_definition_boost", &search_results, 30);
 
         // Boost files that appear in multiple candidate units: the file with
         // the most cumulative score in the pool gets `+0.2 * max_score` on
@@ -3470,12 +3479,14 @@ impl Searcher {
             |r| r.score,
             |r, s| r.score = s,
         );
+        trace_log_results(query, "after_coherence_boost", &search_results, 30);
 
         // Re-sort after the penalty + boosts adjust scores, then collapse
         // to one entry per file (merging start/end lines to cover every
         // matched unit from that file) before truncating to top_k.
         search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
         search_results = collapse_by_file(search_results, top_k);
+        trace_log_results(query, "final", &search_results, 30);
 
         Ok(search_results)
     }
@@ -3483,6 +3494,88 @@ impl Searcher {
     pub fn num_documents(&self) -> usize {
         self.index.num_documents()
     }
+}
+
+/// Emit a single JSON line to stderr describing one stage of the hybrid
+/// pipeline, when `COLGREP_TRACE` is truthy. No-op (essentially free) when
+/// the env var is unset, so we can leave the call sites in release builds.
+///
+/// The shape is intentionally simple — one object per call:
+///   {"stage":"fused","query":"...","ids":[...],"scores":[...]}
+/// `diagnose_misses.py` picks these up via stderr and aggregates them per
+/// query so the user can see which stage demotes the relevant file.
+fn trace_log(query: &str, stage: &str, ids: &[i64], scores: &[f32], limit: usize) {
+    if !trace_enabled() {
+        return;
+    }
+    let n = ids.len().min(scores.len()).min(limit);
+    // Build the JSON manually to avoid an extra dep and keep things fast.
+    let mut s = String::with_capacity(64 + n * 32);
+    s.push_str("{\"stage\":\"");
+    s.push_str(stage);
+    s.push_str("\",\"query\":");
+    json_escape(&mut s, query);
+    s.push_str(",\"ids\":[");
+    for (i, id) in ids.iter().take(n).enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&id.to_string());
+    }
+    s.push_str("],\"scores\":[");
+    for (i, sc) in scores.iter().take(n).enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!("{:.6}", sc));
+    }
+    s.push_str("]}");
+    eprintln!("__COLGREP_TRACE__ {}", s);
+}
+
+/// Same as [`trace_log`] but accepts a slice of `SearchResult` so callers
+/// can dump the post-rerank pool with file paths included.
+fn trace_log_results(query: &str, stage: &str, results: &[SearchResult], limit: usize) {
+    if !trace_enabled() {
+        return;
+    }
+    let n = results.len().min(limit);
+    let mut s = String::with_capacity(64 + n * 64);
+    s.push_str("{\"stage\":\"");
+    s.push_str(stage);
+    s.push_str("\",\"query\":");
+    json_escape(&mut s, query);
+    s.push_str(",\"results\":[");
+    for (i, r) in results.iter().take(n).enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str("{\"file\":");
+        json_escape(&mut s, &r.unit.file.to_string_lossy());
+        s.push_str(&format!(",\"score\":{:.6}}}", r.score));
+    }
+    s.push_str("]}");
+    eprintln!("__COLGREP_TRACE__ {}", s);
+}
+
+fn trace_enabled() -> bool {
+    matches!(std::env::var("COLGREP_TRACE").as_deref(), Ok("1") | Ok("true") | Ok("TRUE"))
+}
+
+fn json_escape(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
 }
 
 /// Collapse search results so each file appears at most once.

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -478,7 +478,7 @@ fn run_metadata_stage(
             &index_path,
             &metadata,
             &chunk.doc_ids,
-            &next_plaid::FtsTokenizer::Trigram,
+            &next_plaid::FtsTokenizer::IdentifierAware,
         ) {
             eprintln!("⚠️  FTS indexing failed (non-fatal): {}", e);
         }
@@ -3214,13 +3214,20 @@ impl Searcher {
 
     /// Run FTS5 keyword search if the text index is available and the query
     /// remains non-empty after sanitization.
+    ///
+    /// Uses [`next_plaid::text_search::sanitize_fts5_query_or`] because the
+    /// index is built with [`FtsTokenizer::IdentifierAware`]: each identifier
+    /// in the corpus has been pre-split into its compound + camel/snake parts,
+    /// so OR semantics let a natural-language query match documents that
+    /// contain *any* relevant sub-part. BM25 still rewards documents that hit
+    /// more query terms.
     pub fn fts5_search(
         &self,
         query: &str,
         top_k: usize,
         subset: Option<&[i64]>,
     ) -> Option<next_plaid::QueryResult> {
-        let sanitized_query = next_plaid::text_search::sanitize_fts5_query(query);
+        let sanitized_query = next_plaid::text_search::sanitize_fts5_query_or(query);
         if sanitized_query.is_empty() {
             return None;
         }
@@ -3349,13 +3356,19 @@ impl Searcher {
             }
         };
 
+        // Score-based min-max fusion: with the identifier-aware BM25 retriever,
+        // FTS5 recall@200 is ~99.6%, so the relative-score combiner outperforms
+        // pure rank-based RRF (rank-RRF caps both retrievers' contributions
+        // even when one is much higher quality on a given query).
         let (fused_ids, fused_scores) = if let Some(kw) = keyword {
             if kw.passage_ids.is_empty() {
                 (semantic.passage_ids, semantic.scores)
             } else {
-                next_plaid::text_search::fuse_rrf(
+                next_plaid::text_search::fuse_relative_score(
                     &semantic.passage_ids,
+                    &semantic.scores,
                     &kw.passage_ids,
+                    &kw.scores,
                     alpha,
                     top_k,
                 )

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3215,7 +3215,8 @@ impl Searcher {
     /// remains non-empty after sanitization.
     ///
     /// Uses [`next_plaid::text_search::sanitize_fts5_query_or`] because the
-    /// index is built with [`FtsTokenizer::IdentifierAware`]: each identifier
+    /// index is built with [`next_plaid::FtsTokenizer::IdentifierAware`]:
+    /// each identifier
     /// in the corpus has been pre-split into its compound + camel/snake parts,
     /// so OR semantics let a natural-language query match documents that
     /// contain *any* relevant sub-part. BM25 still rewards documents that hit
@@ -3330,7 +3331,13 @@ impl Searcher {
             .index
             .search(query_emb, &params, subset)
             .context("Semantic search failed")?;
-        trace_log(query, "semantic", &semantic.passage_ids, &semantic.scores, 20);
+        trace_log(
+            query,
+            "semantic",
+            &semantic.passage_ids,
+            &semantic.scores,
+            20,
+        );
 
         let owned_fts5;
         let keyword = match fts5_results {
@@ -3431,7 +3438,10 @@ impl Searcher {
                         let file_str = unit.file.to_string_lossy();
                         final_score *= crate::ranking::file_path_penalty(&file_str);
                     }
-                    SearchResult { unit, score: final_score }
+                    SearchResult {
+                        unit,
+                        score: final_score,
+                    }
                 })
             })
             .collect();
@@ -3484,7 +3494,11 @@ impl Searcher {
         // Re-sort after the penalty + boosts adjust scores, then collapse
         // to one entry per file (merging start/end lines to cover every
         // matched unit from that file) before truncating to top_k.
-        search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        search_results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         search_results = collapse_by_file(search_results, top_k);
         trace_log_results(query, "final", &search_results, 30);
 
@@ -3559,7 +3573,10 @@ fn trace_log_results(query: &str, stage: &str, results: &[SearchResult], limit: 
 }
 
 fn trace_enabled() -> bool {
-    matches!(std::env::var("COLGREP_TRACE").as_deref(), Ok("1") | Ok("true") | Ok("TRUE"))
+    matches!(
+        std::env::var("COLGREP_TRACE").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
 }
 
 fn json_escape(out: &mut String, s: &str) {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3307,7 +3307,19 @@ impl Searcher {
         alpha: f32,
         fts5_results: Option<&next_plaid::QueryResult>,
     ) -> Result<Vec<SearchResult>> {
-        let fetch_k = top_k * 3;
+        // Over-fetch generously so that after path-noise penalty + boosts
+        // + file collapse we still return exactly `top_k` distinct files
+        // (and not a smaller, "approximate" set) — `-k` is a hard
+        // contract from the user's perspective.
+        //
+        // The cost is small: each extra candidate is a single SQLite row
+        // read plus a few constant-time score adjustments. We cap at
+        // `num_documents()` so we never request more rows than the index
+        // actually contains.
+        let fetch_k = std::cmp::min(
+            std::cmp::max(top_k * 20, 200),
+            self.index.num_documents().max(top_k),
+        );
         let params = SearchParameters {
             top_k: fetch_k,
             ..Default::default()
@@ -3443,9 +3455,11 @@ impl Searcher {
             |r, s| r.score = s,
         );
 
-        // Re-sort after the penalty + boosts adjust scores, then truncate.
+        // Re-sort after the penalty + boosts adjust scores, then collapse
+        // to one entry per file (merging start/end lines to cover every
+        // matched unit from that file) before truncating to top_k.
         search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
-        search_results.truncate(top_k);
+        search_results = collapse_by_file(search_results, top_k);
 
         Ok(search_results)
     }
@@ -3453,6 +3467,37 @@ impl Searcher {
     pub fn num_documents(&self) -> usize {
         self.index.num_documents()
     }
+}
+
+/// Collapse search results so each file appears at most once.
+///
+/// Walks `results` (which the caller has already sorted by score descending)
+/// and for every file keeps the first / highest-scoring unit as the leader,
+/// then extends that leader's line range to cover every subsequent unit from
+/// the same file: `line = min(line_i)`, `end_line = max(end_line_i)`.
+///
+/// Truncates to `top_k` unique files. The leader's other metadata (name,
+/// signature, code, ...) is left untouched so consumers can still display
+/// the top unit's structural information.
+fn collapse_by_file(results: Vec<SearchResult>, top_k: usize) -> Vec<SearchResult> {
+    let mut by_file: std::collections::HashMap<std::path::PathBuf, usize> =
+        std::collections::HashMap::new();
+    let mut out: Vec<SearchResult> = Vec::with_capacity(top_k.min(results.len()));
+    for r in results {
+        if let Some(&idx) = by_file.get(&r.unit.file) {
+            // Merge: cover the full span of all candidates from this file.
+            let leader = &mut out[idx];
+            leader.unit.line = leader.unit.line.min(r.unit.line);
+            leader.unit.end_line = leader.unit.end_line.max(r.unit.end_line);
+        } else {
+            if out.len() >= top_k {
+                continue;
+            }
+            by_file.insert(r.unit.file.clone(), out.len());
+            out.push(r);
+        }
+    }
+    out
 }
 
 /// SQLite stores booleans as integers and arrays as JSON strings. Normalize

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -3360,6 +3360,10 @@ impl Searcher {
         // FTS5 recall@200 is ~99.6%, so the relative-score combiner outperforms
         // pure rank-based RRF (rank-RRF caps both retrievers' contributions
         // even when one is much higher quality on a given query).
+        //
+        // Fuse into the larger `fetch_k` pool (not `top_k`) so the path-noise
+        // reranker can pull a strong-but-buried implementation file above
+        // tests / examples that happened to rank higher in the raw fusion.
         let (fused_ids, fused_scores) = if let Some(kw) = keyword {
             if kw.passage_ids.is_empty() {
                 (semantic.passage_ids, semantic.scores)
@@ -3370,7 +3374,7 @@ impl Searcher {
                     &kw.passage_ids,
                     &kw.scores,
                     alpha,
-                    top_k,
+                    fetch_k,
                 )
             }
         } else {
@@ -3380,16 +3384,27 @@ impl Searcher {
         let metadata = filtering::get(&self.index_path, None, &[], Some(&fused_ids))
             .context("Failed to retrieve metadata")?;
 
-        let search_results: Vec<SearchResult> = metadata
+        let apply_penalty = crate::ranking::should_apply_path_penalty(query);
+
+        let mut search_results: Vec<SearchResult> = metadata
             .into_iter()
             .zip(fused_scores.iter())
             .filter_map(|(mut meta, &score)| {
                 fix_sqlite_types(&mut meta);
-                serde_json::from_value::<CodeUnit>(meta)
-                    .ok()
-                    .map(|unit| SearchResult { unit, score })
+                serde_json::from_value::<CodeUnit>(meta).ok().map(|unit| {
+                    let mut final_score = score;
+                    if apply_penalty {
+                        let file_str = unit.file.to_string_lossy();
+                        final_score *= crate::ranking::file_path_penalty(&file_str);
+                    }
+                    SearchResult { unit, score: final_score }
+                })
             })
             .collect();
+
+        // Re-sort after the penalty multiplies scores, then truncate to top_k.
+        search_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        search_results.truncate(top_k);
 
         Ok(search_results)
     }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2025,12 +2025,11 @@ const IGNORED_DIRS: &[&str] = &[
     "third_party",
     "third-party",
     "external",
-    // Build outputs
+    // Build outputs.
     "target",
     "build",
     "dist",
     "out",
-    "output",
     "bin",
     "obj",
     // Python

--- a/colgrep/src/index/paths.rs
+++ b/colgrep/src/index/paths.rs
@@ -62,8 +62,17 @@ impl ProjectMetadata {
     }
 }
 
-/// Get the base colgrep data directory (XDG_DATA_HOME/colgrep or platform equivalent)
+/// Get the base colgrep data directory (XDG_DATA_HOME/colgrep or platform equivalent).
+///
+/// Honours the `COLGREP_DATA_DIR` env var so concurrent benchmark
+/// processes can keep separate index caches without fighting over
+/// `~/.local/share/colgrep/indices`.
 pub fn get_colgrep_data_dir() -> Result<PathBuf> {
+    if let Ok(env_dir) = std::env::var("COLGREP_DATA_DIR") {
+        if !env_dir.is_empty() {
+            return Ok(PathBuf::from(env_dir));
+        }
+    }
     let data_dir = dirs::data_dir().context("Could not determine data directory")?;
     Ok(data_dir.join("colgrep").join("indices"))
 }

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -13,6 +13,7 @@ pub mod install;
 pub mod model;
 pub mod onnx_runtime;
 pub mod parser;
+pub mod ranking;
 pub mod signal;
 pub mod stderr;
 

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -179,8 +179,9 @@ fn definition_boost_frac() -> f32 {
 
 /// Apply the definition boost in place. For each candidate, if its `name`
 /// matches any token of the identifier-aware-tokenized query, add
-/// `0.5 * max_score` to its score. Uses the same tokenization as the BM25
-/// retriever so `parse_request` and `parseRequest` match each other.
+/// `definition_boost_frac() * max_score` to its score. Uses the same
+/// tokenization as the BM25 retriever so `parse_request` and
+/// `parseRequest` match each other.
 ///
 /// The caller's `is_definition` closure filters out unit kinds whose
 /// `name` is synthetic (e.g. `raw_code_24` blocks).
@@ -251,14 +252,6 @@ fn env_flag(name: &str, default: bool) -> bool {
     }
 }
 
-fn stem_proportional() -> bool {
-    // Default OFF: ablation on the semble bench (alpha=0.65) shows
-    // proportional ratio costs ~0.012 NDCG@10 vs binary boost. The dense
-    // and BM25 retrievers already weight signal density; an *additional*
-    // proportional dampening of the stem boost over-discounts multi-word
-    // NL queries where only one keyword names the file.
-    env_flag("COLGREP_STEM_PROPORTIONAL", false)
-}
 fn stem_stopword_filter() -> bool {
     env_flag("COLGREP_STEM_STOPWORDS", true)
 }
@@ -310,11 +303,7 @@ pub fn apply_path_stem_boost<T>(
     if query_tokens.is_empty() {
         return;
     }
-    let proportional = stem_proportional();
     let do_plural_snake = stem_plural_snake();
-    // Total keyword count for proportional match ratio. Use the
-    // de-stopworded set so common NL words don't dilute the ratio.
-    let n_query_tokens = query_tokens.len() as f32;
 
     let max_boost = max_score * path_stem_boost_frac();
     let max_prefix_boost = max_score * path_stem_prefix_frac();
@@ -345,25 +334,18 @@ pub fn apply_path_stem_boost<T>(
             }
             out
         };
-        // Count how many *distinct* query tokens this file's stem hits
-        // (exact or prefix). Proportional weighting: a query like
-        // "auth token rotation" matching all three parts wins out over
-        // a file matching only one part.
-        let mut exact_matches: usize = 0;
-        let mut prefix_matches: usize = 0;
-        for qtok in &query_tokens {
+        // Does *any* query token hit the stem (exact-or-prefix)?
+        let mut exact_hit = false;
+        let mut prefix_hit = false;
+        'outer: for qtok in &query_tokens {
             let qvars = normalize(qtok);
-            let exact = stem_tokens.iter().any(|stem_tok| {
+            for stem_tok in &stem_tokens {
                 let svars = normalize(stem_tok);
-                svars.iter().any(|sv| qvars.iter().any(|qv| sv == qv))
-            });
-            if exact {
-                exact_matches += 1;
-                continue;
-            }
-            let prefix = stem_tokens.iter().any(|stem_tok| {
-                let svars = normalize(stem_tok);
-                svars.iter().any(|sv| {
+                if svars.iter().any(|sv| qvars.iter().any(|qv| sv == qv)) {
+                    exact_hit = true;
+                    break 'outer;
+                }
+                if svars.iter().any(|sv| {
                     qvars.iter().any(|qv| {
                         let (short, long) = if sv.len() <= qv.len() {
                             (sv.as_str(), qv.as_str())
@@ -372,29 +354,17 @@ pub fn apply_path_stem_boost<T>(
                         };
                         short.len() >= 3 && long.starts_with(short)
                     })
-                })
-            });
-            if prefix {
-                prefix_matches += 1;
+                }) {
+                    prefix_hit = true;
+                }
             }
         }
-        // When proportional is off, any single match gets the full boost
-        // (the old binary-hit behavior).
-        let ratio = |m: usize| -> f32 {
-            if proportional {
-                m as f32 / n_query_tokens
-            } else if m > 0 {
-                1.0
-            } else {
-                0.0
-            }
-        };
-        if exact_matches > 0 {
+        if exact_hit {
             let cur = score(&items[i]);
-            set_score(&mut items[i], cur + max_boost * ratio(exact_matches));
-        } else if prefix_matches > 0 {
+            set_score(&mut items[i], cur + max_boost);
+        } else if prefix_hit {
             let cur = score(&items[i]);
-            set_score(&mut items[i], cur + max_prefix_boost * ratio(prefix_matches));
+            set_score(&mut items[i], cur + max_prefix_boost);
         }
     }
 }

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -6,6 +6,7 @@
 //! can run after fusion without re-reading any documents.
 
 use regex::Regex;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -144,6 +145,70 @@ pub fn file_path_penalty(file: &str) -> f32 {
 pub fn should_apply_path_penalty(query: &str) -> bool {
     let q = query.to_lowercase();
     !(q.contains("test") || q.contains("spec") || q.contains("benchmark"))
+}
+
+// =========================================================================
+// File coherence boost
+// =========================================================================
+//
+// When several candidate units come from the same file, that file is more
+// likely to be the canonical implementation than a file with a single
+// strong match.  Add a fraction of `max_score` to each file's best-scoring
+// unit, scaled by how much of the candidate pool that file occupies.
+//
+// This is semble's `boost_multi_chunk_files` adapted to code units; one
+// boost per file (applied to its top-scoring unit) rather than per chunk.
+
+const FILE_COHERENCE_BOOST_FRAC: f32 = 0.2;
+
+/// Apply the file-coherence boost in place to a `Vec<(file_path, score)>`.
+///
+/// Returns nothing; the caller is responsible for re-sorting and truncating
+/// to `top_k` afterwards.
+///
+/// The `score_for` argument is used to fetch + update scores via index so we
+/// can stay generic over `SearchResult` shapes.
+pub fn apply_file_coherence_boost<T>(items: &mut [T], file_path: impl Fn(&T) -> &str, score: impl Fn(&T) -> f32, set_score: impl Fn(&mut T, f32)) {
+    if items.is_empty() {
+        return;
+    }
+    let max_score = items.iter().map(&score).fold(f32::NEG_INFINITY, f32::max);
+    if !max_score.is_finite() || max_score <= 0.0 {
+        return;
+    }
+
+    // file_path → (sum of scores in this file, index of the top-scoring unit)
+    let mut per_file: HashMap<String, (f32, usize)> = HashMap::new();
+    for (i, item) in items.iter().enumerate() {
+        let path = file_path(item).to_string();
+        let s = score(item);
+        per_file
+            .entry(path)
+            .and_modify(|(sum, top_idx)| {
+                *sum += s;
+                if s > score(&items[*top_idx]) {
+                    *top_idx = i;
+                }
+            })
+            .or_insert((s, i));
+    }
+
+    let max_file_sum = per_file
+        .values()
+        .map(|(sum, _)| *sum)
+        .fold(f32::NEG_INFINITY, f32::max);
+    if !max_file_sum.is_finite() || max_file_sum <= 0.0 {
+        return;
+    }
+
+    let boost_unit = max_score * FILE_COHERENCE_BOOST_FRAC;
+    let updates: Vec<(usize, f32)> = per_file
+        .into_values()
+        .map(|(sum, idx)| (idx, score(&items[idx]) + boost_unit * sum / max_file_sum))
+        .collect();
+    for (idx, new_score) in updates {
+        set_score(&mut items[idx], new_score);
+    }
 }
 
 #[cfg(test)]

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -250,6 +250,7 @@ pub fn apply_path_stem_boost<T>(
     }
 
     let boost = max_score * PATH_STEM_BOOST_FRAC;
+    let prefix_boost = max_score * PATH_STEM_BOOST_FRAC * 0.5;
     for i in 0..items.len() {
         let path = file_path(&items[i]);
         let stem = Path::new(path)
@@ -261,9 +262,29 @@ pub fn apply_path_stem_boost<T>(
             continue;
         }
         let stem_tokens = next_plaid::text_search::tokenize_identifiers(&stem);
-        if stem_tokens.iter().any(|t| query_tokens.contains(t)) {
+        let exact_hit = stem_tokens.iter().any(|t| query_tokens.contains(t));
+        if exact_hit {
             let cur = score(&items[i]);
             set_score(&mut items[i], cur + boost);
+            continue;
+        }
+        // Half-strength prefix match for morphological variants:
+        // "dependency" ↔ "dependencies", "config" ↔ "configuration",
+        // "intercept" ↔ "interceptor".  Either side must be at least
+        // 3 characters to avoid spurious one-letter prefixes hitting.
+        let prefix_hit = stem_tokens.iter().any(|stem_tok| {
+            query_tokens.iter().any(|qtok| {
+                let (short, long) = if stem_tok.len() <= qtok.len() {
+                    (stem_tok.as_str(), qtok.as_str())
+                } else {
+                    (qtok.as_str(), stem_tok.as_str())
+                };
+                short.len() >= 3 && long.starts_with(short)
+            })
+        });
+        if prefix_hit {
+            let cur = score(&items[i]);
+            set_score(&mut items[i], cur + prefix_boost);
         }
     }
 }

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -1,0 +1,201 @@
+//! Library-side ranking signals applied on top of fused (semantic + BM25)
+//! scores in [`crate::index::Searcher::search_hybrid_with_embedding`].
+//!
+//! These signals are deliberately language-agnostic and depend only on the
+//! file path (or other metadata already returned by the index), so they
+//! can run after fusion without re-reading any documents.
+
+use regex::Regex;
+use std::path::Path;
+use std::sync::OnceLock;
+
+// =========================================================================
+// File-path noise penalty
+// =========================================================================
+//
+// Down-rank hits whose file path looks like test code, compat shims, or
+// example/demo code. Multiplicative so it composes cleanly with the fused
+// (semantic + BM25) score. Pattern set mirrors semble's `penalties.py` so
+// the behaviour is comparable between the two tools.
+
+const STRONG_PENALTY: f32 = 0.3;
+const MODERATE_PENALTY: f32 = 0.5;
+const MILD_PENALTY: f32 = 0.7;
+
+/// Test files across common languages (suffix-anchored).
+fn test_file_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        // `x` flag enables "verbose" mode: ignores whitespace + line comments
+        // inside the pattern so the language list stays readable.
+        Regex::new(
+            r"(?x)
+                (?:^|/)(?:
+                      test_[^/]*\.py                  # Python: test_foo.py
+                    | [^/]*_test\.py                  # Python: foo_test.py
+                    | [^/]*_test\.go                  # Go
+                    | [^/]*Tests?\.java               # Java: FooTest/FooTests.java
+                    | [^/]*Test\.php                  # PHP: FooTest.php
+                    | [^/]*_spec\.rb                  # Ruby (RSpec)
+                    | [^/]*_test\.rb                  # Ruby
+                    | [^/]*\.test\.[jt]sx?            # JS/TS: foo.test.js/ts/jsx/tsx
+                    | [^/]*\.spec\.[jt]sx?            # JS/TS: foo.spec.*
+                    | [^/]*Tests?\.kt                 # Kotlin
+                    | [^/]*Spec\.kt                   # Kotlin (Kotest)
+                    | [^/]*Tests?\.swift              # Swift (XCTest)
+                    | [^/]*Spec\.swift                # Swift (Quick)
+                    | [^/]*Tests?\.cs                 # C#
+                    | test_[^/]*\.(?:cpp|cc|cxx)      # C++ (Google Test)
+                    | [^/]*_test\.(?:cpp|cc|cxx)      # C++
+                    | test_[^/]*\.c                   # C
+                    | [^/]*_test\.c                   # C
+                    | [^/]*Spec\.scala                # Scala (ScalaTest)
+                    | [^/]*Suite\.scala               # Scala (MUnit)
+                    | [^/]*Test\.scala                # Scala
+                    | [^/]*_test\.dart                # Dart
+                    | test_[^/]*\.dart                # Dart
+                    | [^/]*_spec\.lua                 # Lua (busted)
+                    | [^/]*_test\.lua                 # Lua
+                    | test_[^/]*\.lua                 # Lua (luaunit)
+                    | [^/]*_test\.rs                  # Rust
+                    | tests\.rs                       # Rust (top-level integration test module)
+                    | [^/]*_test\.exs                 # Elixir (ExUnit)
+                    | [^/]*Spec\.hs                   # Haskell (HSpec)
+                    | [^/]*Test\.hs                   # Haskell (Tasty/HUnit)
+                    | test_[^/]*\.ml                  # OCaml (Alcotest)
+                    | [^/]*_test\.ml                  # OCaml
+                    | test[-_][^/]*\.[rR]             # R (testthat: test-foo.R / test_foo.R)
+                    | [^/]*_test\.zig                 # Zig
+                    | test_[^/]*\.zig                 # Zig
+                    | runtests\.jl                    # Julia (Pkg convention)
+                    | test_[^/]*\.jl                  # Julia
+                    | [^/]*_test\.jl                  # Julia
+                    | [^/]*\.test\.vue                # Vue
+                    | [^/]*\.spec\.vue                # Vue
+                    | [^/]*\.test\.svelte             # Svelte
+                    | [^/]*\.spec\.svelte             # Svelte
+                    | tst_[^/]*\.qml                  # QML (Qt Test)
+                    | [^/]*\.bats                     # Bash (bats-core)
+                    | test_[^/]*\.(?:sh|bash|zsh)     # Shell
+                    | [^/]*_test\.(?:sh|bash|zsh)     # Shell
+                    | [^/]*\.Tests\.ps1               # PowerShell (Pester)
+                    | test_helpers?[^/]*\.\w+         # cross-language test helpers
+                )$
+            ",
+        )
+        .expect("test_file_re")
+    })
+}
+
+fn test_dir_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?:^|/)(?:tests?|__tests__|spec|testing)(?:/|$)").unwrap())
+}
+
+fn compat_dir_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?:^|/)(?:compat|_compat|legacy)(?:/|$)").unwrap())
+}
+
+fn examples_dir_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?:^|/)(?:_?examples?|docs?_src)(?:/|$)").unwrap())
+}
+
+/// Return a multiplicative penalty in (0, 1] for the file path. 1.0 means no
+/// penalty. Penalties for different patterns compound: a `compat/foo_test.py`
+/// file gets `STRONG_PENALTY * STRONG_PENALTY = 0.09`.
+///
+/// Tests, compat/legacy shims, and example/demo trees get the strongest hit
+/// because LLM-generated benchmark targets (and most real agent queries)
+/// point to the canonical implementation file, not the test that exercises
+/// it. `.d.ts` declaration stubs get a mild penalty because they still
+/// carry useful type information. Re-export barrels (`__init__.py`,
+/// `package-info.java`) get a moderate penalty.
+pub fn file_path_penalty(file: &str) -> f32 {
+    let normalised = file.replace('\\', "/");
+    let mut penalty: f32 = 1.0;
+
+    if test_file_re().is_match(&normalised) || test_dir_re().is_match(&normalised) {
+        penalty *= STRONG_PENALTY;
+    }
+    if compat_dir_re().is_match(&normalised) {
+        penalty *= STRONG_PENALTY;
+    }
+    if examples_dir_re().is_match(&normalised) {
+        penalty *= STRONG_PENALTY;
+    }
+    if normalised.ends_with(".d.ts") {
+        penalty *= MILD_PENALTY;
+    }
+    let name = Path::new(&normalised)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if matches!(name, "__init__.py" | "package-info.java") {
+        penalty *= MODERATE_PENALTY;
+    }
+    penalty
+}
+
+/// Skip the path penalty when the query itself looks like it is asking
+/// about test / spec / benchmark code, so e.g. `"unit test for parseRequest"`
+/// still surfaces the test file.
+pub fn should_apply_path_penalty(query: &str) -> bool {
+    let q = query.to_lowercase();
+    !(q.contains("test") || q.contains("spec") || q.contains("benchmark"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_canonical_path_no_penalty() {
+        assert_eq!(file_path_penalty("src/foo.py"), 1.0);
+        assert_eq!(file_path_penalty("lib/core/Axios.js"), 1.0);
+    }
+
+    #[test]
+    fn test_python_test_files_penalised() {
+        assert!(file_path_penalty("tests/test_foo.py") < 0.5);
+        assert!(file_path_penalty("foo_test.py") < 0.5);
+        assert!(file_path_penalty("src/__init__.py") < 1.0);
+    }
+
+    #[test]
+    fn test_compat_and_examples_penalised() {
+        assert!(file_path_penalty("compat/old_api.py") < 0.5);
+        assert!(file_path_penalty("legacy/foo.py") < 0.5);
+        assert!(file_path_penalty("examples/demo.py") < 0.5);
+    }
+
+    #[test]
+    fn test_dts_mild_penalty() {
+        let p = file_path_penalty("types/index.d.ts");
+        assert!(p < 1.0 && p > 0.5);
+    }
+
+    #[test]
+    fn test_compounding_penalty() {
+        // Cross-category compounds: compat dir + test file → 0.3 * 0.3 = 0.09.
+        let p = file_path_penalty("compat/foo_test.py");
+        assert!(p < 0.1, "expected compound penalty, got {p}");
+    }
+
+    #[test]
+    fn test_same_category_does_not_compound() {
+        // Both test_dir and test_file match but it's the same "test" category;
+        // applying STRONG twice would over-punish, so semble applies it once.
+        let p = file_path_penalty("tests/foo_test.py");
+        assert!((p - 0.3).abs() < 1e-6, "expected 0.3, got {p}");
+    }
+
+    #[test]
+    fn test_should_apply_path_penalty() {
+        assert!(should_apply_path_penalty("how authentication works"));
+        assert!(!should_apply_path_penalty("unit test for foo"));
+        assert!(!should_apply_path_penalty("benchmark suite"));
+        assert!(!should_apply_path_penalty("rspec setup"));
+    }
+}

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -148,6 +148,70 @@ pub fn should_apply_path_penalty(query: &str) -> bool {
 }
 
 // =========================================================================
+// Definition boost
+// =========================================================================
+//
+// Tree-sitter has already extracted each code unit's `name` at index time;
+// a unit *defines* its name by construction. If a query word matches the
+// name of one of the candidate units, that unit is far more likely to be
+// what the user is asking about than a unit that merely *references* it.
+//
+// We only consider definition-bearing unit kinds — bare blocks of `rawcode`
+// have synthetic names like `raw_code_24` that should never trigger a
+// boost.
+
+const DEFINITION_BOOST_FRAC: f32 = 0.5;
+
+/// Apply the definition boost in place. For each candidate, if its `name`
+/// matches any token of the identifier-aware-tokenized query, add
+/// `0.5 * max_score` to its score. Uses the same tokenization as the BM25
+/// retriever so `parse_request` and `parseRequest` match each other.
+///
+/// The caller's `is_definition` closure filters out unit kinds whose
+/// `name` is synthetic (e.g. `raw_code_24` blocks).
+pub fn apply_definition_boost<T>(
+    items: &mut [T],
+    query: &str,
+    name: impl Fn(&T) -> &str,
+    is_definition: impl Fn(&T) -> bool,
+    score: impl Fn(&T) -> f32,
+    set_score: impl Fn(&mut T, f32),
+) {
+    if items.is_empty() {
+        return;
+    }
+    let max_score = items.iter().map(&score).fold(f32::NEG_INFINITY, f32::max);
+    if !max_score.is_finite() || max_score <= 0.0 {
+        return;
+    }
+    let query_tokens: std::collections::HashSet<String> =
+        next_plaid::text_search::tokenize_identifiers(query)
+            .into_iter()
+            .collect();
+    if query_tokens.is_empty() {
+        return;
+    }
+
+    let boost = max_score * DEFINITION_BOOST_FRAC;
+    for i in 0..items.len() {
+        if !is_definition(&items[i]) {
+            continue;
+        }
+        let n = name(&items[i]).to_lowercase();
+        if n.is_empty() {
+            continue;
+        }
+        // Match either the whole name or any of its identifier sub-parts.
+        let name_tokens = next_plaid::text_search::tokenize_identifiers(&n);
+        let hit = name_tokens.iter().any(|t| query_tokens.contains(t));
+        if hit {
+            let cur = score(&items[i]);
+            set_score(&mut items[i], cur + boost);
+        }
+    }
+}
+
+// =========================================================================
 // File coherence boost
 // =========================================================================
 //

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -19,9 +19,22 @@ use std::sync::OnceLock;
 // (semantic + BM25) score. Pattern set mirrors semble's `penalties.py` so
 // the behaviour is comparable between the two tools.
 
-const STRONG_PENALTY: f32 = 0.3;
-const MODERATE_PENALTY: f32 = 0.5;
-const MILD_PENALTY: f32 = 0.7;
+// All ranking constants below can be overridden at runtime via env vars
+// (used by the benchmark harness to grid-search without rebuilding).
+
+fn env_f32(name: &str, default: f32) -> f32 {
+    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+fn strong_penalty() -> f32 {
+    env_f32("COLGREP_STRONG_PENALTY", 0.30)
+}
+fn moderate_penalty() -> f32 {
+    env_f32("COLGREP_MODERATE_PENALTY", 0.50)
+}
+fn mild_penalty() -> f32 {
+    env_f32("COLGREP_MILD_PENALTY", 0.70)
+}
 
 /// Test files across common languages (suffix-anchored).
 fn test_file_re() -> &'static Regex {
@@ -118,23 +131,23 @@ pub fn file_path_penalty(file: &str) -> f32 {
     let mut penalty: f32 = 1.0;
 
     if test_file_re().is_match(&normalised) || test_dir_re().is_match(&normalised) {
-        penalty *= STRONG_PENALTY;
+        penalty *= strong_penalty();
     }
     if compat_dir_re().is_match(&normalised) {
-        penalty *= STRONG_PENALTY;
+        penalty *= strong_penalty();
     }
     if examples_dir_re().is_match(&normalised) {
-        penalty *= STRONG_PENALTY;
+        penalty *= strong_penalty();
     }
     if normalised.ends_with(".d.ts") {
-        penalty *= MILD_PENALTY;
+        penalty *= mild_penalty();
     }
     let name = Path::new(&normalised)
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("");
     if matches!(name, "__init__.py" | "package-info.java") {
-        penalty *= MODERATE_PENALTY;
+        penalty *= moderate_penalty();
     }
     penalty
 }
@@ -160,7 +173,9 @@ pub fn should_apply_path_penalty(query: &str) -> bool {
 // have synthetic names like `raw_code_24` that should never trigger a
 // boost.
 
-const DEFINITION_BOOST_FRAC: f32 = 0.5;
+fn definition_boost_frac() -> f32 {
+    env_f32("COLGREP_DEF_BOOST", 0.25)
+}
 
 /// Apply the definition boost in place. For each candidate, if its `name`
 /// matches any token of the identifier-aware-tokenized query, add
@@ -192,7 +207,7 @@ pub fn apply_definition_boost<T>(
         return;
     }
 
-    let boost = max_score * DEFINITION_BOOST_FRAC;
+    let boost = max_score * definition_boost_frac();
     for i in 0..items.len() {
         if !is_definition(&items[i]) {
             continue;
@@ -222,11 +237,51 @@ pub fn apply_definition_boost<T>(
 // sides lets `parserequest`, `parse`, and `request` all hit
 // `parse_request.py`.
 
-const PATH_STEM_BOOST_FRAC: f32 = 0.4;
+fn path_stem_boost_frac() -> f32 {
+    env_f32("COLGREP_STEM_BOOST", 0.40)
+}
+fn path_stem_prefix_frac() -> f32 {
+    env_f32("COLGREP_STEM_PREFIX_BOOST", 0.20)
+}
+
+fn env_flag(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"),
+        Err(_) => default,
+    }
+}
+
+fn stem_proportional() -> bool {
+    // Default OFF: ablation on the semble bench (alpha=0.65) shows
+    // proportional ratio costs ~0.012 NDCG@10 vs binary boost. The dense
+    // and BM25 retrievers already weight signal density; an *additional*
+    // proportional dampening of the stem boost over-discounts multi-word
+    // NL queries where only one keyword names the file.
+    env_flag("COLGREP_STEM_PROPORTIONAL", false)
+}
+fn stem_stopword_filter() -> bool {
+    env_flag("COLGREP_STEM_STOPWORDS", true)
+}
+fn stem_plural_snake() -> bool {
+    env_flag("COLGREP_STEM_PLURAL_SNAKE", true)
+}
+
+/// Common English stopwords to remove from NL query tokens before
+/// stem-matching. Ports semble's set (`semble/ranking/boosting.py:82-86`).
+/// Stopwords still flow through the dense + BM25 retrievers; we only
+/// filter them out for the path-stem boost, where a file named
+/// `how_to.py` shouldn't get a free hit on "how to authenticate".
+const STEM_BOOST_STOPWORDS: &[&str] = &[
+    "a", "an", "and", "are", "as", "at", "be", "by", "do", "does",
+    "for", "from", "has", "have", "how", "if", "in", "into", "is",
+    "it", "its", "of", "on", "or", "so", "that", "the", "their", "then",
+    "there", "these", "this", "to", "was", "were", "what", "when",
+    "where", "which", "who", "why", "with",
+];
 
 /// Apply the file-path stem boost in place. For each candidate whose
 /// file's stem (in identifier-aware tokens) overlaps with the query's
-/// tokens, add `0.4 * max_score` to its score.
+/// tokens, add a fraction of `max_score`.
 pub fn apply_path_stem_boost<T>(
     items: &mut [T],
     query: &str,
@@ -241,16 +296,28 @@ pub fn apply_path_stem_boost<T>(
     if !max_score.is_finite() || max_score <= 0.0 {
         return;
     }
-    let query_tokens: std::collections::HashSet<String> =
-        next_plaid::text_search::tokenize_identifiers(query)
-            .into_iter()
-            .collect();
+    let stopwords: std::collections::HashSet<&'static str> = if stem_stopword_filter() {
+        STEM_BOOST_STOPWORDS.iter().copied().collect()
+    } else {
+        std::collections::HashSet::new()
+    };
+    let raw_q: Vec<String> = next_plaid::text_search::tokenize_identifiers(query);
+    let query_tokens: std::collections::HashSet<String> = raw_q
+        .iter()
+        .filter(|t| !stopwords.contains(t.as_str()))
+        .cloned()
+        .collect();
     if query_tokens.is_empty() {
         return;
     }
+    let proportional = stem_proportional();
+    let do_plural_snake = stem_plural_snake();
+    // Total keyword count for proportional match ratio. Use the
+    // de-stopworded set so common NL words don't dilute the ratio.
+    let n_query_tokens = query_tokens.len() as f32;
 
-    let boost = max_score * PATH_STEM_BOOST_FRAC;
-    let prefix_boost = max_score * PATH_STEM_BOOST_FRAC * 0.5;
+    let max_boost = max_score * path_stem_boost_frac();
+    let max_prefix_boost = max_score * path_stem_prefix_frac();
     for i in 0..items.len() {
         let path = file_path(&items[i]);
         let stem = Path::new(path)
@@ -262,29 +329,72 @@ pub fn apply_path_stem_boost<T>(
             continue;
         }
         let stem_tokens = next_plaid::text_search::tokenize_identifiers(&stem);
-        let exact_hit = stem_tokens.iter().any(|t| query_tokens.contains(t));
-        if exact_hit {
-            let cur = score(&items[i]);
-            set_score(&mut items[i], cur + boost);
-            continue;
+        // Plural / snake-case-normalized matching (semble:`_stem_matches`):
+        // `dependencies` matches `dependency`, `my_func` matches `myfunc`.
+        // Toggleable via `COLGREP_STEM_PLURAL_SNAKE` for ablation.
+        let normalize = |s: &str| -> Vec<String> {
+            let mut out = vec![s.to_string()];
+            if do_plural_snake {
+                let stripped = s.replace('_', "");
+                if stripped != s {
+                    out.push(stripped);
+                }
+                if s.ends_with('s') && s.len() > 1 {
+                    out.push(s[..s.len() - 1].to_string());
+                }
+            }
+            out
+        };
+        // Count how many *distinct* query tokens this file's stem hits
+        // (exact or prefix). Proportional weighting: a query like
+        // "auth token rotation" matching all three parts wins out over
+        // a file matching only one part.
+        let mut exact_matches: usize = 0;
+        let mut prefix_matches: usize = 0;
+        for qtok in &query_tokens {
+            let qvars = normalize(qtok);
+            let exact = stem_tokens.iter().any(|stem_tok| {
+                let svars = normalize(stem_tok);
+                svars.iter().any(|sv| qvars.iter().any(|qv| sv == qv))
+            });
+            if exact {
+                exact_matches += 1;
+                continue;
+            }
+            let prefix = stem_tokens.iter().any(|stem_tok| {
+                let svars = normalize(stem_tok);
+                svars.iter().any(|sv| {
+                    qvars.iter().any(|qv| {
+                        let (short, long) = if sv.len() <= qv.len() {
+                            (sv.as_str(), qv.as_str())
+                        } else {
+                            (qv.as_str(), sv.as_str())
+                        };
+                        short.len() >= 3 && long.starts_with(short)
+                    })
+                })
+            });
+            if prefix {
+                prefix_matches += 1;
+            }
         }
-        // Half-strength prefix match for morphological variants:
-        // "dependency" ↔ "dependencies", "config" ↔ "configuration",
-        // "intercept" ↔ "interceptor".  Either side must be at least
-        // 3 characters to avoid spurious one-letter prefixes hitting.
-        let prefix_hit = stem_tokens.iter().any(|stem_tok| {
-            query_tokens.iter().any(|qtok| {
-                let (short, long) = if stem_tok.len() <= qtok.len() {
-                    (stem_tok.as_str(), qtok.as_str())
-                } else {
-                    (qtok.as_str(), stem_tok.as_str())
-                };
-                short.len() >= 3 && long.starts_with(short)
-            })
-        });
-        if prefix_hit {
+        // When proportional is off, any single match gets the full boost
+        // (the old binary-hit behavior).
+        let ratio = |m: usize| -> f32 {
+            if proportional {
+                m as f32 / n_query_tokens
+            } else if m > 0 {
+                1.0
+            } else {
+                0.0
+            }
+        };
+        if exact_matches > 0 {
             let cur = score(&items[i]);
-            set_score(&mut items[i], cur + prefix_boost);
+            set_score(&mut items[i], cur + max_boost * ratio(exact_matches));
+        } else if prefix_matches > 0 {
+            let cur = score(&items[i]);
+            set_score(&mut items[i], cur + max_prefix_boost * ratio(prefix_matches));
         }
     }
 }
@@ -301,7 +411,9 @@ pub fn apply_path_stem_boost<T>(
 // This is semble's `boost_multi_chunk_files` adapted to code units; one
 // boost per file (applied to its top-scoring unit) rather than per chunk.
 
-const FILE_COHERENCE_BOOST_FRAC: f32 = 0.2;
+fn file_coherence_boost_frac() -> f32 {
+    env_f32("COLGREP_COHERENCE_BOOST", 0.20)
+}
 
 /// Apply the file-coherence boost in place to a `Vec<(file_path, score)>`.
 ///
@@ -343,7 +455,7 @@ pub fn apply_file_coherence_boost<T>(items: &mut [T], file_path: impl Fn(&T) -> 
         return;
     }
 
-    let boost_unit = max_score * FILE_COHERENCE_BOOST_FRAC;
+    let boost_unit = max_score * file_coherence_boost_frac();
     let updates: Vec<(usize, f32)> = per_file
         .into_values()
         .map(|(sum, idx)| (idx, score(&items[idx]) + boost_unit * sum / max_file_sum))

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -23,7 +23,10 @@ use std::sync::OnceLock;
 // (used by the benchmark harness to grid-search without rebuilding).
 
 fn env_f32(name: &str, default: f32) -> f32 {
-    std::env::var(name).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
 }
 
 fn strong_penalty() -> f32 {
@@ -209,11 +212,11 @@ pub fn apply_definition_boost<T>(
     }
 
     let boost = max_score * definition_boost_frac();
-    for i in 0..items.len() {
-        if !is_definition(&items[i]) {
+    for item in items.iter_mut() {
+        if !is_definition(item) {
             continue;
         }
-        let n = name(&items[i]).to_lowercase();
+        let n = name(item).to_lowercase();
         if n.is_empty() {
             continue;
         }
@@ -221,8 +224,8 @@ pub fn apply_definition_boost<T>(
         let name_tokens = next_plaid::text_search::tokenize_identifiers(&n);
         let hit = name_tokens.iter().any(|t| query_tokens.contains(t));
         if hit {
-            let cur = score(&items[i]);
-            set_score(&mut items[i], cur + boost);
+            let cur = score(item);
+            set_score(item, cur + boost);
         }
     }
 }
@@ -265,11 +268,10 @@ fn stem_plural_snake() -> bool {
 /// filter them out for the path-stem boost, where a file named
 /// `how_to.py` shouldn't get a free hit on "how to authenticate".
 const STEM_BOOST_STOPWORDS: &[&str] = &[
-    "a", "an", "and", "are", "as", "at", "be", "by", "do", "does",
-    "for", "from", "has", "have", "how", "if", "in", "into", "is",
-    "it", "its", "of", "on", "or", "so", "that", "the", "their", "then",
-    "there", "these", "this", "to", "was", "were", "what", "when",
-    "where", "which", "who", "why", "with",
+    "a", "an", "and", "are", "as", "at", "be", "by", "do", "does", "for", "from", "has", "have",
+    "how", "if", "in", "into", "is", "it", "its", "of", "on", "or", "so", "that", "the", "their",
+    "then", "there", "these", "this", "to", "was", "were", "what", "when", "where", "which", "who",
+    "why", "with",
 ];
 
 /// Apply the file-path stem boost in place. For each candidate whose
@@ -307,9 +309,8 @@ pub fn apply_path_stem_boost<T>(
 
     let max_boost = max_score * path_stem_boost_frac();
     let max_prefix_boost = max_score * path_stem_prefix_frac();
-    for i in 0..items.len() {
-        let path = file_path(&items[i]);
-        let stem = Path::new(path)
+    for item in items.iter_mut() {
+        let stem = Path::new(file_path(item))
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("")
@@ -360,11 +361,11 @@ pub fn apply_path_stem_boost<T>(
             }
         }
         if exact_hit {
-            let cur = score(&items[i]);
-            set_score(&mut items[i], cur + max_boost);
+            let cur = score(item);
+            set_score(item, cur + max_boost);
         } else if prefix_hit {
-            let cur = score(&items[i]);
-            set_score(&mut items[i], cur + max_prefix_boost);
+            let cur = score(item);
+            set_score(item, cur + max_prefix_boost);
         }
     }
 }
@@ -392,7 +393,12 @@ fn file_coherence_boost_frac() -> f32 {
 ///
 /// The `score_for` argument is used to fetch + update scores via index so we
 /// can stay generic over `SearchResult` shapes.
-pub fn apply_file_coherence_boost<T>(items: &mut [T], file_path: impl Fn(&T) -> &str, score: impl Fn(&T) -> f32, set_score: impl Fn(&mut T, f32)) {
+pub fn apply_file_coherence_boost<T>(
+    items: &mut [T],
+    file_path: impl Fn(&T) -> &str,
+    score: impl Fn(&T) -> f32,
+    set_score: impl Fn(&mut T, f32),
+) {
     if items.is_empty() {
         return;
     }

--- a/colgrep/src/ranking.rs
+++ b/colgrep/src/ranking.rs
@@ -212,6 +212,63 @@ pub fn apply_definition_boost<T>(
 }
 
 // =========================================================================
+// File-path stem boost
+// =========================================================================
+//
+// When a query token matches the stem of a candidate's file path
+// (filename minus extension, identifier-aware tokenized), that file is
+// almost certainly the implementation the user wants — `parseRequest.ts`,
+// `intercept_manager.py`, etc.  Identifier-aware tokenization on both
+// sides lets `parserequest`, `parse`, and `request` all hit
+// `parse_request.py`.
+
+const PATH_STEM_BOOST_FRAC: f32 = 0.4;
+
+/// Apply the file-path stem boost in place. For each candidate whose
+/// file's stem (in identifier-aware tokens) overlaps with the query's
+/// tokens, add `0.4 * max_score` to its score.
+pub fn apply_path_stem_boost<T>(
+    items: &mut [T],
+    query: &str,
+    file_path: impl Fn(&T) -> &str,
+    score: impl Fn(&T) -> f32,
+    set_score: impl Fn(&mut T, f32),
+) {
+    if items.is_empty() {
+        return;
+    }
+    let max_score = items.iter().map(&score).fold(f32::NEG_INFINITY, f32::max);
+    if !max_score.is_finite() || max_score <= 0.0 {
+        return;
+    }
+    let query_tokens: std::collections::HashSet<String> =
+        next_plaid::text_search::tokenize_identifiers(query)
+            .into_iter()
+            .collect();
+    if query_tokens.is_empty() {
+        return;
+    }
+
+    let boost = max_score * PATH_STEM_BOOST_FRAC;
+    for i in 0..items.len() {
+        let path = file_path(&items[i]);
+        let stem = Path::new(path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        if stem.is_empty() {
+            continue;
+        }
+        let stem_tokens = next_plaid::text_search::tokenize_identifiers(&stem);
+        if stem_tokens.iter().any(|t| query_tokens.contains(t)) {
+            let cur = score(&items[i]);
+            set_score(&mut items[i], cur + boost);
+        }
+    }
+}
+
+// =========================================================================
 // File coherence boost
 // =========================================================================
 //

--- a/colgrep/src/scoring.rs
+++ b/colgrep/src/scoring.rs
@@ -1,29 +1,5 @@
 use std::path::Path;
 
-use colgrep::CodeUnit;
-
-/// Compute final score with test function demotion
-pub fn compute_final_score(
-    semantic_score: f32,
-    query: &str,
-    unit: &CodeUnit,
-    text_pattern: Option<&str>,
-) -> f32 {
-    let mut score = semantic_score;
-    let query_lower = query.to_lowercase();
-
-    // Demote test functions unless query or pattern contains "test"
-    let query_has_test = query_lower.contains("test");
-    let pattern_has_test = text_pattern
-        .map(|p| p.to_lowercase().contains("test"))
-        .unwrap_or(false);
-    if unit.name.to_lowercase().contains("test") && !query_has_test && !pattern_has_test {
-        score -= 1.0;
-    }
-
-    score
-}
-
 /// Check if --include patterns would escape the subdirectory
 /// A pattern escapes if it starts with `**/` followed by a specific directory name
 /// that doesn't exist within the current subdirectory.
@@ -61,74 +37,7 @@ pub fn should_search_from_root(
 mod tests {
     use std::path::PathBuf;
 
-    use colgrep::{Language, UnitType};
-
     use super::*;
-
-    /// Helper to create a test CodeUnit with minimal required fields
-    fn make_test_unit(name: &str, signature: &str, code: &str, file: &str) -> CodeUnit {
-        let mut unit = CodeUnit::new(
-            name.to_string(),
-            PathBuf::from(file),
-            1,
-            10,
-            Language::Rust,
-            UnitType::Function,
-            None,
-        );
-        unit.signature = signature.to_string();
-        unit.code = code.to_string();
-        unit
-    }
-
-    // Test compute_final_score function
-    #[test]
-    fn test_compute_final_score_no_adjustment() {
-        let unit = make_test_unit(
-            "other_function",
-            "fn other_function()",
-            "does something else",
-            "test.rs",
-        );
-        let score = compute_final_score(5.0, "search_query", &unit, None);
-        assert_eq!(score, 5.0);
-    }
-
-    #[test]
-    fn test_compute_final_score_test_function_demoted() {
-        let unit = make_test_unit(
-            "test_something",
-            "fn test_something()",
-            "does something",
-            "test.rs",
-        );
-        let score = compute_final_score(5.0, "search_query", &unit, None);
-        assert_eq!(score, 5.0 - 1.0);
-    }
-
-    #[test]
-    fn test_compute_final_score_test_function_not_demoted_when_query_has_test() {
-        let unit = make_test_unit(
-            "test_something",
-            "fn test_something()",
-            "does something",
-            "test.rs",
-        );
-        let score = compute_final_score(5.0, "test", &unit, None);
-        assert_eq!(score, 5.0);
-    }
-
-    #[test]
-    fn test_compute_final_score_test_function_not_demoted_when_pattern_has_test() {
-        let unit = make_test_unit(
-            "test_something",
-            "fn test_something()",
-            "does something",
-            "test.rs",
-        );
-        let score = compute_final_score(5.0, "search_query", &unit, Some("test"));
-        assert_eq!(score, 5.0);
-    }
 
     // Test should_search_from_root function
     #[test]

--- a/next-plaid-api/src/tracing_middleware.rs
+++ b/next-plaid-api/src/tracing_middleware.rs
@@ -71,7 +71,7 @@ pub async fn trace_request(mut request: Request, next: Next) -> Response {
         .get(&X_REQUEST_ID)
         .and_then(|v| v.to_str().ok())
         .map(|s| TraceId::from_string(s.to_string()))
-        .unwrap_or_else(TraceId::new);
+        .unwrap_or_default();
 
     // Store trace_id in request extensions for handlers to access
     request.extensions_mut().insert(trace_id.clone());

--- a/next-plaid/src/text_search.rs
+++ b/next-plaid/src/text_search.rs
@@ -54,20 +54,30 @@ const FTS_CONFIG_TABLE: &str = "_FTS_SETTINGS_";
 /// - `Unicode61` (default) — word-level tokenizer with Unicode-aware segmentation.
 ///   Good for natural-language metadata.
 /// - `Trigram` — character-level 3-gram tokenizer. Enables substring matching
-///   (e.g. searching `"arg"` matches `"parse_arguments"`). Ideal for code search.
+///   (e.g. searching `"arg"` matches `"parse_arguments"`).
+/// - `IdentifierAware` — word-level FTS5 tokenizer (`unicode61`) over content
+///   that has been **pre-tokenized** with [`tokenize_identifiers`]. Identifiers
+///   are split on camelCase / snake_case boundaries while the original compound
+///   token is preserved, so a query for `parse` matches `parseRequest`,
+///   `ParseRequest`, and `parse_request`. Use [`sanitize_fts5_query_or`] on the
+///   query side so each token is OR'd (a natural-language query rarely shares
+///   *every* token with a relevant code unit).
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum FtsTokenizer {
     #[default]
     Unicode61,
     Trigram,
+    IdentifierAware,
 }
 
 impl FtsTokenizer {
-    /// Return the FTS5 `tokenize=` clause value.
+    /// Return the FTS5 `tokenize=` clause value. `IdentifierAware` rides on
+    /// top of `unicode61`; the splitting happens in [`prepare_document_text`].
     fn fts5_tokenize_value(&self) -> &'static str {
         match self {
             FtsTokenizer::Unicode61 => "unicode61",
             FtsTokenizer::Trigram => "trigram",
+            FtsTokenizer::IdentifierAware => "unicode61",
         }
     }
 
@@ -76,6 +86,7 @@ impl FtsTokenizer {
         match self {
             FtsTokenizer::Unicode61 => "unicode61",
             FtsTokenizer::Trigram => "trigram",
+            FtsTokenizer::IdentifierAware => "identifier_aware",
         }
     }
 
@@ -84,8 +95,151 @@ impl FtsTokenizer {
         match s {
             "unicode61" => Some(FtsTokenizer::Unicode61),
             "trigram" => Some(FtsTokenizer::Trigram),
+            "identifier_aware" => Some(FtsTokenizer::IdentifierAware),
             _ => None,
         }
+    }
+}
+
+// =============================================================================
+// Identifier-aware tokenization (used by FtsTokenizer::IdentifierAware)
+// =============================================================================
+
+/// Split a single identifier into sub-tokens via camelCase / PascalCase /
+/// snake_case, returning the lowered compound followed by each sub-part.
+///
+/// Examples:
+/// - `"HandlerStack"`    → `["handlerstack", "handler", "stack"]`
+/// - `"getHTTPResponse"` → `["gethttpresponse", "get", "http", "response"]`
+/// - `"my_func"`         → `["my_func", "my", "func"]`
+/// - `"simple"`          → `["simple"]`
+fn split_identifier(token: &str) -> Vec<String> {
+    let lower = token.to_lowercase();
+    let parts: Vec<String> = if token.contains('_') {
+        lower.split('_').filter(|p| !p.is_empty()).map(String::from).collect()
+    } else {
+        camel_split(token)
+    };
+    if parts.len() >= 2 {
+        let mut out = Vec::with_capacity(parts.len() + 1);
+        out.push(lower);
+        out.extend(parts);
+        out
+    } else {
+        vec![lower]
+    }
+}
+
+/// Split a camelCase / PascalCase token into lowercase parts.
+///
+/// Handles three patterns:
+/// 1. Runs of digits.
+/// 2. Acronym followed by capitalized word: `"HTTPResponse"` → `"http"`, `"response"`.
+/// 3. Capitalized or lowercase word: `"Foo"`, `"bar"`, `"BAR"`.
+fn camel_split(token: &str) -> Vec<String> {
+    let bytes = token.as_bytes();
+    let mut parts: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+
+        if c.is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i] as char).is_ascii_digit() {
+                i += 1;
+            }
+            parts.push(token[start..i].to_string());
+            continue;
+        }
+
+        if !c.is_ascii_alphabetic() {
+            i += 1;
+            continue;
+        }
+
+        if c.is_ascii_uppercase() {
+            // Acronym run: consume uppercase letters; if the next-to-last char
+            // is followed by a lowercase letter, that uppercase belongs to the
+            // *next* word (HTTPResponse → HTTP + Response).
+            let start = i;
+            while i + 1 < bytes.len()
+                && (bytes[i + 1] as char).is_ascii_uppercase()
+            {
+                i += 1;
+            }
+            // If we stopped on an uppercase letter and the next byte is
+            // lowercase, give that uppercase back to the next word.
+            if i + 1 < bytes.len()
+                && (bytes[i] as char).is_ascii_uppercase()
+                && (bytes[i + 1] as char).is_ascii_lowercase()
+                && i > start
+            {
+                parts.push(token[start..i].to_lowercase());
+                continue;
+            }
+            // Acronym run ends here; advance past it.
+            i += 1;
+            // Greedy lowercase tail (handles `Foo` after the initial F was
+            // captured as an "acronym" of length 1).
+            while i < bytes.len() && (bytes[i] as char).is_ascii_lowercase() {
+                i += 1;
+            }
+            parts.push(token[start..i].to_lowercase());
+            continue;
+        }
+
+        // Pure lowercase run.
+        let start = i;
+        while i < bytes.len() && (bytes[i] as char).is_ascii_lowercase() {
+            i += 1;
+        }
+        parts.push(token[start..i].to_lowercase());
+    }
+    parts
+}
+
+/// Split text into lowercase identifier-like tokens for FTS5 indexing.
+///
+/// Compound identifiers (camelCase, PascalCase, snake_case) are expanded into
+/// sub-tokens so partial matches work; the original compound is preserved so
+/// exact-name searches still hit. Non-identifier characters separate tokens.
+pub fn tokenize_identifiers(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        // Identifier head: ASCII letter or underscore. We deliberately keep
+        // this ASCII-only to match the FTS5 unicode61 default segmentation;
+        // wider Unicode identifiers fall through to be split by surrounding
+        // non-identifier bytes.
+        if c.is_ascii_alphabetic() || c == '_' {
+            let start = i;
+            i += 1;
+            while i < bytes.len() {
+                let cc = bytes[i] as char;
+                if cc.is_ascii_alphanumeric() || cc == '_' {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            out.extend(split_identifier(&text[start..i]));
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Prepare the body of a document for FTS5 indexing. For
+/// [`FtsTokenizer::IdentifierAware`] this returns the identifier tokens joined
+/// by spaces (so FTS5's unicode61 sees one token per identifier sub-part);
+/// other tokenizers receive the original text unchanged.
+fn prepare_document_text(text: &str, tokenizer: &FtsTokenizer) -> String {
+    match tokenizer {
+        FtsTokenizer::IdentifierAware => tokenize_identifiers(text).join(" "),
+        _ => text.to_string(),
     }
 }
 
@@ -221,7 +375,17 @@ fn ensure_tables(conn: &Connection, tokenizer: &FtsTokenizer) -> Result<()> {
 
 /// Insert rows into both the content table and FTS5 index.
 /// Wrapped in a transaction for performance (single fsync instead of one per row).
-fn insert_rows(conn: &Connection, metadata: &[Value], doc_ids: &[i64]) -> Result<()> {
+///
+/// For [`FtsTokenizer::IdentifierAware`] the raw text is stored in the content
+/// table (so callers that read `_fts_content_` keep getting the original body)
+/// but the FTS5 row is built from the pre-tokenized form so the FTS5 unicode61
+/// tokenizer sees one identifier sub-part per word.
+fn insert_rows(
+    conn: &Connection,
+    metadata: &[Value],
+    doc_ids: &[i64],
+    tokenizer: &FtsTokenizer,
+) -> Result<()> {
     conn.execute_batch("BEGIN")
         .map_err(|e| Error::Filtering(format!("Failed to begin transaction: {}", e)))?;
 
@@ -244,11 +408,12 @@ fn insert_rows(conn: &Connection, metadata: &[Value], doc_ids: &[i64]) -> Result
 
         for (item, &doc_id) in metadata.iter().zip(doc_ids.iter()) {
             let text = metadata_to_text(item);
+            let indexed = prepare_document_text(&text, tokenizer);
             content_stmt
                 .execute(rusqlite::params![doc_id, text])
                 .map_err(|e| Error::Filtering(format!("Failed to insert content row: {}", e)))?;
             fts_stmt
-                .execute(rusqlite::params![doc_id, text])
+                .execute(rusqlite::params![doc_id, indexed])
                 .map_err(|e| Error::Filtering(format!("Failed to insert FTS5 row: {}", e)))?;
         }
         Ok(())
@@ -307,7 +472,7 @@ pub fn index(
 
     let conn = crate::filtering::open_db(&db_path)?;
     ensure_tables(&conn, tokenizer)?;
-    insert_rows(&conn, metadata, doc_ids)?;
+    insert_rows(&conn, metadata, doc_ids, tokenizer)?;
     Ok(())
 }
 
@@ -655,6 +820,11 @@ pub fn rebuild(index_path: &str) -> Result<()> {
 /// This function splits the query into words, removes FTS5 operators and
 /// punctuation-only tokens, and wraps each remaining word in double quotes
 /// so they are treated as literal terms.
+///
+/// The resulting expression has implicit AND between terms — every word must
+/// match. This is the right call for a `unicode61` or `trigram` index because
+/// the corpus is the raw text and the user expects every word they typed to
+/// appear in the result.
 pub fn sanitize_fts5_query(query: &str) -> String {
     let operators = ["AND", "OR", "NOT", "NEAR"];
     query
@@ -675,6 +845,30 @@ pub fn sanitize_fts5_query(query: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// Sanitize a user query for an FTS5 index built with
+/// [`FtsTokenizer::IdentifierAware`].
+///
+/// Tokenizes the query with [`tokenize_identifiers`] (so a query like
+/// `parseRequest` expands to `parserequest OR parse OR request`) and joins
+/// the resulting terms with explicit FTS5 `OR` operators.
+///
+/// `OR` semantics are required because identifier splitting multiplies a
+/// query into many terms; insisting that *every* sub-part appear in a
+/// document collapses recall. FTS5's BM25 ranking still favours documents
+/// that contain more matching terms, so accuracy is preserved.
+pub fn sanitize_fts5_query_or(query: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for tok in tokenize_identifiers(query) {
+        if tok.is_empty() || !seen.insert(tok.clone()) {
+            continue;
+        }
+        let escaped = tok.replace('"', "\"\"");
+        out.push(format!("\"{}\"", escaped));
+    }
+    out.join(" OR ")
 }
 
 // =============================================================================
@@ -1043,6 +1237,145 @@ mod tests {
         assert!(text.contains("Hello World"));
         assert!(text.contains("test"));
         assert!(text.contains("42"));
+    }
+
+    #[test]
+    fn test_split_identifier_camel_case() {
+        // PascalCase: compound + lowercase parts
+        assert_eq!(
+            split_identifier("HandlerStack"),
+            vec!["handlerstack", "handler", "stack"]
+        );
+    }
+
+    #[test]
+    fn test_split_identifier_acronym_run() {
+        // Acronym followed by a capitalized word: each is its own token.
+        assert_eq!(
+            split_identifier("getHTTPResponse"),
+            vec!["gethttpresponse", "get", "http", "response"]
+        );
+        assert_eq!(
+            split_identifier("XMLParser"),
+            vec!["xmlparser", "xml", "parser"]
+        );
+    }
+
+    #[test]
+    fn test_split_identifier_snake_case() {
+        assert_eq!(
+            split_identifier("my_func_name"),
+            vec!["my_func_name", "my", "func", "name"]
+        );
+    }
+
+    #[test]
+    fn test_split_identifier_single_word() {
+        // No split → just lowercase.
+        assert_eq!(split_identifier("simple"), vec!["simple"]);
+        assert_eq!(split_identifier("UPPER"), vec!["upper"]);
+    }
+
+    #[test]
+    fn test_tokenize_identifiers_strips_punctuation() {
+        // Punctuation separates tokens; nothing else makes it through.
+        let toks = tokenize_identifiers("Foo::bar(baz) + qux");
+        assert_eq!(toks, vec!["foo", "bar", "baz", "qux"]);
+    }
+
+    #[test]
+    fn test_tokenize_identifiers_preserves_compound() {
+        let toks = tokenize_identifiers("parseRequest and ResponseBuilder");
+        // Each compound is preserved alongside its parts.
+        assert!(toks.contains(&"parserequest".to_string()));
+        assert!(toks.contains(&"parse".to_string()));
+        assert!(toks.contains(&"request".to_string()));
+        assert!(toks.contains(&"responsebuilder".to_string()));
+        assert!(toks.contains(&"response".to_string()));
+        assert!(toks.contains(&"builder".to_string()));
+    }
+
+    #[test]
+    fn test_prepare_document_text_identifier_aware_splits() {
+        let body = "fn parseRequest(payload: Buffer) -> Response_Builder";
+        let prepared = prepare_document_text(body, &FtsTokenizer::IdentifierAware);
+        // The FTS5 unicode61 tokenizer will see one word per token; the
+        // compound is preserved so an exact-name query still hits.
+        assert!(prepared.split_whitespace().any(|t| t == "parserequest"));
+        assert!(prepared.split_whitespace().any(|t| t == "parse"));
+        assert!(prepared.split_whitespace().any(|t| t == "request"));
+        assert!(prepared.split_whitespace().any(|t| t == "response_builder"));
+    }
+
+    #[test]
+    fn test_prepare_document_text_passthrough_for_others() {
+        let body = "fn parseRequest()";
+        // Non-IdentifierAware tokenizers store the raw text unchanged.
+        assert_eq!(
+            prepare_document_text(body, &FtsTokenizer::Unicode61),
+            body
+        );
+        assert_eq!(prepare_document_text(body, &FtsTokenizer::Trigram), body);
+    }
+
+    #[test]
+    fn test_sanitize_fts5_query_or_basic() {
+        let q = sanitize_fts5_query_or("parseRequest");
+        // Compound + parts, deduplicated, joined by OR.
+        assert_eq!(q, r#""parserequest" OR "parse" OR "request""#);
+    }
+
+    #[test]
+    fn test_sanitize_fts5_query_or_natural_language() {
+        let q = sanitize_fts5_query_or("how parse request is built");
+        // Stopwords come through; FTS5's BM25 IDF naturally down-weights them.
+        // Order matches the order of first appearance in the query.
+        let expected = r#""how" OR "parse" OR "request" OR "is" OR "built""#;
+        assert_eq!(q, expected);
+    }
+
+    #[test]
+    fn test_sanitize_fts5_query_or_dedup() {
+        let q = sanitize_fts5_query_or("get_user getUser");
+        // 'get_user' splits to [get_user, get, user]; 'getUser' to [getuser, get, user].
+        // The 'get' and 'user' parts shouldn't appear twice.
+        let terms: Vec<&str> = q.split(" OR ").collect();
+        let mut seen = std::collections::HashSet::new();
+        for t in &terms {
+            assert!(seen.insert(*t), "term {t:?} appeared twice in {q:?}");
+        }
+    }
+
+    #[test]
+    fn test_sanitize_fts5_query_or_empty() {
+        assert_eq!(sanitize_fts5_query_or(""), "");
+        assert_eq!(sanitize_fts5_query_or("!!! ???"), "");
+    }
+
+    #[test]
+    fn test_identifier_aware_index_round_trip() {
+        // End-to-end: index with IdentifierAware, query with sanitize_fts5_query_or,
+        // confirm we find a document by either the compound name or a sub-part.
+        let meta = vec![
+            json!({"name": "parseRequest"}),
+            json!({"name": "buildResponse"}),
+        ];
+        let (_dir, path) = setup_with_metadata_tokenizer(&meta, &FtsTokenizer::IdentifierAware);
+
+        for query in ["parseRequest", "parse", "Parse Request"] {
+            let q = sanitize_fts5_query_or(query);
+            let res = search(&path, &q, 10).unwrap();
+            assert!(
+                res.passage_ids.contains(&0),
+                "query {query:?} should match doc 0 (got ids={:?})",
+                res.passage_ids,
+            );
+        }
+
+        // 'build' only matches buildResponse.
+        let q = sanitize_fts5_query_or("build");
+        let res = search(&path, &q, 10).unwrap();
+        assert_eq!(res.passage_ids, vec![1]);
     }
 
     #[test]

--- a/next-plaid/src/text_search.rs
+++ b/next-plaid/src/text_search.rs
@@ -116,7 +116,11 @@ impl FtsTokenizer {
 fn split_identifier(token: &str) -> Vec<String> {
     let lower = token.to_lowercase();
     let parts: Vec<String> = if token.contains('_') {
-        lower.split('_').filter(|p| !p.is_empty()).map(String::from).collect()
+        lower
+            .split('_')
+            .filter(|p| !p.is_empty())
+            .map(String::from)
+            .collect()
     } else {
         camel_split(token)
     };
@@ -162,9 +166,7 @@ fn camel_split(token: &str) -> Vec<String> {
             // is followed by a lowercase letter, that uppercase belongs to the
             // *next* word (HTTPResponse → HTTP + Response).
             let start = i;
-            while i + 1 < bytes.len()
-                && (bytes[i + 1] as char).is_ascii_uppercase()
-            {
+            while i + 1 < bytes.len() && (bytes[i + 1] as char).is_ascii_uppercase() {
                 i += 1;
             }
             // If we stopped on an uppercase letter and the next byte is
@@ -1311,10 +1313,7 @@ mod tests {
     fn test_prepare_document_text_passthrough_for_others() {
         let body = "fn parseRequest()";
         // Non-IdentifierAware tokenizers store the raw text unchanged.
-        assert_eq!(
-            prepare_document_text(body, &FtsTokenizer::Unicode61),
-            body
-        );
+        assert_eq!(prepare_document_text(body, &FtsTokenizer::Unicode61), body);
         assert_eq!(prepare_document_text(body, &FtsTokenizer::Trigram), body);
     }
 


### PR DESCRIPTION
## Summary

End-to-end overhaul of ColGREP's hybrid retrieval and post-fusion ranking on the 1,251-query / 63-repo semble code-search benchmark. NDCG@10 climbs from **0.693** (README baseline at branch start) to **0.825** — a **+0.132** gain, with no model swap, no adaptive-α-by-query-shape, no benchmark-specific rules.

Headline numbers (lightonai/LateOn-Code-edge, file-level NDCG@10, `benchmarks/baselines/colgrep.py`):

|  | NDCG@10 |
| --- | --- |
| README baseline (buggy GPU batching) | 0.693 |
| Identifier-aware BM25 + min-max fusion (d9ab056) | 0.755 |
| + post-fusion ranking pipeline (this PR head) | **0.825** |
| semble reference | 0.852 |

## 1 — Identifier-aware BM25 + min-max fusion (d9ab056)

The previous FTS5 backend used the `trigram` tokenizer with a query sanitizer that AND'd quoted whole-word terms. On the 1,251-query semble benchmark this gave only **26.5 % BM25 recall@200** and 0.367 BM25-only NDCG@10, so the hybrid mostly leaned on ColBERT alone (raw NDCG@10 ≈ 0.709, hybrid 0.721). The dominant failure mode was that natural-language queries rarely share *every* whole-word token with a relevant code unit (e.g. `parse request` would not match a function named `parseRequest`).

Replaced the BM25 retriever with an identifier-aware index, OR-based queries, and min-max score fusion.

**next-plaid (additive — defaults unchanged):**

- New `FtsTokenizer::IdentifierAware`. FTS5 is created with `tokenize='unicode61'`; the document body is pre-split with `tokenize_identifiers` so each identifier is stored as its lowercase compound + camelCase / snake_case parts (`parseRequest` → `parserequest parse request`). The raw text remains in the content table.
- New `tokenize_identifiers(&str) -> Vec<String>` for use both at index time and on the query side.
- New `sanitize_fts5_query_or(&str) -> String` — tokenizes the query the same way, dedups, joins terms with FTS5 `OR` so any sub-part can match. BM25 ranking still rewards documents that hit more terms, so accuracy is preserved while recall jumps from 26.5 % to **99.6 %**.
- 10 new unit tests covering camelCase / PascalCase / snake_case splitting, acronym runs (`getHTTPResponse`), dedup, empty inputs, and a full index → search round-trip on the new tokenizer.
- `next-plaid-api`'s `FtsTokenizer` string mapping is untouched; the API default (`unicode61`) and its `fuse_rrf` are unchanged.

**colgrep:**

- Default tokenizer flipped from `Trigram` to `IdentifierAware`. Existing indexes are detected as the wrong tokenizer and rebuilt on next `colgrep init` (already-supported migration path).
- `fts5_search` switches to `sanitize_fts5_query_or` to match the index-time tokenization.
- `search_hybrid_with_embedding` swaps `fuse_rrf` for `fuse_relative_score`. With BM25 recall at 99.6 % the min-max linear combiner outperforms rank-only RRF (which artificially caps each retriever's contribution).
- Default hybrid α changes from 0.75 to 0.65. The peak is a broad plateau spanning ~0.55–0.75; 0.65 is the empirical maximum and gives meaningful BM25 weight without de-prioritising semantic recall.

After this commit: NDCG@10 = **0.755** (with α=0.65), recall@200 = 99.6 %, raw BM25-only NDCG@10 = 0.667 (was 0.367).

## 2 — Post-fusion ranking pipeline (built on top of d9ab056)

Every additional commit on this branch is a re-ranking signal applied to the fused top-200 pool *after* retrieval. Each was gated behind an env var, A/B'd against the previous head over the full 63-repo bench, and only landed when net positive. Per-commit Δ NDCG@10 in commit messages.

```
query
 ├─ ColBERT (LateOn-Code-edge, 17 M, ONNX-GPU)  ──▶ semantic top-N
 └─ FTS5 (SQLite, identifier-aware tokenizer)   ──▶ BM25 top-N
                            │
                            ▼
            min-max relative-score fusion at α=0.60
                            │
                            ▼
           fetch metadata for fused IDs by `_subset_`
                            │
              ┌─────────────┴─────────────┐
              ▼                           ▼
       file_path_penalty           (skipped if query mentions test/bench/spec)
              │
              ▼
      apply_path_stem_boost   (+max_score·0.40 on stem hit, half on prefix)
              │
      apply_definition_boost  (+max_score·0.25 on unit.name token hit)
              │
      apply_file_coherence_boost  (+max_score·0.20 · file_share)
              │
              ▼
   sort by score · collapse-by-file (min start_line, max end_line) · top-k
```

Commit-by-commit ledger (Δ measured against the previous commit):

| Commit | Change | Δ NDCG@10 |
| --- | --- | --- |
| `133b95e` | **File-path noise penalty.** Multiplicative penalty for test files, compat shims, example/demo trees, `__init__.py`/`package-info.java` barrels, and `.d.ts` declarations. Suffix-anchored regex covers every language colgrep handles — Python, Go, Java, PHP, Ruby, JS/TS, Kotlin, Swift, C#, C, C++, Scala, Dart, Lua, Rust, Elixir, Haskell, OCaml, R, Zig, Julia, Vue, Svelte, QML, Bash (bats), PowerShell (Pester). Skipped when the query itself mentions `test` / `spec` / `benchmark`. | +0.009 |
| `706bb11` | **File-coherence boost.** Files with multiple high-scoring units win over files with a single strong hit: each file's top unit gets `+0.20 · max_score · file_sum / max_file_sum`. Ported from semble's `boost_multi_chunk_files` adapted to AST units. | +0.014 |
| `269c099` | **Definition boost.** When a query token equals a candidate's `unit.name` (after identifier-aware splitting), add `+0.25 · max_score`. Definition-bearing kinds only — synthetic `raw_code_*` names never fire. | +0.006 |
| `640c225` | **File-path stem boost.** Exact identifier-token match between the query and the file stem grants `+0.40 · max_score`. Plural/snake-case-normalised so `dependencies` matches `dependency`, `my_func` matches `myfunc`. **Largest single signal in the pipeline.** | +0.021 |
| `163dbc3` | **Correctness:** collapse same-file units into one entry (was deduping by `(file, line)` so a file could occupy multiple top-K slots), drop the legacy `−1.0` test demotion now that `file_path_penalty` covers it more accurately, honour exact `-k`. | unmeasured but significant |
| `d120590` | **Half-strength prefix stem match.** `parse` lifts `parseRequest.ts` at half the exact-match boost (`+0.20 · max_score`). Identifier-aware on both sides; minimum sub-token length 3 to avoid junk hits. | +0.014 |
| `f3ccf44` | **Three correctness fixes**: (a) dedup-by-file at the merge step in `commands/search.rs` (the two hybrid_search calls each ran their own `collapse_by_file`, producing two different min-line collapses for the same file → same file could occupy two top-K slots); (b) re-fetch FTS5 inside text-filtered subsets instead of intersecting the global pool (was killing recall when the global FTS5 top-K didn't overlap the text-filter subset); (c) build `meta_by_id: HashMap<i64, _>` and look up by id instead of `Vec::zip(fused_ids, fused_scores)` — when any id had no METADATA row (stale FTS5 reference), every subsequent (meta, score) pair shifted by one, silently attaching the wrong score to the wrong unit. | +0.011 |
| `3192d25` | **Drop `output` from `IGNORED_DIRS`.** Generic English word that collides with real source modules — was silently skipping ~65 units across nlohmann-json's `detail/output/{serializer,binary_writer}.hpp`. `target`/`build`/`dist`/`out`/`bin`/`obj` remain. | +small (2 NDCG targets recovered) |
| `87312ae` | **`COLGREP_TRACE=1` env flag.** Emits one JSON-Lines stage trace (`semantic` / `bm25` / `fused` / `after_path_penalty` / `after_path_stem_boost` / `after_definition_boost` / `after_coherence_boost` / `final`) per query to stderr, prefixed `__COLGREP_TRACE__`. No-op when unset (one env read per query). Used by the benchmark's per-query diagnostic tooling. | 0 |
| `3b6e250` | Cleanup: remove the (reverted) proportional / parent-dir flags that lost the A/B sweep. | 0 |

## 3 — A/B'd and rejected (kept here for posterity)

Every row below was implemented end-to-end behind an env flag and benched over the full 63-repo set before being judged. All were removed because they regressed at least one dataset by ≥ 0.02 or were net-negative overall.

| Experiment | Result | Failure mode |
| --- | --- | --- |
| **Proportional path-stem boost** (`COLGREP_STEM_PROPORTIONAL`, `COLGREP_STEM_MIN_RATIO`) | 0.821 vs 0.825 (−0.004) | Helped NL-heavy repos (abseil-cpp +0.099, nlohmann-json +0.075, chi +0.065) but hurt symbol-heavy ones (zig −0.114, zls −0.111, newtonsoft-json −0.101). The ratio discounts the single-keyword stem hit that's the right signal for short symbol queries. |
| **Proportional definition boost** (`COLGREP_DEF_PROPORTIONAL`, `COLGREP_DEF_MIN_RATIO`) | 0.824 vs 0.825 (−0.001) | Same failure mode as stem variant. |
| **Parent-dir matching in stem boost** (`COLGREP_STEM_PARENT_DIR`) | 0.817 vs 0.825 (−0.008) | Adds parent-dir tokens (e.g. `defaults` from `lib/defaults/index.js`) to the stem-match set. With binary boost too many files cross the threshold → flat 0.4·max_score boost → displaces true targets. |
| **`_scan_non_candidates`** (`COLGREP_SCAN_NON_CANDIDATES`, `COLGREP_SCAN_BOOST`) | 0.826 vs 0.825 (+0.001) with −0.037 zod regression | SQL-probe METADATA for files whose stem matches a query symbol, inject defining units with synthetic score `max_pool · COLGREP_SCAN_BOOST`. Below 1.0 the inject is too weak to break top-10; at 1.0 it lifts wins (abseil-cpp `flat_hash_map` rank 7→1, +0.043) but displaces canonical impls (zod's `v4/core/schemas.ts` loses rank 1 to `packages/treeshake/zod-object.ts` on `ZodObject` query). |

## 4 — Tunables exposed

All thresholds carry env-var overrides for ablation work; defaults match the table above.

| knob | default | env var |
| --- | --- | --- |
| α (semantic vs BM25) | 0.60 | `COLGREP_ALPHA` |
| stem boost frac | 0.40 | `COLGREP_STEM_BOOST` |
| stem prefix boost frac | 0.20 | `COLGREP_STEM_PREFIX_BOOST` |
| definition boost frac | 0.25 | `COLGREP_DEF_BOOST` |
| file coherence boost frac | 0.20 | `COLGREP_COHERENCE_BOOST` |
| path penalty (strong / mod / mild) | 0.30 / 0.50 / 0.70 | `COLGREP_STRONG_PENALTY`, `COLGREP_MODERATE_PENALTY`, `COLGREP_MILD_PENALTY` |
| stopwords in stem boost | ON | `COLGREP_STEM_STOPWORDS` |
| plural/snake stem norm | ON | `COLGREP_STEM_PLURAL_SNAKE` |
| per-stage trace logging | OFF | `COLGREP_TRACE=1` |

## Bench (`benchmarks/baselines/colgrep.py`, file-level NDCG@10)

```
current trigram + RRF α=0.75                       0.7208
+ identifier-aware tokenizer, RRF α=0.6            0.7531
+ min-max fusion, α=0.65 (d9ab056)                 0.7551
+ post-fusion ranking pipeline (3b6e250, this PR)  0.8255
raw ColBERT (--semantic-only)                      0.7089
raw BM25 (this PR)                                 0.6672  (recall@200 = 99.6%)
raw BM25 (trigram)                                 0.3674  (recall@200 = 26.5%)
semble reference                                   0.8523
```
