### PR TITLE
Add --color=auto|always|never to control ANSI output (#81)

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+use crate::color::ColorChoice;
+
 pub const MAIN_HELP: &str = "\
 EXAMPLES:
     # Search for code semantically (auto-indexes if needed)
@@ -427,6 +429,16 @@ pub struct Cli {
     /// Automatically confirm indexing without prompting (for large codebases > 10K code units)
     #[arg(short = 'y', long = "yes")]
     pub auto_confirm: bool,
+
+    /// When to colorize output and syntax highlighting: auto, always, or never.
+    /// `never` emits plain text with no ANSI escape sequences (useful for agents/pipes).
+    #[arg(
+        long = "color",
+        value_name = "WHEN",
+        default_value = "auto",
+        global = true
+    )]
+    pub color: ColorChoice,
 
     /// Force CPU execution for all runtime paths
     #[arg(long = "force-cpu", global = true, conflicts_with = "force_gpu")]

--- a/colgrep/src/color.rs
+++ b/colgrep/src/color.rs
@@ -1,0 +1,108 @@
+//! Centralized control over colorized / ANSI output.
+//!
+//! colgrep emits color through two independent channels:
+//! 1. the `colored` crate (`.cyan()`, `.dimmed()`, …) for headers and line numbers, and
+//! 2. raw ANSI escapes from `syntect` syntax highlighting in [`crate::display`].
+//!
+//! `colored` honors its own override, but `syntect` does not — so without a single switch the
+//! two disagree and `NO_COLOR` can't fully strip escapes. This module resolves one decision
+//! from `--color` (plus the usual env vars) and applies it to *both* channels: it sets the
+//! `colored` override and records the result for the syntax highlighter to consult via
+//! [`colorize_enabled`].
+
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// When to colorize output. Mirrors grep/ripgrep's `--color` values.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum ColorChoice {
+    /// Colorize only when stdout is a terminal and no env var disables it.
+    #[default]
+    Auto,
+    /// Always colorize, even when piped or redirected.
+    Always,
+    /// Never colorize — emit plain text with no ANSI escape sequences.
+    Never,
+}
+
+/// Resolved decision, read by the syntax highlighter. Defaults to `true` so any output produced
+/// before [`init`] runs still matches the historical (always-colored) behavior.
+static COLOR_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Resolve `choice` into a single on/off decision and apply it everywhere.
+///
+/// Call once, early in `main`, before any output is produced.
+pub fn init(choice: ColorChoice) {
+    let enabled = match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => auto_detect(),
+    };
+
+    // Force the `colored` crate to the same decision so `.cyan()`/`.dimmed()` agree with the
+    // syntect path. Overriding even in `auto` keeps a single source of truth.
+    colored::control::set_override(enabled);
+    COLOR_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether colorized output (including syntax-highlight ANSI escapes) is enabled.
+pub fn colorize_enabled() -> bool {
+    COLOR_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Auto-detection for `--color=auto`, following the conventions shared by grep, ripgrep, and the
+/// `NO_COLOR`/`CLICOLOR` specs:
+/// - `CLICOLOR_FORCE` set to a non-empty, non-`0` value forces color on (even when piped);
+/// - otherwise `NO_COLOR` set to any non-empty value disables color;
+/// - otherwise `CLICOLOR=0` disables color;
+/// - otherwise color is on only when stdout is a terminal.
+fn auto_detect() -> bool {
+    if env_truthy("CLICOLOR_FORCE") {
+        return true;
+    }
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    if std::env::var("CLICOLOR").is_ok_and(|v| v == "0") {
+        return false;
+    }
+    std::io::stdout().is_terminal()
+}
+
+/// True when an env var is set to a non-empty value other than `"0"`.
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| !v.is_empty() && v != "0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_choice_is_auto() {
+        assert_eq!(ColorChoice::default(), ColorChoice::Auto);
+    }
+
+    #[test]
+    fn test_env_truthy() {
+        // env_truthy is pure w.r.t. its read; use a name unlikely to be set, set it locally.
+        std::env::set_var("COLGREP_TEST_TRUTHY", "1");
+        assert!(env_truthy("COLGREP_TEST_TRUTHY"));
+        std::env::set_var("COLGREP_TEST_TRUTHY", "0");
+        assert!(!env_truthy("COLGREP_TEST_TRUTHY"));
+        std::env::set_var("COLGREP_TEST_TRUTHY", "");
+        assert!(!env_truthy("COLGREP_TEST_TRUTHY"));
+        std::env::remove_var("COLGREP_TEST_TRUTHY");
+        assert!(!env_truthy("COLGREP_TEST_TRUTHY"));
+    }
+
+    #[test]
+    fn test_always_and_never_set_global() {
+        init(ColorChoice::Always);
+        assert!(colorize_enabled());
+        init(ColorChoice::Never);
+        assert!(!colorize_enabled());
+        // Restore a sane default for any later code in the same test binary.
+        init(ColorChoice::Always);
+    }
+}

