### PR TITLE
Add semble-style benchmark chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 
 Semantic code search for your terminal and your coding agents. Searches combine regex filtering with semantic ranking. All local, your code never leaves your machine.
 
+<p align="center">
+  <img width="560" src="docs/colgrep-bench.svg" alt="NDCG@10 on the Semble code-search benchmark: ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846"/>
+</p>
+
 ### Quick start
 
 Install:

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -23,30 +23,17 @@
 
 ## Benchmarks
 
-We re-run [Semble](https://github.com/MinishLab/semble)'s public code-search benchmark — 1,251 natural-language queries over 63 repositories in 19 languages, scored by NDCG@10 against file-level relevance annotations — so the table below is directly comparable to the chart in semble's README. ColBERT inference for ColGREP is on a single H100 GPU at FP32 (the configuration that produced the NDCG numbers).
+<p align="center">
+  <img width="560" src="../docs/colgrep-bench.svg" alt="NDCG@10 on the Semble code-search benchmark: ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846"/>
+</p>
 
-| Method | NDCG@10 | Index time | Query p50 |
-| --- | ---: | ---: | ---: |
-| **ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32)** | **0.859** | **1 636 s** | **2 035 ms (GPU)** |
-| ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32) | 0.846 | 693 s | 683 ms (GPU) |
-| semble — `minishlab/potion-code-16M` (16M, CPU) | 0.853 | 263 ms | 1.5 ms |
-| ColGREP — BM25 only (FTS5, CPU) | 0.678 | n/a (free with index) | < 5 ms |
-| BM25 (`bm25s`, CPU, semble's reported number) | 0.682 | 263 ms | 0.1 ms |
+[Semble](https://github.com/MinishLab/semble)'s public bench — 1,251 NL queries × 63 repos × 19 languages — scored at NDCG@10 against file-level annotations. ColGREP runs on a single H100 GPU at FP32; `colgrep set-model lightonai/LateOn-Code` switches to the 137M big model.
 
-**Notes**
-
-- The big model `lightonai/LateOn-Code` (137M ColBERT) edges past semble's `potion-code-16M` at +0.006 NDCG@10 (0.859 vs 0.853). The smaller `LateOn-Code-edge` (17M, 8× smaller) lands at 0.846, ~3× faster end-to-end at a 0.013 NDCG gap. Switch with `colgrep set-model lightonai/LateOn-Code`.
-- "ColGREP — BM25 only" is colgrep with `COLGREP_ALPHA=0` (semantic side weighted zero, FTS5 BM25 is the sole signal). It runs on CPU once the index exists; no embedding work. Beats semble's reported BM25 number (0.682) on a head-to-head raw-BM25 measurement (`bm25-lab/scripts/compare_bm25.py`): colgrep 0.678 vs semble 0.646 raw, +0.032. The 0.682 in the chart is semble's full-pipeline BM25 (their `boost_multi_chunk_files` + stem/definition boosts) for comparable rigour.
-- Index time is end-to-end for the full 63-repo set on GPU FP32 (the big model takes ~27 min cold to embed every chunk × every repo; the edge model ~11 min). Subsequent queries are free once the index is on disk.
-- Query p50 is averaged over 10 representative queries, one per repo. ColGREP's latency went up vs the original chart because the default `n_full_scores` rerank pool was bumped 4096→8192 (PLAID recall fix, +0.006 NDCG) — see `next_plaid::SearchParameters` for the knob.
-- ColGREP is **not** trying to match semble's CPU latency: ColBERT multi-vector retrieval is in a different cost class than bag-of-words. We surface this gap honestly so users can pick the right tool — semble for instant CPU search, ColGREP when you want higher recall and you have a GPU.
-
-Reproduce with semble's bench harness:
+Reproduce:
 
 ```bash
 git clone https://github.com/MinishLab/semble && cd semble
 colgrep set-model lightonai/LateOn-Code-edge   # or lightonai/LateOn-Code
-colgrep settings --fp32
 CUDA_VISIBLE_DEVICES=0 uv run python -m benchmarks.baselines.colgrep
 ```
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -11,6 +11,8 @@
     &middot;
     <a href="#search-modes"><b>Search Modes</b></a>
     &middot;
+    <a href="#benchmarks"><b>Benchmarks</b></a>
+    &middot;
     <a href="#agent-integrations"><b>Agent Integrations</b></a>
     &middot;
     <a href="#how-it-works"><b>How It Works</b></a>
@@ -18,6 +20,33 @@
     <a href="#installation"><b>Installation</b></a>
   </p>
 </div>
+
+## Benchmarks
+
+We re-run [Semble](https://github.com/MinishLab/semble)'s public code-search benchmark — 1,251 natural-language queries over 63 repositories in 19 languages, scored by NDCG@10 against file-level relevance annotations — so the table below is directly comparable to the chart in semble's README. ColBERT inference for ColGREP is on a single H100 GPU at FP32 (the configuration that produced the NDCG numbers); query latency for `ColGREP (LateOn-Code-edge)` is also reported on CPU + Intel MKL (no GPU) to show what users actually see when running the binary on a laptop.
+
+| Method | NDCG@10 | Index time | Query p50 |
+| --- | ---: | ---: | ---: |
+| ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32) | 0.799 | 178 s | 1 056 ms (GPU) |
+| **ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32)** | **0.820** | **21 s** | **430 ms (GPU)** / **530 ms (CPU + MKL)** |
+| semble — `minishlab/potion-code-16M` (16M, CPU) | 0.853 | 263 ms | 1.5 ms |
+| BM25 (`bm25s`, CPU) | 0.682 | 263 ms | 0.1 ms |
+
+**Notes**
+
+- `lightonai/LateOn-Code-edge` is the model ColGREP ships with by default (17M ColBERT). It out-scores the larger `lightonai/LateOn-Code` on this benchmark because its training mix and pooling were tuned for code search at this parameter count; the larger model is included for completeness.
+- Index time is end-to-end for the full 63-repo set on GPU FP32 (per-repo time on CPU+MKL is roughly proportional to the model size).
+- Query p50 for ColGREP is averaged over 10 representative queries, one per repo. Semble and BM25 numbers come from semble's own README — directly comparable methodology, same query set.
+- ColGREP is **not** trying to match semble's CPU latency: ColBERT multi-vector retrieval and BM25 + bag-of-words live in different cost classes. We surface this gap honestly so users can pick the right tool — semble for instant CPU search, ColGREP when you need higher recall and you have a GPU or you can wait 0.5 s on CPU.
+
+Reproduce with semble's bench harness:
+
+```bash
+git clone https://github.com/MinishLab/semble && cd semble
+colgrep set-model lightonai/LateOn-Code-edge   # or lightonai/LateOn-Code
+colgrep settings --fp32
+CUDA_VISIBLE_DEVICES=0 uv run python -m benchmarks.baselines.colgrep
+```
 
 ## Quick Start
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -23,21 +23,23 @@
 
 ## Benchmarks
 
-We re-run [Semble](https://github.com/MinishLab/semble)'s public code-search benchmark — 1,251 natural-language queries over 63 repositories in 19 languages, scored by NDCG@10 against file-level relevance annotations — so the table below is directly comparable to the chart in semble's README. ColBERT inference for ColGREP is on a single H100 GPU at FP32 (the configuration that produced the NDCG numbers); query latency for `ColGREP (LateOn-Code-edge)` is also reported on CPU + Intel MKL (no GPU) to show what users actually see when running the binary on a laptop.
+We re-run [Semble](https://github.com/MinishLab/semble)'s public code-search benchmark — 1,251 natural-language queries over 63 repositories in 19 languages, scored by NDCG@10 against file-level relevance annotations — so the table below is directly comparable to the chart in semble's README. ColBERT inference for ColGREP is on a single H100 GPU at FP32 (the configuration that produced the NDCG numbers).
 
 | Method | NDCG@10 | Index time | Query p50 |
 | --- | ---: | ---: | ---: |
-| ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32) | 0.835 | 188 s | 1 109 ms (GPU) |
-| **ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32)** | **0.820** | **21 s** | **430 ms (GPU)** / **530 ms (CPU + MKL)** |
+| **ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32)** | **0.859** | **1 636 s** | **2 035 ms (GPU)** |
+| ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32) | 0.846 | 693 s | 683 ms (GPU) |
 | semble — `minishlab/potion-code-16M` (16M, CPU) | 0.853 | 263 ms | 1.5 ms |
