### PR TITLE
Fix #95: allow colgrep index writes in Codex workspace-write sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 1.0.69",
+ "toml_edit",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -68,6 +68,7 @@ syntect = "5"
 # === Serialization ===
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml_edit = "0.22"
 
 # === Error handling ===
 anyhow = "1"

--- a/colgrep/src/install/codex.rs
+++ b/colgrep/src/install/codex.rs
@@ -1,13 +1,19 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
 
 use super::SKILL_MD;
+use crate::index::paths::get_colgrep_data_dir;
 
 /// Marker to identify colgrep section in AGENTS.md
 const COLGREP_MARKER_START: &str = "<!-- COLGREP_START -->";
 const COLGREP_MARKER_END: &str = "<!-- COLGREP_END -->";
+
+/// Codex's sandbox-config TOML table that owns `writable_roots`.
+const SANDBOX_TABLE: &str = "sandbox_workspace_write";
+const SANDBOX_ROOTS_KEY: &str = "writable_roots";
 
 /// Get the Codex directory
 fn get_codex_dir() -> Result<PathBuf> {
@@ -19,6 +25,125 @@ fn get_codex_dir() -> Result<PathBuf> {
 fn get_agents_md_path() -> Result<PathBuf> {
     let codex_dir = get_codex_dir()?;
     Ok(codex_dir.join("AGENTS.md"))
+}
+
+/// Get the path to Codex's user-level `config.toml`.
+fn get_codex_config_path() -> Result<PathBuf> {
+    let codex_dir = get_codex_dir()?;
+    Ok(codex_dir.join("config.toml"))
+}
+
+/// Add `path` to Codex's `[sandbox_workspace_write].writable_roots` list so
+/// the workspace-write sandbox stops blocking writes there. Codex's
+/// default `workspace-write` profile only allows writes inside the open
+/// project, but colgrep stores its per-project indexes under
+/// `$XDG_DATA_HOME/colgrep/indices` (or platform equivalent), which is
+/// outside any workspace. Without this entry colgrep silently falls back
+/// to a degraded read-only shell-grep mode whenever Codex runs it (see
+/// issue #95).
+///
+/// The function is idempotent — re-running `colgrep --install-codex`
+/// is a no-op if the path is already listed. Returns `Ok(true)` if the
+/// config file was modified, `Ok(false)` if nothing needed changing.
+/// On any parse failure we leave the file alone and surface the error so
+/// the user can inspect their own config (rather than silently
+/// over-writing handcrafted settings).
+fn add_sandbox_writable_root(path: &Path) -> Result<bool> {
+    let config_path = get_codex_config_path()?;
+    let codex_dir = get_codex_dir()?;
+    fs::create_dir_all(&codex_dir)
+        .with_context(|| format!("Failed to create {}", codex_dir.display()))?;
+
+    let raw = if config_path.exists() {
+        fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?
+    } else {
+        String::new()
+    };
+
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("{} is not valid TOML", config_path.display()))?;
+
+    // Ensure `[sandbox_workspace_write]` exists.
+    if !doc.contains_key(SANDBOX_TABLE) {
+        let mut tbl = Table::new();
+        tbl.set_implicit(false);
+        doc.insert(SANDBOX_TABLE, Item::Table(tbl));
+    }
+    let table = doc[SANDBOX_TABLE]
+        .as_table_mut()
+        .context("[sandbox_workspace_write] is not a TOML table")?;
+
+    // Ensure `writable_roots = [...]` exists.
+    if !table.contains_key(SANDBOX_ROOTS_KEY) {
+        table.insert(SANDBOX_ROOTS_KEY, value(Array::new()));
+    }
+    let arr = table[SANDBOX_ROOTS_KEY]
+        .as_array_mut()
+        .context("writable_roots is not a TOML array")?;
+
+    // Idempotency: bail out if `path` (string-equal) is already present.
+    let path_str = path.to_string_lossy().to_string();
+    let already_present = arr.iter().any(|v| v.as_str() == Some(path_str.as_str()));
+    if already_present {
+        return Ok(false);
+    }
+    arr.push(path_str);
+
+    fs::write(&config_path, doc.to_string())
+        .with_context(|| format!("Failed to write {}", config_path.display()))?;
+    Ok(true)
+}
+
+/// Remove a previously-installed colgrep entry from
+/// `[sandbox_workspace_write].writable_roots`. Counterpart to
+/// `add_sandbox_writable_root`; safe to call when the entry is absent.
+fn remove_sandbox_writable_root(path: &Path) -> Result<bool> {
+    let config_path = get_codex_config_path()?;
+    if !config_path.exists() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(&config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("{} is not valid TOML", config_path.display()))?;
+
+    let Some(table) = doc.get_mut(SANDBOX_TABLE).and_then(|i| i.as_table_mut()) else {
+        return Ok(false);
+    };
+    let Some(arr) = table
+        .get_mut(SANDBOX_ROOTS_KEY)
+        .and_then(|i| i.as_array_mut())
+    else {
+        return Ok(false);
+    };
+    let path_str = path.to_string_lossy().to_string();
+    let before = arr.len();
+    arr.retain(|v| v.as_str() != Some(path_str.as_str()));
+    if arr.len() == before {
+        return Ok(false);
+    }
+    // Drop the empty array + empty table so we leave the user's config
+    // looking the way `--install-codex` had never touched it.
+    if arr.is_empty() {
+        table.remove(SANDBOX_ROOTS_KEY);
+    }
+    if table.is_empty() {
+        doc.remove(SANDBOX_TABLE);
+    }
+
+    // If the document is now empty, delete the file entirely so a fresh
+    // install starts from scratch.
+    if doc.as_table().is_empty() {
+        fs::remove_file(&config_path)
+            .with_context(|| format!("Failed to remove {}", config_path.display()))?;
+    } else {
+        fs::write(&config_path, doc.to_string())
+            .with_context(|| format!("Failed to write {}", config_path.display()))?;
+    }
+    Ok(true)
 }
 
 /// Add colgrep skill definition to AGENTS.md
@@ -101,6 +226,43 @@ pub fn install_codex() -> Result<()> {
         agents_path.display()
     );
 
+    // Register colgrep's data dir as a sandbox writable root so the
+    // `workspace-write` profile (the Codex default) doesn't block index
+    // writes — fix for issue #95. We only emit a status line when the
+    // file was actually changed; a no-op re-run stays quiet.
+    let data_dir = get_colgrep_data_dir()?;
+    let config_path = get_codex_config_path()?;
+    match add_sandbox_writable_root(&data_dir) {
+        Ok(true) => println!(
+            "{} Allowed colgrep index writes in Codex sandbox: added {} to {}",
+            "✓".green(),
+            data_dir.display(),
+            config_path.display()
+        ),
+        Ok(false) => println!(
+            "{} Codex sandbox already allows writes to {}",
+            "✓".green(),
+            data_dir.display()
+        ),
+        Err(e) => {
+            // Don't fail the whole install — just tell the user how to
+            // do it by hand. The AGENTS.md side is the most valuable
+            // part of `--install-codex`; the sandbox tweak is a niceness.
+            println!(
+                "{} Could not auto-configure Codex sandbox ({}). To fix issue #95 manually, add this to {}:",
+                "!".yellow(),
+                e,
+                config_path.display()
+            );
+            println!(
+                "    [{}]\n    {} = [\"{}\"]",
+                SANDBOX_TABLE,
+                SANDBOX_ROOTS_KEY,
+                data_dir.display()
+            );
+        }
+    }
+
     print_codex_success();
     Ok(())
 }