--- a/colgrep/src/display.rs
+++ b/colgrep/src/display.rs
@@ -469,6 +469,45 @@ pub fn truncate_ansi_string(s: &str, max_width: usize) -> String {
     result
 }
 
+/// Truncate a plain (escape-free) string to a maximum visible width, appending "..." if cut.
+fn truncate_plain(s: &str, max_width: usize) -> String {
+    if s.chars().count() <= max_width {
+        return s.to_string();
+    }
+    let mut result: String = s.chars().take(max_width).collect();
+    result.push_str("...");
+    result
+}
+
+/// Print a range of lines as plain text (line number + code, no ANSI escapes).
+/// Used when color is disabled (`--color=never`, `NO_COLOR`, or a non-terminal stdout).
+/// Line numbers go through `.dimmed()`, which the `colored` override renders plain.
+fn print_plain_ranges(
+    lines: &[&str],
+    ranges: &[(usize, usize)],
+    unit_end: usize,
+    line_num_width: usize,
+) {
+    for (range_idx, &(start, end)) in ranges.iter().enumerate() {
+        let display_end = end.min(lines.len());
+        let display_start = start.min(lines.len());
+        if display_start >= lines.len() {
+            continue;
+        }
+        for (offset, line) in lines[display_start..display_end].iter().enumerate() {
+            let line_num = display_start + offset + 1;
+            println!(
+                "{} {}",
+                format!("{:>width$}", line_num, width = line_num_width).dimmed(),
+                truncate_plain(line.trim_end_matches('\n'), MAX_LINE_WIDTH)
+            );
+        }
+        if range_idx < ranges.len() - 1 || display_end < unit_end {
+            println!("{}", "...".dimmed());
+        }
+    }
+}
+
 /// Print content with syntax highlighting for multiple ranges
 pub fn print_highlighted_ranges(
     file_path: &Path,
@@ -477,6 +516,11 @@ pub fn print_highlighted_ranges(
     unit_end: usize,
     line_num_width: usize,
 ) {
+    if !crate::color::colorize_enabled() {
+        print_plain_ranges(lines, ranges, unit_end, line_num_width);
+        return;
+    }
+
     let ps = SyntaxSet::load_defaults_newlines();
     let ts = ThemeSet::load_defaults();
     let theme = &ts.themes["base16-ocean.dark"];
@@ -537,6 +581,24 @@ pub fn print_highlighted_content(
     end_line: usize,
     line_num_width: usize,
 ) {
+    let display_end = end_line.min(start_line.saturating_add(max_lines));
+    let truncated = end_line > display_end;
+
+    if !crate::color::colorize_enabled() {
+        for (i, line) in lines[start_line..display_end].iter().enumerate() {
+            let line_num = start_line + i + 1;
+            println!(
+                "{} {}",
+                format!("{:>width$}", line_num, width = line_num_width).dimmed(),
+                truncate_plain(line.trim_end_matches('\n'), MAX_LINE_WIDTH)
+            );
+        }
+        if truncated {
+            println!("{}", "...".dimmed());
+        }
+        return;
+    }
+
     let ps = SyntaxSet::load_defaults_newlines();
     let ts = ThemeSet::load_defaults();
     let theme = &ts.themes["base16-ocean.dark"];
@@ -549,9 +611,6 @@ pub fn print_highlighted_content(
         .unwrap_or_else(|| ps.find_syntax_plain_text());
 
     let mut highlighter = HighlightLines::new(syntax, theme);
-
-    let display_end = end_line.min(start_line.saturating_add(max_lines));
-    let truncated = end_line > display_end;
 
     // Reconstruct the content for highlighting
     let content_to_highlight: String = lines[start_line..display_end]

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod color;
 mod commands;
 mod display;
 mod scoring;
@@ -30,6 +31,11 @@ fn main() -> Result<()> {
     init_global_rayon_pool();
 
     let cli = Cli::parse();
+
+    // Resolve --color once, before any output, so both the `colored` crate and the syntect
+    // highlighter agree on whether to emit ANSI escapes.
+    color::init(cli.color);
+
     let env_mode = env_acceleration_mode()?;
     let acceleration_mode = if cli.force_cpu {
         AccelerationMode::ForceCpu


### PR DESCRIPTION
Closes #81.

## Problem

colgrep emits color through **two independent channels**:
1. the `colored` crate (`.cyan()` file headers, `.dimmed()` line numbers), and
2. raw ANSI escapes from `syntect` syntax highlighting in `display.rs`.

`colored` honors `NO_COLOR`, but **syntect doesn't** — so output always contained escape sequences regardless of `NO_COLOR`/`CLICOLOR`/`CLICOLOR_FORCE`/`TERM`. As @divaltor noted, that pollutes context for agents/plugins that consume the output directly rather than through a terminal.

## Change

A small `color` module resolves a single decision from `--color` and applies it to **both** channels:
- sets the `colored` crate override (so every `.cyan()`/`.dimmed()` obeys), and
- records the result for the syntect path to consult via `colorize_enabled()`.

`display.rs` now prints plain, line-numbered text (no syntect, no `\x1b[0m`) when color is off.

```
--color auto     # default: color only on a TTY, honoring NO_COLOR / CLICOLOR / CLICOLOR_FORCE
--color always   # force color even when piped
--color never    # plain text, zero ANSI escapes
```

The flag is **global**, so it works on every subcommand (`colgrep --color never ...`, `colgrep search --color never ...`, etc.). Env handling in `auto`: `CLICOLOR_FORCE` (non-empty, non-`0`) forces on; else `NO_COLOR` (non-empty) disables; else `CLICOLOR=0` disables; else colorize only on a TTY. An explicit `--color always/never` always wins.

A nice side effect: because `auto` now respects the TTY, **piped output is plain by default** too — which is the behavior @divaltor originally expected from `NO_COLOR`.

## Testing

Unit tests for the env/auto-detection and the global toggle. End-to-end (verbose `-c` path, which is what triggers syntax highlighting), counting actual ESC (`0x1b`) bytes in captured output:

| Invocation | ESC bytes |
|---|---|
| `--color never` | **0** |
| default `auto`, piped (non-TTY) | **0** |
| `NO_COLOR=1` (auto) | **0** |
| user's exact repro + `--color never` | **0** |
| `--color always` | 1047 |
| `CLICOLOR_FORCE=1` (auto, piped) | >0 |
| `NO_COLOR=1 --color always` | >0 (explicit wins) |

Plain output keeps line numbers and content intact; `cargo fmt`/`clippy`/full colgrep test suite (541 lib + 55 bin) green.

## Note on the follow-up ask
The issue also floated *"might add an option to disable line numbers."* I kept this PR scoped to color since that's the titled request and what the maintainer comment committed to; happy to add `--no-line-numbers` in a follow-up if wanted.