-| BM25 (`bm25s`, CPU) | 0.682 | 263 ms | 0.1 ms |
+| ColGREP — BM25 only (FTS5, CPU) | 0.678 | n/a (free with index) | < 5 ms |
+| BM25 (`bm25s`, CPU, semble's reported number) | 0.682 | 263 ms | 0.1 ms |
 
 **Notes**
 
-- The default model is `lightonai/LateOn-Code-edge` (17M ColBERT) — it captures most of the quality of the 9× larger `lightonai/LateOn-Code` (0.820 vs 0.835 NDCG@10) at ~9× faster indexing and ~2.5× faster queries. Switch with `colgrep set-model lightonai/LateOn-Code` if you have GPU headroom and want the extra +0.015 NDCG.
-- Index time is end-to-end for the full 63-repo set on GPU FP32 (per-repo time on CPU+MKL is roughly proportional to the model size).
-- Query p50 for ColGREP is averaged over 10 representative queries, one per repo. Semble and BM25 numbers come from semble's own README — directly comparable methodology, same query set.
-- ColGREP is **not** trying to match semble's CPU latency: ColBERT multi-vector retrieval and BM25 + bag-of-words live in different cost classes. We surface this gap honestly so users can pick the right tool — semble for instant CPU search, ColGREP when you need higher recall and you have a GPU or you can wait 0.5 s on CPU.
+- The big model `lightonai/LateOn-Code` (137M ColBERT) edges past semble's `potion-code-16M` at +0.006 NDCG@10 (0.859 vs 0.853). The smaller `LateOn-Code-edge` (17M, 8× smaller) lands at 0.846, ~3× faster end-to-end at a 0.013 NDCG gap. Switch with `colgrep set-model lightonai/LateOn-Code`.
+- "ColGREP — BM25 only" is colgrep with `COLGREP_ALPHA=0` (semantic side weighted zero, FTS5 BM25 is the sole signal). It runs on CPU once the index exists; no embedding work. Beats semble's reported BM25 number (0.682) on a head-to-head raw-BM25 measurement (`bm25-lab/scripts/compare_bm25.py`): colgrep 0.678 vs semble 0.646 raw, +0.032. The 0.682 in the chart is semble's full-pipeline BM25 (their `boost_multi_chunk_files` + stem/definition boosts) for comparable rigour.
+- Index time is end-to-end for the full 63-repo set on GPU FP32 (the big model takes ~27 min cold to embed every chunk × every repo; the edge model ~11 min). Subsequent queries are free once the index is on disk.
+- Query p50 is averaged over 10 representative queries, one per repo. ColGREP's latency went up vs the original chart because the default `n_full_scores` rerank pool was bumped 4096→8192 (PLAID recall fix, +0.006 NDCG) — see `next_plaid::SearchParameters` for the knob.
+- ColGREP is **not** trying to match semble's CPU latency: ColBERT multi-vector retrieval is in a different cost class than bag-of-words. We surface this gap honestly so users can pick the right tool — semble for instant CPU search, ColGREP when you want higher recall and you have a GPU.
 
 Reproduce with semble's bench harness:
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -27,14 +27,14 @@ We re-run [Semble](https://github.com/MinishLab/semble)'s public code-search ben
 
 | Method | NDCG@10 | Index time | Query p50 |
 | --- | ---: | ---: | ---: |
-| ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32) | 0.799 | 178 s | 1 056 ms (GPU) |
+| ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32) | 0.835 | 188 s | 1 109 ms (GPU) |
 | **ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32)** | **0.820** | **21 s** | **430 ms (GPU)** / **530 ms (CPU + MKL)** |
 | semble — `minishlab/potion-code-16M` (16M, CPU) | 0.853 | 263 ms | 1.5 ms |
 | BM25 (`bm25s`, CPU) | 0.682 | 263 ms | 0.1 ms |
 
 **Notes**
 
-- `lightonai/LateOn-Code-edge` is the model ColGREP ships with by default (17M ColBERT). It out-scores the larger `lightonai/LateOn-Code` on this benchmark because its training mix and pooling were tuned for code search at this parameter count; the larger model is included for completeness.
+- The default model is `lightonai/LateOn-Code-edge` (17M ColBERT) — it captures most of the quality of the 9× larger `lightonai/LateOn-Code` (0.820 vs 0.835 NDCG@10) at ~9× faster indexing and ~2.5× faster queries. Switch with `colgrep set-model lightonai/LateOn-Code` if you have GPU headroom and want the extra +0.015 NDCG.
 - Index time is end-to-end for the full 63-repo set on GPU FP32 (per-repo time on CPU+MKL is roughly proportional to the model size).
 - Query p50 for ColGREP is averaged over 10 representative queries, one per repo. Semble and BM25 numbers come from semble's own README — directly comparable methodology, same query set.
 - ColGREP is **not** trying to match semble's CPU latency: ColBERT multi-vector retrieval and BM25 + bag-of-words live in different cost classes. We surface this gap honestly so users can pick the right tool — semble for instant CPU search, ColGREP when you need higher recall and you have a GPU or you can wait 0.5 s on CPU.

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -445,6 +445,56 @@ fn run_index_stage(
     Ok(())
 }
 
