### PR TITLE
Emit every matching line in regex mode (parity with grep)

### DIFF
--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -126,6 +126,48 @@ impl PatternMatcher {
             })
             .collect()
     }
+
+    /// Scan a file from disk for matching lines. Used by compact regex mode
+    /// so we don't miss matches in chunks that were merged into a leader
+    /// by `collapse_by_file` (the leader's `unit.code` only carries one
+    /// chunk's text). Returns 1-indexed `(line_number, line_content)`
+    /// pairs in source order.
+    fn find_matches_in_file(&self, file: &Path) -> Vec<(usize, String)> {
+        let content = match std::fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(_) => return Vec::new(),
+        };
+
+        let scan = |needle: &dyn Fn(&str) -> bool| -> Vec<(usize, String)> {
+            content
+                .lines()
+                .enumerate()
+                .filter_map(|(i, line)| {
+                    if needle(line) {
+                        Some((i + 1, line.to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        match self {
+            PatternMatcher::Regex(re) => {
+                let matches = scan(&|line| re.is_match(line));
+                if !matches.is_empty() {
+                    return matches;
+                }
+                // Literal fallback when the regex (often regex metacharacters
+                // a user meant literally) finds nothing.
+                let pattern_lower = re.as_str().to_lowercase();
+                scan(&|line| line.to_lowercase().contains(&pattern_lower))
+            }
+            PatternMatcher::Literal(pattern_lower) => {
+                scan(&|line| line.to_lowercase().contains(pattern_lower))
+            }
+        }
+    }
 }
 
 /// Strip regex special characters from a pattern for use in semantic queries.
@@ -543,36 +585,53 @@ pub fn cmd_search(
             });
 
             if let Some(ref matcher) = compact_matcher {
-                // Regex mode: print matching lines, capped at top_k total lines
-                let mut printed = 0usize;
+                // Regex mode: emit *every* matching line in each result file,
+                // not just the lines that happen to fall inside the leader
+                // chunk's `unit.code`. `collapse_by_file` merges multiple
+                // matching chunks of the same file into one leader and only
+                // keeps the leader's text, so a per-`unit.code` scan silently
+                // drops matches from the merged-in chunks (a `def foo` line
+                // at line 150 plus three comment hits at line 800+ would
+                // collapse to just one of those, depending on which chunk
+                // led the file).
+                //
+                // Scanning the file from disk keeps the line-count consistent
+                // with `grep` while preserving colgrep's score-based file
+                // ordering: results are already sorted by score, so the first
+                // occurrence of each file wins.
+                use std::collections::HashSet;
+
+                let mut seen: HashSet<PathBuf> = HashSet::new();
+                let mut per_file: Vec<(&colgrep::SearchResult, Vec<(usize, String)>)> = Vec::new();
                 let mut total_matches = 0usize;
+
                 for result in &results {
-                    let matching_lines = matcher.find_matches_in_unit(&result.unit);
-                    total_matches += matching_lines.len();
+                    if !seen.insert(result.unit.file.clone()) {
+                        continue;
+                    }
+                    let file_matches = matcher.find_matches_in_file(&result.unit.file);
+                    total_matches += file_matches.len();
+                    if !file_matches.is_empty() {
+                        per_file.push((result, file_matches));
+                    }
                 }
 
-                'outer: for result in &results {
+                let mut printed = 0usize;
+                'outer: for (result, matching_lines) in &per_file {
                     let file_path = display_path(&result.unit.file, use_relative);
-                    let matching_lines = matcher.find_matches_in_unit(&result.unit);
-                    for &match_line in &matching_lines {
+                    for (line_num, raw_line) in matching_lines {
                         if printed >= top_k {
                             break 'outer;
                         }
-                        let line_content = result
-                            .unit
-                            .code
-                            .lines()
-                            .nth(match_line - result.unit.line)
-                            .unwrap_or("")
-                            .trim();
+                        let trimmed = raw_line.trim();
                         let truncated: String =
-                            line_content.chars().take(COMPACT_LINE_MAX_CHARS).collect();
-                        let suffix = if line_content.chars().count() > COMPACT_LINE_MAX_CHARS {
+                            trimmed.chars().take(COMPACT_LINE_MAX_CHARS).collect();
+                        let suffix = if trimmed.chars().count() > COMPACT_LINE_MAX_CHARS {
                             "..."
                         } else {
                             ""
                         };
-                        println!("{}:{}:{}{}", file_path, match_line, truncated, suffix);
+                        println!("{}:{}:{}{}", file_path, line_num, truncated, suffix);
                         printed += 1;
                     }
                 }


### PR DESCRIPTION
## Summary

Compact regex mode (`colgrep -e <pattern>`) was silently dropping matches when multiple chunks of the same file collapsed into a single `SearchResult`. This PR makes regex emission scan the actual file from disk so output matches `grep` line-for-line, while leaving semantic-only output untouched.

## Root cause

`collapse_by_file` (src/index/mod.rs:3605) merges multiple matching chunks of the same file into one leader `SearchResult`, expanding `unit.line`/`unit.end_line` to span the whole region but **only keeping the leader chunk's `unit.code`**. Compact regex mode then scanned that one chunk's text via `find_matches_in_unit`, so matches living in the merged-in chunks were lost.

Concrete example on a 291-file repo, searching for `run_pipeline` (whole-word):

| File | grep hits | colgrep before | colgrep after |
|---|---|---|---|
| `run.py` | 4 (l. 64, 299, 339, 365) | 1 (l. 6 - a docstring) | 4 |
| `sources/indexer_daemon.py` | 7 | 1 | 7 |
| `sources/utils/index_health.py` | 5 | 1 | 5 |
| `scripts/reindex_broken.py` | 4 | 1 | 4 |
| ... | | | |
| **Total** | **38** | **19** | **38** |

## Change

Add `PatternMatcher::find_matches_in_file` that reads the file from disk and returns every `(line, content)` match (with the same literal-fallback semantics as `find_matches_in_unit`). Compact regex mode now:

1. Iterates `results` in score-descending order (already sorted upstream).
2. For each unique file, scans the file once and collects all matches.
3. Prints `file:line:content`, capped at `-k` total printed lines.

Semantic-only output path is unchanged: still emits `path:start-end` per chunk.

## Verified

On a 291-file mixed Python/Rust/JS repo (parity with `grep`):

- `-e run_pipeline -w`: **19 -> 38** matches (matches `grep`)
- `-e 'async fn' --include=*.rs`: **208** vs `grep`'s 208
- `-e 'Result<' --include=*.rs`: **103** vs `grep`'s 103
- `-e TODO -F` (case-insensitive): **10** vs `grep -i`'s 10
- Hybrid `-e 'fn .*auth' 'authentication'` still ranks by colgrep score
- Semantic-only output unchanged (`path:start-end` per chunk)
- 537/537 unit tests pass

## Test plan
- [x] Build with `cargo build --release`
- [x] `cargo test --release --lib` -> 537 passed
- [x] Manual stress test (counts above)
- [ ] Reviewer: run `colgrep -e <pattern>` on your own repo and confirm line counts match `grep -E`