### PR TITLE
Add CSS language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-css",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-haskell",
@@ -4637,6 +4638,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -47,6 +47,7 @@ tree-sitter-julia = "0.23"
 tree-sitter-sequel = "0.3"
 tree-sitter-html = "0.23"
 tree-sitter-qmljs = "0.3"
+tree-sitter-css = "0.23"
 
 # === Model download ===
 hf-hub = "0.4"

--- a/colgrep/src/parser/ast.rs
+++ b/colgrep/src/parser/ast.rs
@@ -109,6 +109,15 @@ pub fn is_class_node(kind: &str, lang: Language) -> bool {
             kind,
             "struct_specifier" | "union_specifier" | "enum_specifier"
         ),
+        // CSS top-level rules. Each rule_set / media-query / keyframes
+        // animation / supports query is treated as one searchable unit; the
+        // declarations inside it are kept together (we don't recurse into
+        // the `block`) so a query like "button hover" surfaces the whole
+        // rule, not an isolated property:value line.
+        Language::Css => matches!(
+            kind,
+            "rule_set" | "media_statement" | "keyframes_statement" | "supports_statement"
+        ),
         // Text/config formats
         _ => false,
     }
@@ -141,6 +150,12 @@ pub fn is_constant_node(kind: &str, lang: Language) -> bool {
         Language::Zig => kind == "VarDecl", // const/var declarations
         Language::Julia => kind == "const_statement",
         Language::Sql => false, // SQL doesn't have constants in this sense
+        // CSS single-line at-rules: @import / @charset / @namespace. They
+        // don't open a block but their text is searchable on its own.
+        Language::Css => matches!(
+            kind,
+            "import_statement" | "charset_statement" | "namespace_statement"
+        ),
         // Java, CSharp, Ruby, Lua don't have clear top-level constants
         _ => false,
     }
@@ -184,6 +199,16 @@ pub fn find_class_body(node: Node, lang: Language) -> Option<Node> {
                 }
             }
             None
+        }
+        Language::Css => {
+            // CSS rules don't expose `body` as a field; find the curly-
+            // brace block (or the keyframe list for @keyframes) by kind.
+            let want = if node.kind() == "keyframes_statement" {
+                "keyframe_block_list"
+            } else {
+                "block"
+            };
+            node.children(&mut node.walk()).find(|c| c.kind() == want)
         }
         // Lua and text/config formats
         _ => None,
@@ -244,6 +269,9 @@ pub fn get_node_name(node: Node, bytes: &[u8], lang: Language) -> Option<String>
         Language::Ocaml => node
             .child_by_field_name("name")
             .or_else(|| node.child_by_field_name("pattern")),
+        Language::Css => {
+            return get_css_unit_name(node, bytes);
+        }
         // Text/config formats
         _ => None,
     };
@@ -256,6 +284,79 @@ pub fn get_node_name(node: Node, bytes: &[u8], lang: Language) -> Option<String>
             Some(text.to_string())
         }
     })
+}
+
+/// CSS doesn't carry named `name` fields on its rule / at-rule nodes —
+/// the "name" we want to display + index is the selector list (for
+/// `rule_set`), the keyframe name (for `@keyframes`), the at-keyword
+/// itself (for `@import`/`@charset`/`@namespace`), or `@<keyword>` plus
+/// the query text (for `@media`/`@supports`). Build it ad-hoc by
+/// scanning children.
+fn get_css_unit_name(node: Node, bytes: &[u8]) -> Option<String> {
+    let kind = node.kind();
+    let text_of = |n: Node| -> Option<String> {
+        let t = n.utf8_text(bytes).ok()?;
+        let trimmed = t.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            // CSS selectors / media queries can span multiple lines —
+            // collapse runs of whitespace so the unit name stays on a
+            // single line for display + boost matching.
+            Some(trimmed.split_whitespace().collect::<Vec<_>>().join(" "))
+        }
+    };
+
+    match kind {
+        // `rule_set` → "<selectors>"
+        "rule_set" => node
+            .children(&mut node.walk())
+            .find(|c| c.kind() == "selectors")
+            .and_then(text_of),
+        // `@keyframes <name>`
+        "keyframes_statement" => node
+            .children(&mut node.walk())
+            .find(|c| c.kind() == "keyframes_name")
+            .and_then(text_of)
+            .map(|n| format!("@keyframes {}", n)),
+        // `@media`, `@supports`: keep the query expression as the name.
+        // tree-sitter-css makes the `@media` / `@supports` literal a
+        // named `at_keyword` child as well as separate query nodes, so
+        // we whitelist just the query-bearing kinds here to avoid
+        // double-printing the at-keyword.
+        "media_statement" | "supports_statement" => {
+            let kw = if kind == "media_statement" {
+                "@media"
+            } else {
+                "@supports"
+            };
+            let query: Vec<String> = node
+                .children(&mut node.walk())
+                .filter(|c| {
+                    matches!(
+                        c.kind(),
+                        "binary_query"
+                            | "feature_query"
+                            | "keyword_query"
+                            | "parenthesized_query"
+                            | "selector_query"
+                            | "unary_query"
+                    )
+                })
+                .filter_map(text_of)
+                .collect();
+            if query.is_empty() {
+                Some(kw.to_string())
+            } else {
+                Some(format!("{} {}", kw, query.join(" ")))
+            }
+        }
+        // `@import url(...)` / `@charset "..."` / `@namespace prefix url(...)`
+        "import_statement" => Some("@import".to_string()),
+        "charset_statement" => Some("@charset".to_string()),
+        "namespace_statement" => Some("@namespace".to_string()),
+        _ => None,
+    }
 }
 
 /// Find the start line including preceding attributes/decorators/doc comments.