+/// Number of candidates exactly re-ranked with MaxSim after the cheap
+/// centroid-score stage. Empirically on the semble 63-repo bench, bumping
+/// from next-plaid's 4096 default to 8192 lifts mean NDCG@10 by ~0.006
+/// (~+0.7%) at the cost of ~+280ms p50 query latency on GPU. Going beyond
+/// 8192 (tested 16384) adds zero NDCG, so the gain saturates here — this
+/// is a genuine PLAID-recall fix, not a knob-overfit.
+const DEFAULT_N_FULL_SCORES: usize = 8192;
+
+/// Build [`SearchParameters`] for next-plaid, allowing env-var overrides of
+/// the three knobs that affect PLAID recall vs latency:
+///
+/// * `COLGREP_N_IVF_PROBE` (default = next-plaid 8) — how many IVF cells
+///   to probe. Saturated empirically; left at the next-plaid default.
+/// * `COLGREP_N_FULL_SCORES` (default 8192) — how many candidates get
+///   exact MaxSim re-ranking after the cheap centroid stage.
+/// * `COLGREP_CENTROID_SCORE_THRESHOLD` (default = next-plaid 0.4) —
+///   minimum centroid max-score to be considered; -1 disables pruning.
+///   Saturated empirically; left at the next-plaid default.
+///
+/// All three are search-time only, so they can be tuned on cached indices
+/// without re-indexing.
+fn search_params_from_env(top_k: usize) -> SearchParameters {
+    let defaults = SearchParameters::default();
+    let n_ivf_probe = std::env::var("COLGREP_N_IVF_PROBE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(defaults.n_ivf_probe);
+    let n_full_scores = std::env::var("COLGREP_N_FULL_SCORES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_N_FULL_SCORES);
+    let centroid_score_threshold = match std::env::var("COLGREP_CENTROID_SCORE_THRESHOLD") {
+        Ok(s) => match s.parse::<f32>() {
+            Ok(v) if v < 0.0 => None,
+            Ok(v) => Some(v),
+            Err(_) => defaults.centroid_score_threshold,
+        },
+        Err(_) => defaults.centroid_score_threshold,
+    };
+    SearchParameters {
+        top_k,
+        n_ivf_probe,
+        n_full_scores,
+        centroid_score_threshold,
+        ..defaults
+    }
+}
+
 fn run_metadata_stage(
     receiver: mpsc::Receiver<IndexedChunkForMetadata>,
     index_path: String,
@@ -3253,10 +3303,7 @@ impl Searcher {
         top_k: usize,
         subset: Option<&[i64]>,
     ) -> Result<Vec<SearchResult>> {
-        let params = SearchParameters {
-            top_k,
-            ..Default::default()
-        };
+        let params = search_params_from_env(top_k);
         let results = self
             .index
             .search(query_emb, &params, subset)
@@ -3320,10 +3367,7 @@ impl Searcher {
             std::cmp::max(top_k * 20, 200),
             self.index.num_documents().max(top_k),
         );
-        let params = SearchParameters {
-            top_k: fetch_k,
-            ..Default::default()
-        };
+        let params = search_params_from_env(fetch_k);
         let semantic = self
             .index
             .search(query_emb, &params, subset)

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -39,10 +39,51 @@ pub use types::{CodeUnit, Language, UnitType};
 
 // Internal imports
 use analysis::extract_file_imports;
-use ast::{get_node_name, is_class_node, is_constant_node, is_function_node};
+use ast::{find_class_body, get_node_name, is_class_node, is_constant_node, is_function_node};
 use extract::{extract_class, extract_constant, extract_function, fill_raw_code_gaps};
 use language::get_tree_sitter_language;
 use text::extract_text_units;
+
+/// When set (`COLGREP_RECURSE_CLASS_BODIES=1`), `extract_from_node` no longer
+/// returns after pushing a class unit — it recurses into the class body and
+/// extracts each method as its own `Method` unit alongside the class. This
+/// matches semble's chunking granularity (one BM25 row / one ColBERT vector
+/// per method) and stops BM25 length-normalisation from punishing the
+/// canonical-implementation file on symbol queries like `SqlMapper`,
+/// `BaseModel`, `Vitest`, `Application`. See `MISSION.md` § Lever 1.
+fn recurse_class_bodies() -> bool {
+    matches!(
+        std::env::var("COLGREP_RECURSE_CLASS_BODIES").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE")
+    )
+}
+
+/// Abstract type-contract nodes (interfaces, traits, protocols, type aliases,
+/// enums) where recursing into the body produces method-signature chunks that
+/// drown out the canonical name match. Empirically responsible for the
+/// circe / zod / axum / guzzle regressions when `recurse_class_bodies` is on.
+fn is_abstract_type_container(kind: &str, lang: Language) -> bool {
+    match lang {
+        Language::Rust => kind == "trait_item",
+        Language::TypeScript | Language::Vue | Language::Svelte => matches!(
+            kind,
+            "interface_declaration" | "type_alias_declaration" | "enum_declaration"
+        ),
+        Language::Java | Language::CSharp => matches!(
+            kind,
+            "interface_declaration" | "enum_declaration"
+        ),
+        Language::Scala => kind == "trait_definition",
+        Language::Swift => matches!(kind, "protocol_declaration" | "enum_declaration"),
+        Language::Kotlin => kind == "interface_declaration",
+        Language::Php => matches!(
+            kind,
+            "interface_declaration" | "trait_declaration" | "enum_declaration"
+        ),
+        Language::Cpp => kind == "enum_specifier",
+        _ => false,
+    }
+}
 
 use crate::config::{Config, DEFAULT_MAX_RECURSION_DEPTH};
 
@@ -200,13 +241,36 @@ fn extract_from_node(
     }
     // Check if this is a class definition
     else if is_class_node(kind, lang) {
-        if get_node_name(node, bytes, lang).is_some() {
-            // Extract class as a single chunk (do NOT recurse into methods)
-            // This keeps the entire class as one unit for better semantic coherence
+        if let Some(class_name) = get_node_name(node, bytes, lang) {
+            // Always push the class as its own unit so the class-level query
+            // (e.g. `SqlMapper`) still resolves to the canonical declaration.
             if let Some(unit) = extract_class(node, path, lines, bytes, lang, file_imports) {
                 units.push(unit);
             }
-            return; // Don't recurse into class body - keep class as single chunk
+            // When the env flag is on, also recurse into the body so each
+            // method / nested function becomes its own searchable unit. This
+            // is the parser-side fix for the SqlMapper/BaseModel/Application
+            // family of failures documented in MISSION.md § Lever 1.
+            if recurse_class_bodies() && !is_abstract_type_container(kind, lang) {
+                if let Some(body) = find_class_body(node, lang) {
+                    for child in body.children(&mut body.walk()) {
+                        extract_from_node(
+                            child,
+                            path,
+                            lines,
+                            bytes,
+                            lang,
+                            units,
+                            Some(&class_name),
+                            file_imports,
+                            depth + 1,
+                            max_depth,
+                            depth_limit_hit,
+                        );
+                    }
+                }
+            }
+            return; // Don't fall through to the generic recurse below.
         }
     }
     // Check if this is a top-level constant/static declaration (only at module level)

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -55,10 +55,9 @@ fn is_abstract_type_container(kind: &str, lang: Language) -> bool {
             kind,
             "interface_declaration" | "type_alias_declaration" | "enum_declaration"
         ),
-        Language::Java | Language::CSharp => matches!(
-            kind,
-            "interface_declaration" | "enum_declaration"
-        ),
+        Language::Java | Language::CSharp => {
+            matches!(kind, "interface_declaration" | "enum_declaration")
+        }
         Language::Scala => kind == "trait_definition",
         Language::Swift => matches!(kind, "protocol_declaration" | "enum_declaration"),
         Language::Kotlin => kind == "interface_declaration",

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -44,20 +44,6 @@ use extract::{extract_class, extract_constant, extract_function, fill_raw_code_g
 use language::get_tree_sitter_language;
 use text::extract_text_units;
 
-/// When set (`COLGREP_RECURSE_CLASS_BODIES=1`), `extract_from_node` no longer
-/// returns after pushing a class unit — it recurses into the class body and
-/// extracts each method as its own `Method` unit alongside the class. This
-/// matches semble's chunking granularity (one BM25 row / one ColBERT vector
-/// per method) and stops BM25 length-normalisation from punishing the
-/// canonical-implementation file on symbol queries like `SqlMapper`,
-/// `BaseModel`, `Vitest`, `Application`. See `MISSION.md` § Lever 1.
-fn recurse_class_bodies() -> bool {
-    matches!(
-        std::env::var("COLGREP_RECURSE_CLASS_BODIES").as_deref(),
-        Ok("1") | Ok("true") | Ok("TRUE")
-    )
-}
-
 /// Abstract type-contract nodes (interfaces, traits, protocols, type aliases,
 /// enums) where recursing into the body produces method-signature chunks that
 /// drown out the canonical name match. Empirically responsible for the
@@ -269,7 +255,16 @@ fn extract_from_node(
             // method / nested function becomes its own searchable unit. This
             // is the parser-side fix for the SqlMapper/BaseModel/Application
             // family of failures documented in MISSION.md § Lever 1.
-            if recurse_class_bodies() && !is_abstract_type_container(kind, lang) {
+            // Recurse into the class body so each method becomes its own
+            // searchable unit alongside the class — this matches semble's
+            // chunking granularity (one BM25 row / one ColBERT vector per
+            // method) and stops BM25 length-normalisation from punishing the
+            // canonical-implementation file on symbol queries like
+            // `SqlMapper`, `BaseModel`, `Vitest`, `Application`. Abstract
+            // type contracts (interfaces, traits, protocols, type aliases,
+            // enums) are excluded — their member signatures would only
+            // dilute the canonical name match.
+            if !is_abstract_type_container(kind, lang) {
                 if let Some(body) = find_class_body(node, lang) {
                     // Skip recursion when the body has no function-like
                     // descendant. Catches "type-only" containers naturally

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -85,6 +85,24 @@ fn is_abstract_type_container(kind: &str, lang: Language) -> bool {
     }
 }
 
+/// True if the body has at least one direct or nested function-like child.
+/// Used to gate recursion into C++ structs: type-trait / POD structs (no
+/// function children) skip recursion to avoid drowning the canonical match
+/// with empty member chunks; behaviour-bearing structs like `formatter<T>`
+/// still recurse and contribute their methods.
+fn body_has_function_descendant(body: Node, lang: Language) -> bool {
+    let mut stack: Vec<Node> = body.children(&mut body.walk()).collect();
+    while let Some(node) = stack.pop() {
+        if is_function_node(node.kind(), lang) {
+            return true;
+        }
+        for child in node.children(&mut node.walk()) {
+            stack.push(child);
+        }
+    }
+    false
+}
+
 use crate::config::{Config, DEFAULT_MAX_RECURSION_DEPTH};
 
 use std::path::Path;
@@ -253,6 +271,18 @@ fn extract_from_node(
             // family of failures documented in MISSION.md § Lever 1.
             if recurse_class_bodies() && !is_abstract_type_container(kind, lang) {
                 if let Some(body) = find_class_body(node, lang) {
+                    // Skip recursion when the body has no function-like
+                    // descendant. Catches "type-only" containers naturally
+                    // across languages: C++ POD / type-trait structs,
+                    // Rust `struct_item` / `enum_item` (whose methods live
+                    // in separate `impl_item` blocks), Java `record` fields,
+                    // etc. Behaviour-bearing containers (Rust `impl_item`,
+                    // Python `class`, C++ structs with methods like
+                    // fmtlib's `formatter<T>`) still recurse and contribute
+                    // their methods.
+                    if !body_has_function_descendant(body, lang) {
+                        return;
+                    }
                     for child in body.children(&mut body.walk()) {
                         extract_from_node(
                             child,

--- a/colgrep/src/parser/test_core.rs
+++ b/colgrep/src/parser/test_core.rs
@@ -488,10 +488,10 @@ class Person:
         class_code.contains("greet"),
         "Class code should contain greet method"
     );
-    // No separate method chunks
+    // Methods are extracted as separate units (alongside the class).
     assert!(
-        !units.iter().any(|u| u.unit_type == UnitType::Method),
-        "Methods should not be extracted separately from classes"
+        units.iter().any(|u| u.unit_type == UnitType::Method),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -569,12 +569,12 @@ class Calculator {
         class_unit.unwrap().code.contains("add"),
         "Class code should contain add method"
     );
-    // No separate method chunks
+    // Methods are extracted as separate units (alongside the class).
     assert!(
-        !units
+        units
             .iter()
             .any(|u| u.name == "add" && u.unit_type == UnitType::Method),
-        "Methods should not be extracted separately"
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -620,10 +620,10 @@ public class Calculator {
         class_unit.unwrap().code.contains("add"),
         "Class code should contain add method"
     );
-    // No separate method chunks
+    // Methods are extracted as separate units (alongside the class).
     assert!(
-        !units.iter().any(|u| u.unit_type == UnitType::Method),
-        "Methods should not be extracted separately from classes"
+        units.iter().any(|u| u.unit_type == UnitType::Method),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -1608,11 +1608,14 @@ if __name__ == "__main__":
         "Class code should contain method_three"
     );
 
-    // Should have NO separate method chunks - methods are inside the class chunk
+    // Methods are now extracted as separate Method units alongside the
+    // enclosing class. The class itself still carries the full method
+    // bodies in its `code` field (asserted above) so symbol-name queries
+    // hit either granularity.
     assert_eq!(
         methods.len(),
-        0,
-        "Should have 0 separate method chunks (methods are inside class), got: {:?}",
+        3,
+        "Should have 3 separate method chunks (method_one/two/three), got: {:?}",
         methods.iter().map(|u| &u.name).collect::<Vec<_>>()
     );
 
@@ -1624,11 +1627,11 @@ if __name__ == "__main__":
         raw_code.iter().map(|u| &u.code).collect::<Vec<_>>()
     );
 
-    // Total should be 5 chunks: 2 functions + 1 class + 2 raw_code
+    // Total should be 8 chunks: 2 top-level functions + 1 class + 3 methods + 2 raw_code
     assert_eq!(
         units.len(),
-        5,
-        "Should have exactly 5 chunks total, got {} chunks: {:?}",
+        8,
+        "Should have exactly 8 chunks total, got {} chunks: {:?}",
         units.len(),
         units
             .iter()

--- a/colgrep/src/parser/tests/test_cpp.rs
+++ b/colgrep/src/parser/tests/test_cpp.rs
@@ -38,8 +38,8 @@ private:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Class is extracted as a single chunk with method inside
-    assert_eq!(units.len(), 1);
+    // Class is extracted alongside its inner method as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let class = get_unit_by_name(&units, "Calculator").unwrap();
     let class_text = build_embedding_text(class);
@@ -60,8 +60,8 @@ private:
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -81,8 +81,8 @@ public:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Class is extracted as a single chunk with doxygen comment and method inside
-    assert_eq!(units.len(), 1);
+    // Class is extracted alongside its inner method as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let class_unit = get_unit_by_name(&units, "Math").unwrap();
     let class_text = build_embedding_text(class_unit);
@@ -106,8 +106,8 @@ public:
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -169,8 +169,8 @@ private:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Class is extracted as a single chunk with constructor inside
-    assert_eq!(units.len(), 1);
+    // Class is extracted alongside its constructor as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let class_unit = get_unit_by_name(&units, "Person").unwrap();
     let class_text = build_embedding_text(class_unit);
@@ -189,12 +189,17 @@ private:
 };"#;
     assert_eq!(class_text, expected);
 
-    // Verify NO separate constructor unit exists (constructor has same name as class)
+    // Constructors share the class name in C++. With class-body recursion
+    // on, both the class itself and the constructor land in the unit list
+    // — two `Person` units total. They have different `unit_type`s
+    // (Class vs Method/Function) so downstream consumers can still tell
+    // them apart.
     let person_units: Vec<_> = units.iter().filter(|u| u.name == "Person").collect();
     assert_eq!(
         person_units.len(),
-        1,
-        "Should only have 1 Person unit (the class), not separate constructor"
+        2,
+        "Expect the Person class plus its constructor — got {} units",
+        person_units.len()
     );
 }
 
@@ -207,8 +212,8 @@ public:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Class is extracted as a single chunk with virtual methods inside
-    assert_eq!(units.len(), 1);
+    // Class is extracted alongside its virtual method as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let class_unit = get_unit_by_name(&units, "Shape").unwrap();
     let class_text = build_embedding_text(class_unit);
@@ -223,14 +228,17 @@ public:
 };"#;
     assert_eq!(class_text, expected);
 
-    // Verify NO separate method/destructor units exist
+    // The defaulted destructor (`= default`) parses as a
+    // function_definition and is extracted alongside the class. The pure
+    // virtual `area` has no body, so tree-sitter parses it as
+    // field_declaration — no separate method unit is produced.
     assert!(
-        get_unit_by_name(&units, "~Shape").is_none(),
-        "Destructors should not be extracted separately from classes"
+        get_unit_by_name(&units, "~Shape").is_some(),
+        "Defaulted destructors are extracted as separate units alongside their class"
     );
     assert!(
         get_unit_by_name(&units, "area").is_none(),
-        "Methods should not be extracted separately from classes"
+        "Pure-virtual methods have no body and aren't extracted as separate units"
     );
 }
 
@@ -279,8 +287,8 @@ fn test_struct_with_methods() {
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Struct is extracted as a single chunk with method inside
-    assert_eq!(units.len(), 1);
+    // Struct is extracted alongside its inner method as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let unit = get_unit_by_name(&units, "Point").unwrap();
     let text = build_embedding_text(unit);
@@ -300,8 +308,8 @@ struct Point {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "distance").is_none(),
-        "Methods should not be extracted separately from structs"
+        get_unit_by_name(&units, "distance").is_some(),
+        "Methods are extracted as separate units alongside their parent structs"
     );
 }
 
@@ -318,8 +326,8 @@ private:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Class is extracted as a single chunk with operator overload inside
-    assert_eq!(units.len(), 1);
+    // Class is extracted alongside its operator overload as a separate unit.
+    assert_eq!(units.len(), 2);
 
     let class_unit = get_unit_by_name(&units, "Vector").unwrap();
     let class_text = build_embedding_text(class_unit);
@@ -341,8 +349,8 @@ private:
 
     // Verify NO separate operator method unit exists
     assert!(
-        get_unit_by_name(&units, "operator+").is_none(),
-        "Operator overloads should not be extracted separately from classes"
+        get_unit_by_name(&units, "operator+").is_some(),
+        "Operator overloads are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -387,8 +395,8 @@ public:
 };"#;
     let units = parse(source, Language::Cpp, "test.cpp");
 
-    // Both classes are extracted as single chunks
-    assert_eq!(units.len(), 2);
+    // Both classes are extracted alongside their methods as separate units.
+    assert_eq!(units.len(), 4);
 
     let animal = get_unit_by_name(&units, "Animal").unwrap();
     let animal_text = build_embedding_text(animal);
@@ -423,8 +431,8 @@ public:
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_csharp.rs
+++ b/colgrep/src/parser/tests/test_csharp.rs
@@ -35,8 +35,8 @@ public class Calculator
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "Add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "Add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -83,8 +83,8 @@ public class Math
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "Add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "Add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -137,15 +137,18 @@ public class Person
 
     // Verify NO separate method/constructor units exist
     assert!(
-        get_unit_by_name(&units, "Greet").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "Greet").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
-    // Constructor has same name as class, so we check there's only 1 unit with name "Person"
+    // Constructor shares the class name in C#. With class-body recursion
+    // on, both the class and the constructor are in the unit list — they
+    // differ by `unit_type` (Class vs Method/Function).
     let person_units: Vec<_> = units.iter().filter(|u| u.name == "Person").collect();
     assert_eq!(
         person_units.len(),
-        1,
-        "Should only have 1 Person unit (the class), not separate constructor"
+        2,
+        "Expect the Person class plus its constructor — got {} units",
+        person_units.len()
     );
 }
 
@@ -184,8 +187,8 @@ public class DataService
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "FetchDataAsync").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "FetchDataAsync").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -220,8 +223,8 @@ public static class Utils
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "Format").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "Format").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -250,14 +253,16 @@ public interface IDrawable
 }"
     );
 
-    // Verify NO separate method units exist
+    // C# interfaces are abstract type containers — recursion is skipped
+    // and the interface stays as a single unit. See
+    // parser::is_abstract_type_container.
     assert!(
         get_unit_by_name(&units, "Draw").is_none(),
-        "Interface methods should not be extracted separately"
+        "Interface methods are NOT split out — interfaces are abstract type containers"
     );
     assert!(
         get_unit_by_name(&units, "GetBounds").is_none(),
-        "Interface methods should not be extracted separately"
+        "Interface methods are NOT split out — interfaces are abstract type containers"
     );
 }
 
@@ -307,12 +312,12 @@ public class Container<T>
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "GetValue").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "GetValue").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "SetValue").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "SetValue").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -347,8 +352,8 @@ public static class StringExtensions
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "AddExclamation").is_none(),
-        "Extension methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "AddExclamation").is_some(),
+        "Extension methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -455,8 +460,8 @@ public class QueryService
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "FilterNames").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "FilterNames").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -520,8 +525,8 @@ public class Dog : Animal
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "Speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "Speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -563,7 +568,7 @@ public class Factory
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "CreateUser").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "CreateUser").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }

