### PR TITLE
README: theme-aware bench chart, moved to end of ColGREP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@
 
 Semantic code search for your terminal and your coding agents. Searches combine regex filtering with semantic ranking. All local, your code never leaves your machine.
 
-<p align="center">
-  <img width="560" src="docs/colgrep-bench.svg" alt="NDCG@10 on the Semble code-search benchmark: ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846"/>
-</p>
-
 ### Quick start
 
 Install:
@@ -145,6 +141,17 @@ def fetch_with_retry(url: str, max_retries: int = 3) -> Response:
 This structured input gives the model richer signal than raw code alone.
 
 **Documentation:** install variants, performance tuning, all flags and options → [ColGREP documentation](colgrep/README.md)
+
+### Benchmark
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/colgrep-bench-dark.svg">
+    <img width="560" src="docs/colgrep-bench-light.svg" alt="NDCG@10 on the Semble code-search benchmark — ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846">
+  </picture>
+</p>
+
+ColGREP on a single H100 GPU at FP32 against [Semble](https://github.com/MinishLab/semble)'s public bench — 1,251 NL queries × 63 repos × 19 languages.
 
 ---
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -23,10 +23,6 @@
 
 ## Benchmarks
 
-<p align="center">
-  <img width="560" src="../docs/colgrep-bench.svg" alt="NDCG@10 on the Semble code-search benchmark: ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846"/>
-</p>
-
 [Semble](https://github.com/MinishLab/semble)'s public bench — 1,251 NL queries × 63 repos × 19 languages — scored at NDCG@10 against file-level annotations. ColGREP runs on a single H100 GPU at FP32; `colgrep set-model lightonai/LateOn-Code` switches to the 137M big model.
 
 Reproduce:
@@ -36,6 +32,13 @@ git clone https://github.com/MinishLab/semble && cd semble
 colgrep set-model lightonai/LateOn-Code-edge   # or lightonai/LateOn-Code
 CUDA_VISIBLE_DEVICES=0 uv run python -m benchmarks.baselines.colgrep
 ```
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../docs/colgrep-bench-dark.svg">
+    <img width="560" src="../docs/colgrep-bench-light.svg" alt="NDCG@10 on the Semble code-search benchmark — ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846">
+  </picture>
+</p>
 
 ## Quick Start
 

--- a/docs/colgrep-bench-dark.svg
+++ b/docs/colgrep-bench-dark.svg
@@ -1,39 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 230" role="img" aria-label="NDCG@10 on Semble code-search benchmark — ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846">
   <style>
-    .title  { font: 600 14px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; }
-    .sub    { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; opacity: 0.55; }
-    .label  { font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: currentColor; }
-    .value  { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: currentColor; }
-    .axis   { stroke: currentColor; stroke-opacity: 0.15; stroke-width: 1; }
-    .tick   { font: 400 10px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: currentColor; opacity: 0.5; }
-    .bar-cg { fill: #6366f1; }
-    .bar-sb { fill: #94a3b8; }
+    .title  { font: 600 14px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #e5e7eb; }
+    .sub    { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #9ca3af; }
+    .label  { font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #e5e7eb; }
+    .value  { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #e5e7eb; }
+    .axis   { stroke: #4b5563; stroke-width: 1; }
+    .tick   { font: 400 10px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #6b7280; }
+    .bar-cg { fill: #818cf8; }
+    .bar-sb { fill: #64748b; }
   </style>
 
   <text class="title" x="0"  y="18">NDCG@10 on the Semble code-search benchmark</text>
   <text class="sub"   x="0"  y="35">1,251 NL queries · 63 repos · 19 languages · file-level NDCG@10</text>
 
-  <!-- Plot area: x ∈ [220, 520], y per bar -->
-  <!-- Domain: 0 → 1, plotted width = 300 px starting at x=220 -->
-
-  <!-- Axis ticks at 0.7, 0.8, 0.9 -->
   <line class="axis" x1="430" y1="62"  x2="430" y2="186"/>
   <line class="axis" x1="490" y1="62"  x2="490" y2="186"/>
   <text class="tick" x="430" y="200" text-anchor="middle">0.80</text>
   <text class="tick" x="490" y="200" text-anchor="middle">0.90</text>
   <line class="axis" x1="220" y1="186" x2="520" y2="186"/>
 
-  <!-- Bar 1 — ColGREP LateOn-Code 0.859 (width = 0.859*300 = 257.7) -->
   <text class="label" x="210" y="82"  text-anchor="end">ColGREP · LateOn-Code (137M)</text>
   <rect class="bar-cg" x="220" y="68"  width="257.7" height="24" rx="3"/>
   <text class="value" x="486" y="84">0.859</text>
 
-  <!-- Bar 2 — semble potion-code-16M 0.853 -->
   <text class="label" x="210" y="120" text-anchor="end">semble · potion-code-16M (16M)</text>
   <rect class="bar-sb" x="220" y="106" width="255.9" height="24" rx="3"/>
   <text class="value" x="484" y="122">0.853</text>
 
-  <!-- Bar 3 — ColGREP LateOn-Code-edge 0.846 -->
   <text class="label" x="210" y="158" text-anchor="end">ColGREP · LateOn-Code-edge (17M)</text>
   <rect class="bar-cg" x="220" y="144" width="253.8" height="24" rx="3"/>
   <text class="value" x="482" y="160">0.846</text>

--- a/docs/colgrep-bench-light.svg
+++ b/docs/colgrep-bench-light.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 230" role="img" aria-label="NDCG@10 on Semble code-search benchmark — ColGREP LateOn-Code 0.859, semble potion-code-16M 0.853, ColGREP LateOn-Code-edge 0.846">
+  <style>
+    .title  { font: 600 14px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #1f2937; }
+    .sub    { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #6b7280; }
+    .label  { font: 500 12px -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; fill: #1f2937; }
+    .value  { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #1f2937; }
+    .axis   { stroke: #d1d5db; stroke-width: 1; }
+    .tick   { font: 400 10px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9ca3af; }
+    .bar-cg { fill: #6366f1; }
+    .bar-sb { fill: #94a3b8; }
+  </style>
+
+  <text class="title" x="0"  y="18">NDCG@10 on the Semble code-search benchmark</text>
+  <text class="sub"   x="0"  y="35">1,251 NL queries · 63 repos · 19 languages · file-level NDCG@10</text>
+
+  <line class="axis" x1="430" y1="62"  x2="430" y2="186"/>
+  <line class="axis" x1="490" y1="62"  x2="490" y2="186"/>
+  <text class="tick" x="430" y="200" text-anchor="middle">0.80</text>
+  <text class="tick" x="490" y="200" text-anchor="middle">0.90</text>
+  <line class="axis" x1="220" y1="186" x2="520" y2="186"/>
+
+  <text class="label" x="210" y="82"  text-anchor="end">ColGREP · LateOn-Code (137M)</text>
+  <rect class="bar-cg" x="220" y="68"  width="257.7" height="24" rx="3"/>
+  <text class="value" x="486" y="84">0.859</text>
+
+  <text class="label" x="210" y="120" text-anchor="end">semble · potion-code-16M (16M)</text>
+  <rect class="bar-sb" x="220" y="106" width="255.9" height="24" rx="3"/>
+  <text class="value" x="484" y="122">0.853</text>
+
+  <text class="label" x="210" y="158" text-anchor="end">ColGREP · LateOn-Code-edge (17M)</text>
+  <rect class="bar-cg" x="220" y="144" width="253.8" height="24" rx="3"/>
+  <text class="value" x="482" y="160">0.846</text>
+</svg>


### PR DESCRIPTION
The single `docs/colgrep-bench.svg` shipped with GitHub's dark theme showing only the bars — `currentColor` doesn't resolve when an SVG is rendered inside an `<img>` tag (the tag is in its own document context with no inherited stroke/fill color), so the labels were effectively black-on-black.

Fix: ship two themed variants
  * docs/colgrep-bench-light.svg (gray-800 text, indigo + slate bars)
  * docs/colgrep-bench-dark.svg  (gray-200 text, brighter indigo + slate)

…and reference both via the `<picture>` element with `(prefers-color-scheme: dark)` — GitHub's standard pattern for theme-aware images. The `<img>` fallback inside `<picture>` is the light variant.

Placement
  * `README.md` (repo root): chart moved to the very end of the `## ColGREP` block, just before `---` and `## Why multi-vector?`, so the intro reads cleanly first and the benchmark land at the bottom of the section.
  * `colgrep/README.md`: chart moved to the end of the existing `## Benchmarks` section (text + reproduce snippet first, chart below).