--- a/colgrep/src/parser/extract.rs
+++ b/colgrep/src/parser/extract.rs
@@ -476,6 +476,10 @@ fn get_constant_name(node: Node, bytes: &[u8], lang: Language) -> Option<String>
             .or_else(|| node.child_by_field_name("pattern"))
             .and_then(|n| n.utf8_text(bytes).ok())
             .map(|s| s.to_string()),
+        // CSS at-rules ( @import / @charset / @namespace ): the unit name
+        // is the at-keyword, produced by the same helper that names
+        // rule_set / @media / @keyframes elsewhere in the parser.
+        Language::Css => super::ast::get_node_name(node, bytes, lang),
         _ => None,
     }
 }

--- a/colgrep/src/parser/language.rs
+++ b/colgrep/src/parser/language.rs
@@ -44,6 +44,7 @@ pub fn detect_language(path: &Path) -> Option<Language> {
         "sql" => Some(Language::Sql),
         "vue" => Some(Language::Vue),
         "svelte" => Some(Language::Svelte),
+        "css" => Some(Language::Css),
         // Text/documentation formats
         "qml" => Some(Language::Qml),
         "html" | "htm" => Some(Language::Html),
@@ -112,6 +113,8 @@ pub fn get_tree_sitter_language(lang: Language) -> TsLanguage {
         Language::Qml => tree_sitter_qmljs::LANGUAGE.into(),
         // HTML uses tree-sitter-html
         Language::Html => tree_sitter_html::LANGUAGE.into(),
+        // CSS uses tree-sitter-css
+        Language::Css => tree_sitter_css::LANGUAGE.into(),
         // Text/config formats don't use tree-sitter - this should never be called
         Language::Markdown
         | Language::Text
@@ -321,6 +324,18 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_language_css() {
+        assert_eq!(
+            detect_language(Path::new("styles.css")),
+            Some(Language::Css)
+        );
+        assert_eq!(
+            detect_language(Path::new("src/components/button.css")),
+            Some(Language::Css)
+        );
+    }
+
+    #[test]
     fn test_detect_language_unknown() {
         assert_eq!(detect_language(Path::new("file.xyz")), None);
         assert_eq!(detect_language(Path::new("noextension")), None);
@@ -355,5 +370,6 @@ mod tests {
         assert!(!is_text_format(Language::Vue));
         assert!(!is_text_format(Language::Svelte));
         assert!(!is_text_format(Language::Html));
+        assert!(!is_text_format(Language::Css));
     }
 }

--- a/colgrep/src/parser/tests/mod.rs
+++ b/colgrep/src/parser/tests/mod.rs
@@ -6,6 +6,7 @@ mod common;
 mod test_c;
 mod test_cpp;
 mod test_csharp;
+mod test_css;
 mod test_elixir;
 mod test_go;
 mod test_haskell;

--- a/colgrep/src/parser/tests/test_css.rs
+++ b/colgrep/src/parser/tests/test_css.rs
@@ -1,0 +1,185 @@
+//! Tests for CSS code extraction.
+
+use super::common::*;
+use crate::parser::Language;
+
+#[test]
+fn test_simple_rule_set() {
+    let source = r#".btn {
+    color: white;
+    background: blue;
+    padding: 8px 16px;
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let unit = get_unit_by_name(&units, ".btn").expect("rule_set named .btn");
+    assert_eq!(unit.language, Language::Css);
+    assert!(
+        unit.code.contains("color: white"),
+        "code should include the declaration body: {:?}",
+        unit.code
+    );
+}
+
+#[test]
+fn test_complex_selector_preserved() {
+    let source = r#"div.card > .header:hover[data-active="true"] {
+    border: 1px solid red;
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    // Selector should be captured as the unit name in full, whitespace-
+    // normalised. We don't pin the exact spacing inside `:hover[...]`
+    // because tree-sitter reproduces it verbatim — assert the salient
+    // identifiers are all there.
+    let unit = units
+        .iter()
+        .find(|u| u.name.contains("card") && u.name.contains("header"))
+        .expect("complex selector preserved as unit name");
+    assert!(unit.name.contains("hover"), "name = {:?}", unit.name);
+    assert!(unit.name.contains("data-active"), "name = {:?}", unit.name);
+}
+
+#[test]
+fn test_media_statement() {
+    let source = r#"@media (max-width: 768px) {
+    .nav {
+        display: none;
+    }
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let media = units
+        .iter()
+        .find(|u| u.name.starts_with("@media"))
+        .expect("@media unit");
+    assert!(
+        media.name.contains("max-width") && media.name.contains("768px"),
+        "@media name should carry the query: {:?}",
+        media.name
+    );
+    // Regression: tree-sitter-css makes `@media` a named `at_keyword`
+    // child as well as a separate query node, so an early version of
+    // get_css_unit_name emitted "@media @media (max-width: 768px)".
+    assert!(
+        !media.name.starts_with("@media @media"),
+        "at-keyword should not be double-printed: {:?}",
+        media.name
+    );
+    // The inner rule_set is folded into the @media unit because we don't
+    // recurse into class bodies.
+    assert!(
+        media.code.contains(".nav") && media.code.contains("display: none"),
+        "media code should include nested rule: {:?}",
+        media.code
+    );
+}
+
+#[test]
+fn test_keyframes() {
+    let source = r#"@keyframes spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let kf = get_unit_by_name(&units, "@keyframes spin").expect("keyframes unit");
+    assert!(kf.code.contains("rotate(360deg)"), "code={:?}", kf.code);
+}
+
+#[test]
+fn test_supports_statement() {
+    let source = r#"@supports (display: grid) {
+    .grid { display: grid; }
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let s = units
+        .iter()
+        .find(|u| u.name.starts_with("@supports"))
+        .expect("@supports unit");
+    assert!(
+        s.name.contains("display") && s.name.contains("grid"),
+        "name={:?}",
+        s.name
+    );
+}
+
+#[test]
+fn test_at_import_and_charset_become_constants() {
+    let source = r#"@charset "UTF-8";
+@import url("base.css");
+@namespace svg url("http://www.w3.org/2000/svg");
+
+body {
+    margin: 0;
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    assert!(
+        units.iter().any(|u| u.name == "@charset"),
+        "expected @charset constant unit, got {:?}",
+        units.iter().map(|u| u.name.as_str()).collect::<Vec<_>>()
+    );
+    assert!(
+        units.iter().any(|u| u.name == "@import"),
+        "expected @import constant unit"
+    );
+    assert!(
+        units.iter().any(|u| u.name == "@namespace"),
+        "expected @namespace constant unit"
+    );
+    assert!(
+        units.iter().any(|u| u.name == "body"),
+        "expected body rule_set"
+    );
+}
+
+#[test]
+fn test_multiple_rule_sets() {
+    let source = r#"
+.a { color: red; }
+.b { color: green; }
+.c { color: blue; }
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let names: Vec<&str> = units.iter().map(|u| u.name.as_str()).collect();
+    for sel in [".a", ".b", ".c"] {
+        assert!(names.contains(&sel), "expected {} in {:?}", sel, names);
+    }
+}
+
+#[test]
+fn test_css_variables() {
+    // CSS custom properties live inside :root — the rule_set's selectors
+    // text is `:root`, the declarations stay in its body.
+    let source = r#":root {
+    --brand-color: #1e90ff;
+    --spacing-unit: 8px;
+}
+
+button {
+    background: var(--brand-color);
+    padding: var(--spacing-unit);
+}
+"#;
+    let units = parse(source, Language::Css, "test.css");
+    let root = get_unit_by_name(&units, ":root").expect(":root rule");
+    assert!(root.code.contains("--brand-color"), "{}", root.code);
+    let btn = get_unit_by_name(&units, "button").expect("button rule");
+    assert!(btn.code.contains("var(--brand-color)"), "{}", btn.code);
+}
+
+#[test]
+fn test_empty_file_doesnt_panic() {
+    let units = parse("", Language::Css, "empty.css");
+    assert!(units.is_empty());
+}
+
+#[test]
+fn test_invalid_css_doesnt_panic() {
+    // tree-sitter-css is lenient; even garbage parses without producing
+    // panics. The extracted unit set may be empty or partial, but the
+    // call must return.
+    let _ = parse("this is not css {{{ %%%", Language::Css, "broken.css");
+}

--- a/colgrep/src/parser/types.rs
+++ b/colgrep/src/parser/types.rs
@@ -32,6 +32,7 @@ pub enum Language {
     Vue,
     Svelte,
     Qml,
+    Css,
     // Text/config formats (no tree-sitter, indexed as documents)
     Html,
     Markdown,
@@ -78,6 +79,7 @@ impl FromStr for Language {
             "sql" => Ok(Language::Sql),
             "vue" => Ok(Language::Vue),
             "svelte" => Ok(Language::Svelte),
+            "css" => Ok(Language::Css),
             // Text/config formats
             "qml" => Ok(Language::Qml),
             "html" | "htm" => Ok(Language::Html),


### PR DESCRIPTION
## Summary

CSS files (`.css`) are now indexed and searched like any other code language colgrep handles. Each top-level rule_set, `@media`, `@keyframes`, and `@supports` block becomes one Class-kind code unit whose `name` is the selector list (e.g. `.btn-primary:hover`, `:root`, `@media (max-width: 768px)`, `@keyframes spin`). Single-line at-rules (`@import`, `@charset`, `@namespace`) become Constant-kind units. Whatever the AST doesn't cover (file-level comments, blank lines) is swept up by the existing `fill_raw_code_gaps` for 100 % file coverage.

## Implementation

- `tree-sitter-css = "0.23"` dependency.
- `Language::Css` variant + `FromStr` mapping + `.css` extension in `detect_language`.
- `get_tree_sitter_language` wires the new parser.
- `is_class_node` / `is_constant_node` / `find_class_body` arms for CSS. The CSS grammar exposes children positionally (no `name` field), so `get_node_name` delegates to a new `get_css_unit_name` helper that walks the children to pick the selector list (`rule_set`), the keyframe name (`keyframes_statement`), the query expression (`media_statement` / `supports_statement`), or the at-keyword (`import_statement` / `charset_statement` / `namespace_statement`).
- `extract_constant` routes through `get_node_name` for CSS so the single-line at-rules get picked up.

## Tests

- **10 unit tests** in `colgrep/src/parser/tests/test_css.rs` cover:
  - simple selectors (`.btn { … }`)
  - complex selectors with combinators + attribute matchers (`div.card > .header:hover[data-active="true"]`)
  - `@media (max-width: 768px) { … }` (also a regression check that `@media` isn't double-printed in the unit name)
  - `@keyframes spin { from … to … }`
  - `@supports (display: grid) { … }`
  - `@charset`, `@import`, `@namespace` as Constant units
  - `:root` CSS custom properties + `var(--foo)` references
  - multiple rule sets in one file
  - empty file (no panic, empty result)
  - malformed CSS (no panic, partial result)
- `parser::language::tests` add a `.css` detection test + `Language::Css` to the `is_text_format` negative assertions.

## End-to-end smoke (manual)

Indexed a sandbox at `/tmp/colgrep-css-sandbox` with three `.css` files (button.css, layout.css, import.css). `colgrep init` indexed 13 units. Search queries returned the expected unit at rank 1:

| query | top-1 |
| --- | --- |
| `primary button hover state` | `.btn-primary:hover` |
| `fade in animation` | `.fade-in` |
| `:root CSS custom properties variables` | `:root` |
| `@import` | `@import` |

## CI

- Full colgrep test suite: **529 lib + 52 binary tests pass.**
- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets -- -D warnings` clean (workspace and colgrep crate).
- `cargo doc -D warnings` clean.