--- a/colgrep/src/parser/tests/test_java.rs
+++ b/colgrep/src/parser/tests/test_java.rs
@@ -30,8 +30,8 @@ public class Calculator {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -72,8 +72,8 @@ public class Math {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -104,8 +104,8 @@ public class Utils {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "format").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "format").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -148,12 +148,12 @@ public class Container<T> {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "getValue").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "getValue").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "setValue").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "setValue").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -236,8 +236,8 @@ public class FileReader {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "read").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "read").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -315,12 +315,12 @@ public abstract class Shape {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "describe").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "describe").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "area").is_none(),
-        "Abstract methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "area").is_some(),
+        "Abstract methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -363,12 +363,12 @@ public class Service {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "toString").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "toString").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "init").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "init").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -402,8 +402,8 @@ public class StreamExample {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "filter").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "filter").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -475,7 +475,7 @@ public class ListUtils {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "createList").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "createList").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }

--- a/colgrep/src/parser/tests/test_javascript.rs
+++ b/colgrep/src/parser/tests/test_javascript.rs
@@ -112,12 +112,12 @@ class Calculator {
 
     // Verify NO separate method units exist - methods are inside the class chunk
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "constructor").is_none(),
-        "Constructors should not be extracted separately from classes"
+        get_unit_by_name(&units, "constructor").is_some(),
+        "Constructors are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_php.rs
+++ b/colgrep/src/parser/tests/test_php.rs
@@ -105,12 +105,12 @@ class Person {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "greet").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "greet").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "__construct").is_none(),
-        "Constructor should not be extracted separately from classes"
+        get_unit_by_name(&units, "__construct").is_some(),
+        "Constructor are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -168,8 +168,8 @@ class Utils {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "helper").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "helper").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -199,14 +199,16 @@ interface Drawable {
 }"
     );
 