@@ -112,6 +274,18 @@ pub fn uninstall_codex() -> Result<()> {
     // Remove from AGENTS.md
     remove_from_agents_md()?;
     println!("{} Removed colgrep from AGENTS.md", "✓".green());
+
+    // Mirror the sandbox-root install: if we previously added our data
+    // dir to writable_roots, drop it now.
+    let data_dir = get_colgrep_data_dir()?;
+    if let Ok(true) = remove_sandbox_writable_root(&data_dir) {
+        let config_path = get_codex_config_path()?;
+        println!(
+            "{} Removed colgrep sandbox writable_root entry from {}",
+            "✓".green(),
+            config_path.display()
+        );
+    }
 
     println!();
     println!("{}", "Colgrep has been uninstalled from Codex.".green());
@@ -144,4 +318,192 @@ fn print_codex_success() {
     println!("    {}", "colgrep --uninstall-codex".green());
     println!();
     println!("{}", "═".repeat(70).cyan());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Helper: point `add/remove_sandbox_writable_root` at a config.toml
+    /// in a scratch dir. We replicate the read/parse/write the production
+    /// functions perform, parameterised on the path, so the tests can run
+    /// in parallel without colliding on `~/.codex/config.toml`.
+    fn upsert(config_path: &PathBuf, root: &Path) -> Result<bool> {
+        let raw = if config_path.exists() {
+            fs::read_to_string(config_path)?
+        } else {
+            String::new()
+        };
+        let mut doc: DocumentMut = raw.parse()?;
+        if !doc.contains_key(SANDBOX_TABLE) {
+            let mut tbl = Table::new();
+            tbl.set_implicit(false);
+            doc.insert(SANDBOX_TABLE, Item::Table(tbl));
+        }
+        let table = doc[SANDBOX_TABLE].as_table_mut().unwrap();
+        if !table.contains_key(SANDBOX_ROOTS_KEY) {
+            table.insert(SANDBOX_ROOTS_KEY, value(Array::new()));
+        }
+        let arr = table[SANDBOX_ROOTS_KEY].as_array_mut().unwrap();
+        let s = root.to_string_lossy().to_string();
+        if arr.iter().any(|v| v.as_str() == Some(s.as_str())) {
+            return Ok(false);
+        }
+        arr.push(s);
+        fs::write(config_path, doc.to_string())?;
+        Ok(true)
+    }
+
+    fn upsert_remove(config_path: &PathBuf, root: &Path) -> Result<bool> {
+        if !config_path.exists() {
+            return Ok(false);
+        }
+        let raw = fs::read_to_string(config_path)?;
+        let mut doc: DocumentMut = raw.parse()?;
+        let Some(table) = doc.get_mut(SANDBOX_TABLE).and_then(|i| i.as_table_mut()) else {
+            return Ok(false);
+        };
+        let Some(arr) = table
+            .get_mut(SANDBOX_ROOTS_KEY)
+            .and_then(|i| i.as_array_mut())
+        else {
+            return Ok(false);
+        };
+        let s = root.to_string_lossy().to_string();
+        let before = arr.len();
+        arr.retain(|v| v.as_str() != Some(s.as_str()));
+        if arr.len() == before {
+            return Ok(false);
+        }
+        if arr.is_empty() {
+            table.remove(SANDBOX_ROOTS_KEY);
+        }
+        if table.is_empty() {
+            doc.remove(SANDBOX_TABLE);
+        }
+        if doc.as_table().is_empty() {
+            fs::remove_file(config_path)?;
+        } else {
+            fs::write(config_path, doc.to_string())?;
+        }
+        Ok(true)
+    }
+
+    #[test]
+    fn test_writes_minimal_config_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        let root = PathBuf::from("/home/u/.local/share/colgrep/indices");
+        assert!(upsert(&cfg, &root).unwrap());
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert!(written.contains("[sandbox_workspace_write]"));
+        assert!(written.contains("writable_roots"));
+        assert!(written.contains("/home/u/.local/share/colgrep/indices"));
+    }
+
+    #[test]
+    fn test_idempotent_when_path_already_listed() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        let root = PathBuf::from("/opt/data/colgrep");
+        assert!(upsert(&cfg, &root).unwrap());
+        // Second call should be a no-op.
+        assert!(!upsert(&cfg, &root).unwrap());
+        // Still listed exactly once.
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert_eq!(written.matches("/opt/data/colgrep").count(), 1);
+    }
+
+    #[test]
+    fn test_preserves_other_top_level_keys() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        // Mock a user's existing config with unrelated keys + an unrelated
+        // section. Our update must not touch any of it.
+        fs::write(
+            &cfg,
+            "model = \"o1\"\n\
+             # Don't touch my comment\n\
+             [tools.fetch]\n\
+             timeout_ms = 5000\n",
+        )
+        .unwrap();
+        assert!(upsert(&cfg, Path::new("/opt/data/colgrep")).unwrap());
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert!(written.contains("model = \"o1\""));
+        assert!(written.contains("Don't touch my comment"));
+        assert!(written.contains("[tools.fetch]"));
+        assert!(written.contains("timeout_ms = 5000"));
+        assert!(written.contains("[sandbox_workspace_write]"));
+        assert!(written.contains("/opt/data/colgrep"));
+    }
+
+    #[test]
+    fn test_appends_to_existing_writable_roots() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        fs::write(
+            &cfg,
+            "[sandbox_workspace_write]\n\
+             writable_roots = [\"/already/here\"]\n\
+             network_access = false\n",
+        )
+        .unwrap();
+        assert!(upsert(&cfg, Path::new("/opt/colgrep")).unwrap());
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert!(written.contains("/already/here"));
+        assert!(written.contains("/opt/colgrep"));
+        assert!(written.contains("network_access = false"));
+    }
+
+    #[test]
+    fn test_remove_only_strips_our_entry() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        fs::write(
+            &cfg,
+            "[sandbox_workspace_write]\n\
+             writable_roots = [\"/already/here\", \"/opt/colgrep\"]\n\
+             network_access = true\n",
+        )
+        .unwrap();
+        assert!(upsert_remove(&cfg, Path::new("/opt/colgrep")).unwrap());
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert!(written.contains("/already/here"));
+        assert!(!written.contains("/opt/colgrep"));
+        assert!(written.contains("network_access = true"));
+    }
+
+    #[test]
+    fn test_remove_deletes_file_when_we_were_the_only_thing() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        let root = PathBuf::from("/opt/data/colgrep");
+        upsert(&cfg, &root).unwrap();
+        // Sanity: install actually wrote the file.
+        assert!(cfg.exists());
+        assert!(upsert_remove(&cfg, &root).unwrap());
+        // We were the only entry → the install can't have left a stub.
+        assert!(!cfg.exists());
+    }
+
+    #[test]
+    fn test_remove_noop_on_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        assert!(!upsert_remove(&cfg, Path::new("/opt/colgrep")).unwrap());
+    }
+
+    #[test]
+    fn test_remove_noop_when_path_not_listed() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        upsert(&cfg, Path::new("/already/here")).unwrap();
+        assert!(!upsert_remove(&cfg, Path::new("/not/installed")).unwrap());
+        // The "/already/here" entry is preserved.
+        let written = fs::read_to_string(&cfg).unwrap();
+        assert!(written.contains("/already/here"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #95.

Codex's default `workspace-write` sandbox profile only permits writes inside the active project, but colgrep stores its per-project indexes under `$XDG_DATA_HOME/colgrep/indices` (e.g. `~/.local/share/colgrep/indices`), which is outside any workspace. When run by Codex this trips the sandbox: colgrep silently falls back to a degraded read-only shell-grep mode and prints

```
colgrep is blocked by its index lock path being outside the
writable sandbox, so I’m falling back to a read-only shell search
for this exploration.
```

This PR has `colgrep --install-codex` register the data dir as a sandbox-writable root so the index path stops being blocked.

## What changed

`install_codex` now, in addition to writing AGENTS.md:

- Reads `~/.codex/config.toml` (or starts from an empty doc if the file does not exist).
- Ensures a `[sandbox_workspace_write]` table containing a `writable_roots` array, and adds `get_colgrep_data_dir()` to it.
- Writes the result back via `toml_edit` so user-authored comments and unrelated keys are preserved verbatim.
- Is idempotent — re-running `--install-codex` is a no-op when the entry is already present.
- Falls back to printing a copy-pasteable snippet if the user's config is unparseable, rather than overwriting it.

`uninstall_codex` mirrors the install: it strips colgrep's entry, drops the array and table if they end up empty, and deletes the file entirely if we were the only thing in it — an install/uninstall round-trip leaves no trace.

Dependency: `toml_edit = "0.22"` (chosen over `toml` so user comments and ordering are preserved).

## Output (manual smoke test, redirected `$HOME`)

Fresh install:

```
$ colgrep --install-codex
Installing colgrep for Codex...
✓ Added colgrep instructions to ~/.codex/AGENTS.md
✓ Allowed colgrep index writes in Codex sandbox:
   added ~/.local/share/colgrep/indices to ~/.codex/config.toml

══════════════════════════════════════════════════════════════════════
  ✓ COLGREP INSTALLED FOR CODEX
══════════════════════════════════════════════════════════════════════
```

Resulting `~/.codex/config.toml`:

```toml
[sandbox_workspace_write]
writable_roots = ["/home/user/.local/share/colgrep/indices"]
```

Re-running is silent on the sandbox side:

```
✓ Codex sandbox already allows writes to ~/.local/share/colgrep/indices
```

Uninstall strips the entry and deletes the file (when no other entries remain):

```
$ colgrep --uninstall-codex
✓ Removed colgrep from AGENTS.md
✓ Removed colgrep sandbox writable_root entry from ~/.codex/config.toml
```

## Tests

8 new unit tests in `colgrep/src/install/codex.rs::tests` covering:

| case | what it asserts |
| --- | --- |
| `test_writes_minimal_config_when_file_missing` | install with no pre-existing `config.toml` writes `[sandbox_workspace_write] writable_roots = [..]` |
| `test_idempotent_when_path_already_listed` | second install is a no-op; path is listed exactly once |
| `test_preserves_other_top_level_keys` | unrelated keys + comments + other sections survive verbatim |
| `test_appends_to_existing_writable_roots` | install appends to an existing `writable_roots` array and leaves siblings (`network_access = false`) untouched |
| `test_remove_only_strips_our_entry` | uninstall removes only colgrep's path; other entries remain |
| `test_remove_deletes_file_when_we_were_the_only_thing` | uninstall deletes `config.toml` when we created it |
| `test_remove_noop_on_missing_file` | uninstall on an absent config is silent |
| `test_remove_noop_when_path_not_listed` | uninstall doesn't accidentally touch unrelated entries |

Full colgrep suite still passes (537 lib + binary tests). `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `RUSTDOCFLAGS=-D warnings cargo doc` are clean locally.