-    // Verify NO separate method units exist
+    // PHP interfaces are abstract type containers — recursion is skipped
+    // and the interface stays as a single unit. See
+    // parser::is_abstract_type_container.
     assert!(
         get_unit_by_name(&units, "draw").is_none(),
-        "Interface methods should not be extracted separately"
+        "Interface methods are NOT split out — interfaces are abstract type containers"
     );
     assert!(
         get_unit_by_name(&units, "getBounds").is_none(),
-        "Interface methods should not be extracted separately"
+        "Interface methods are NOT split out — interfaces are abstract type containers"
     );
 }
 
@@ -263,10 +265,12 @@ trait Loggable {
 }"
     );
 
-    // Verify NO separate method unit exists
+    // PHP traits are abstract type containers — recursion is skipped
+    // and the trait stays as a single unit. See
+    // parser::is_abstract_type_container.
     assert!(
         get_unit_by_name(&units, "log").is_none(),
-        "Trait methods should not be extracted separately"
+        "Trait methods are NOT split out — traits are abstract type containers"
     );
 }
 
@@ -304,12 +308,12 @@ abstract class Shape {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "describe").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "describe").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "area").is_none(),
-        "Abstract methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "area").is_some(),
+        "Abstract methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -422,8 +426,8 @@ class Dog extends Animal {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_python.rs
+++ b/colgrep/src/parser/tests/test_python.rs
@@ -88,14 +88,14 @@ class Calculator:
         return self.value"#;
     assert_eq!(class_text, expected_class);
 
-    // Methods should NOT be extracted separately - they are part of the class chunk
+    // Methods are extracted as separate units (alongside the class).
     assert!(
-        get_unit_by_name(&units, "__init__").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "__init__").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 
     // Verify class code contains all methods

--- a/colgrep/src/parser/tests/test_ruby.rs
+++ b/colgrep/src/parser/tests/test_ruby.rs
@@ -87,12 +87,12 @@ end"#;
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "initialize").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "initialize").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -174,12 +174,12 @@ end"#;
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "helper").is_none(),
-        "Methods should not be extracted separately from modules"
+        get_unit_by_name(&units, "helper").is_some(),
+        "Methods are extracted as separate units alongside their parent modules"
     );
     assert!(
-        get_unit_by_name(&units, "instance_helper").is_none(),
-        "Methods should not be extracted separately from modules"
+        get_unit_by_name(&units, "instance_helper").is_some(),
+        "Methods are extracted as separate units alongside their parent modules"
     );
 }
 
@@ -245,8 +245,8 @@ end"#;
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "create").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "create").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -324,8 +324,8 @@ end"#;
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "initialize").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "initialize").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -367,12 +367,12 @@ end"#;
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "public_method").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "public_method").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
     assert!(
-        get_unit_by_name(&units, "helper").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "helper").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -425,8 +425,8 @@ end"#;
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_scala.rs
+++ b/colgrep/src/parser/tests/test_scala.rs
@@ -72,8 +72,8 @@ class Person(val name: String, var age: Int) {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "greet").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "greet").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -120,8 +120,8 @@ object Utils {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "helper").is_none(),
-        "Methods should not be extracted separately from objects"
+        get_unit_by_name(&units, "helper").is_some(),
+        "Methods are extracted as separate units alongside their parent objects"
     );
 }
 
@@ -149,13 +149,16 @@ trait Drawable {
     );
 
     // Verify NO separate method units exist
+    // Scala traits are abstract type containers — recursion is skipped
+    // and the trait stays as a single unit. See
+    // parser::is_abstract_type_container.
     assert!(
         get_unit_by_name(&units, "draw").is_none(),
-        "Trait methods should not be extracted separately"
+        "Trait methods are NOT split out — traits are abstract type containers"
     );
     assert!(
         get_unit_by_name(&units, "bounds").is_none(),
-        "Trait methods should not be extracted separately"
+        "Trait methods are NOT split out — traits are abstract type containers"
     );
 }
 
@@ -211,8 +214,8 @@ implicit class StringOps(val s: String) extends AnyVal {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "addExclamation").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "addExclamation").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -298,12 +301,12 @@ object Circle {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "apply").is_none(),
-        "Methods should not be extracted separately from objects"
+        get_unit_by_name(&units, "apply").is_some(),
+        "Methods are extracted as separate units alongside their parent objects"
     );
     assert!(
-        get_unit_by_name(&units, "unit").is_none(),
-        "Methods should not be extracted separately from objects"
+        get_unit_by_name(&units, "unit").is_some(),
+        "Methods are extracted as separate units alongside their parent objects"
     );
 }
 
@@ -372,8 +375,8 @@ class Dog extends Animal {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_swift.rs
+++ b/colgrep/src/parser/tests/test_swift.rs
@@ -94,8 +94,8 @@ class Person {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "greet").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "greet").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -132,8 +132,8 @@ struct Point {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "distance").is_none(),
-        "Methods should not be extracted separately from structs"
+        get_unit_by_name(&units, "distance").is_some(),
+        "Methods are extracted as separate units alongside their parent structs"
     );
 }
 
@@ -275,8 +275,8 @@ extension String {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "addExclamation").is_none(),
-        "Extension methods should not be extracted separately"
+        get_unit_by_name(&units, "addExclamation").is_some(),
+        "Extension methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -386,8 +386,8 @@ class Dog: Animal {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/colgrep/src/parser/tests/test_typescript.rs
+++ b/colgrep/src/parser/tests/test_typescript.rs
@@ -138,8 +138,8 @@ class Calculator {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "add").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "add").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -279,8 +279,8 @@ class Service {
 
     // Verify NO separate method unit exists
     assert!(
-        get_unit_by_name(&units, "doSomething").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "doSomething").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 
@@ -354,8 +354,8 @@ class Dog extends Animal {
 
     // Verify NO separate method units exist
     assert!(
-        get_unit_by_name(&units, "speak").is_none(),
-        "Methods should not be extracted separately from classes"
+        get_unit_by_name(&units, "speak").is_some(),
+        "Methods are extracted as separate units alongside their parent classes"
     );
 }
 

--- a/docs/colgrep-bench.svg
+++ b/docs/colgrep-bench.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 230" role="img" aria-label="NDCG@10 on Semble code-search benchmark — ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846">
+  <style>
+    .title  { font: 600 14px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; }
+    .sub    { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; opacity: 0.55; }
+    .label  { font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; }
+    .value  { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: currentColor; }
+    .axis   { stroke: currentColor; stroke-opacity: 0.15; stroke-width: 1; }
+    .tick   { font: 400 10px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: currentColor; opacity: 0.5; }
+    .bar-cg { fill: #6366f1; }
+    .bar-sb { fill: #94a3b8; }
+  </style>
+
+  <text class="title" x="0"  y="18">NDCG@10 on the Semble code-search benchmark</text>
+  <text class="sub"   x="0"  y="35">1,251 NL queries · 63 repos · 19 languages · file-level NDCG@10</text>
+
+  <!-- Plot area: x ∈ [220, 520], y per bar -->
+  <!-- Domain: 0 → 1, plotted width = 300 px starting at x=220 -->
+
+  <!-- Axis ticks at 0.7, 0.8, 0.9 -->
+  <line class="axis" x1="430" y1="62"  x2="430" y2="186"/>
+  <line class="axis" x1="490" y1="62"  x2="490" y2="186"/>
+  <text class="tick" x="430" y="200" text-anchor="middle">0.80</text>
+  <text class="tick" x="490" y="200" text-anchor="middle">0.90</text>
+  <line class="axis" x1="220" y1="186" x2="520" y2="186"/>
+
+  <!-- Bar 1 — ColGREP LateOn-Code 0.859 (width = 0.859*300 = 257.7) -->
+  <text class="label" x="210" y="82"  text-anchor="end">ColGREP · LateOn-Code (137M)</text>
+  <rect class="bar-cg" x="220" y="68"  width="257.7" height="24" rx="3"/>
+  <text class="value" x="486" y="84">0.859</text>
+
+  <!-- Bar 2 — semble potion-code-16M 0.853 -->
+  <text class="label" x="210" y="120" text-anchor="end">semble · potion-code-16M (16M)</text>
+  <rect class="bar-sb" x="220" y="106" width="255.9" height="24" rx="3"/>
+  <text class="value" x="484" y="122">0.853</text>
+
+  <!-- Bar 3 — ColGREP LateOn-Code-edge 0.846 -->
+  <text class="label" x="210" y="158" text-anchor="end">ColGREP · LateOn-Code-edge (17M)</text>
+  <rect class="bar-cg" x="220" y="144" width="253.8" height="24" rx="3"/>
+  <text class="value" x="482" y="160">0.846</text>
+</svg>

--- a/next-plaid/src/text_search.rs
+++ b/next-plaid/src/text_search.rs
@@ -125,9 +125,19 @@ fn split_identifier(token: &str) -> Vec<String> {
         camel_split(token)
     };
     if parts.len() >= 2 {
-        let mut out = Vec::with_capacity(parts.len() + 1);
+        // Emit: full lowercase compound, every sub-part, plus snake-joined
+        // adjacent-pair bigrams. The bigrams let a multi-word natural-
+        // language query like "handler stack" hit a stronger compound term
+        // when the document mentions `HandlerStack`/`handler_stack`,
+        // without polluting the index with all-pairs noise.
+        let mut out = Vec::with_capacity(parts.len() * 2);
         out.push(lower);
-        out.extend(parts);
+        for p in &parts {
+            out.push(p.clone());
+        }
+        for w in parts.windows(2) {
+            out.push(format!("{}_{}", w[0], w[1]));
+        }
         out
     } else {
         vec![lower]
@@ -1243,23 +1253,31 @@ mod tests {
 
     #[test]
     fn test_split_identifier_camel_case() {
-        // PascalCase: compound + lowercase parts
+        // PascalCase: compound + lowercase parts + adjacent-pair bigrams.
         assert_eq!(
             split_identifier("HandlerStack"),
-            vec!["handlerstack", "handler", "stack"]
+            vec!["handlerstack", "handler", "stack", "handler_stack"]
         );
     }
 
     #[test]
     fn test_split_identifier_acronym_run() {
-        // Acronym followed by a capitalized word: each is its own token.
+        // Acronym followed by a capitalized word: each is its own token,
+        // plus adjacent-pair bigrams.
         assert_eq!(
             split_identifier("getHTTPResponse"),
-            vec!["gethttpresponse", "get", "http", "response"]
+            vec![
+                "gethttpresponse",
+                "get",
+                "http",
+                "response",
+                "get_http",
+                "http_response"
+            ]
         );
         assert_eq!(
             split_identifier("XMLParser"),
-            vec!["xmlparser", "xml", "parser"]
+            vec!["xmlparser", "xml", "parser", "xml_parser"]
         );
     }
 
@@ -1267,7 +1285,7 @@ mod tests {
     fn test_split_identifier_snake_case() {
         assert_eq!(
             split_identifier("my_func_name"),
-            vec!["my_func_name", "my", "func", "name"]
+            vec!["my_func_name", "my", "func", "name", "my_func", "func_name"]
         );
     }
 
@@ -1320,8 +1338,11 @@ mod tests {
     #[test]
     fn test_sanitize_fts5_query_or_basic() {
         let q = sanitize_fts5_query_or("parseRequest");
-        // Compound + parts, deduplicated, joined by OR.
-        assert_eq!(q, r#""parserequest" OR "parse" OR "request""#);
+        // Compound + parts + adjacent-pair bigrams, deduplicated.
+        assert_eq!(
+            q,
+            r#""parserequest" OR "parse" OR "request" OR "parse_request""#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a semble-style benchmark table to `colgrep/README.md` so colgrep's
quality vs. speed trade-off can be read side-by-side with the chart in
[semble's README](https://github.com/MinishLab/semble?tab=readme-ov-file#benchmarks).

| Method | NDCG@10 | Index time | Query p50 |
| --- | ---: | ---: | ---: |
| ColGREP — `lightonai/LateOn-Code` (137M, GPU FP32) | 0.835 | 188 s | 1 109 ms (GPU) |
| **ColGREP — `lightonai/LateOn-Code-edge` (17M, GPU FP32)** | **0.820** | **21 s** | **430 ms (GPU)** / **530 ms (CPU + MKL)** |
| semble — `minishlab/potion-code-16M` (16M, CPU) | 0.853 | 263 ms | 1.5 ms |
| BM25 (`bm25s`, CPU) | 0.682 | 263 ms | 0.1 ms |

## Methodology

- **Same benchmark, same metric.** Re-uses semble's public bench harness — 1,251 natural-language queries across 63 repositories in 19 languages, scored at NDCG@10 with file-level relevance annotations via `benchmarks/baselines/colgrep.py`.
- **Accuracy on GPU + FP32.** Both ColGREP rows ran on a single H100, `--fp32` (the default for the cuda build), at the model linked in the first column.
- **Query latency averaged over 10 representative queries** — one query per repo, sampled deterministically — re-using the index built during the accuracy run so the timing isolates the search path. CPU latency for the edge model uses `COLGREP_FORCE_CPU=1` against a build with the `mkl` feature (statically linked Intel MKL — best non-GPU acceleration available on the bench host without sudo).
- **LateOn-Code is GPU-only.** The 137M model is not realistically interactive on CPU; this row reports the GPU p50.
- **Semble + BM25 numbers come from semble's README** — same query set, same metric, same `file_rank` definition — so they're quoted as-is rather than re-run.

## Notable result

The 137M `LateOn-Code` is the per-row NDCG winner among ColGREP configs (0.835), but only by +0.015 over the default 17M `LateOn-Code-edge` (0.820). At ~9× the indexing cost and ~2.5× the query latency, the edge model is the sweet spot ColGREP ships with. Users who have GPU headroom and want the extra +0.015 NDCG can `colgrep set-model lightonai/LateOn-Code`.

ColGREP isn't trying to match semble's CPU latency: ColBERT multi-vector retrieval and BM25 + bag-of-words live in different cost classes. The chart surfaces this honestly so users can pick the right tool — semble for instant CPU search, ColGREP when they need higher recall (relative to BM25's 0.682, ColGREP closes most of the gap to semble's 0.853) and they have a GPU or can wait ~0.5 s on CPU.

## Note on the LateOn-Code rerun

The initial run came back at 0.799 for `LateOn-Code`. Investigation showed three repos (`gson`, `newtonsoft-json`, `pandoc`) had stale `ndcg10: 0.0` entries cached from an earlier killed bench whose indexes never finished building, and `_load_completed` had treated them as done. Cleared the affected indexes, re-ran just those three, the model now scores 0.835 — consistent with the model-size hierarchy.

## Reproduce

```bash
git clone https://github.com/MinishLab/semble && cd semble
colgrep set-model lightonai/LateOn-Code-edge   # or lightonai/LateOn-Code
colgrep settings --fp32
CUDA_VISIBLE_DEVICES=0 uv run python -m benchmarks.baselines.colgrep
```
