### PR TITLE
Reject embedding dims where dim*nbits isn't a multiple of 8 (instead of panicking)

### DIFF
--- a/next-plaid/src/codec.rs
+++ b/next-plaid/src/codec.rs
@@ -363,8 +363,23 @@ impl ResidualCodec {
 
         let n = residuals.nrows();
         let dim = residuals.ncols();
-        let packed_dim = dim * self.nbits / 8;
         let nbits = self.nbits;
+
+        // The bit-packing layout stores exactly `8 / nbits` dimensions per byte, and the
+        // decompress path reads whole bytes, so the codec only supports dimensions where
+        // `dim * nbits` is a multiple of 8 (true for real ColBERT dims such as 96 or 128).
+        // For other dims, `packed_dim` would floor-divide below the number of bits actually
+        // written, and the packing loop indexed past the end of the row — previously a
+        // worker-thread panic ("index out of bounds"). Reject it up front with a clear error.
+        if dim != 0 && !(dim * nbits).is_multiple_of(8) {
+            return Err(Error::Codec(format!(
+                "unsupported embedding dimension {dim} for nbits={nbits}: \
+                 dim * nbits ({}) must be a multiple of 8",
+                dim * nbits
+            )));
+        }
+
+        let packed_dim = dim * nbits / 8;
 
         if n == 0 {
             return Ok(Array2::zeros((0, packed_dim)));
@@ -749,5 +764,51 @@ mod tests {
 
         let codes = codec.compress_into_codes_cpu(&embeddings);
         assert_eq!(codes[0], 1);
+    }
+
+    /// Build a 4-bit codec (16 buckets) for quantization tests.
+    fn codec_4bit(dim: usize) -> ResidualCodec {
+        let bucket_cutoffs: Vec<f32> = (1..16).map(|i| (i as f32 / 16.0 - 0.5) * 2.0).collect();
+        let bucket_weights: Vec<f32> = (0..16)
+            .map(|i| ((i as f32 + 0.5) / 16.0 - 0.5) * 2.0)
+            .collect();
+        ResidualCodec::new(
+            4,
+            Array2::zeros((4, dim)),
+            Array1::zeros(dim),
+            Some(Array1::from_vec(bucket_cutoffs)),
+            Some(Array1::from_vec(bucket_weights)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn quantize_rejects_unaligned_dim_instead_of_panicking() {
+        // dim * nbits must be a multiple of 8. dim=3, nbits=4 -> 12 bits, not byte-aligned;
+        // this previously panicked with an out-of-bounds index deep inside a worker thread.
+        let codec = codec_4bit(3);
+        let residuals =
+            Array2::from_shape_vec((2, 3), vec![0.1, -0.2, 0.3, -0.4, 0.5, -0.6]).unwrap();
+
+        let result = codec.quantize_residuals(&residuals);
+        assert!(result.is_err(), "unaligned dim must return Err, not panic");
+        let msg = format!("{:?}", result.err().unwrap());
+        assert!(
+            msg.contains("multiple of 8"),
+            "error should explain the constraint, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn quantize_accepts_byte_aligned_dim() {
+        // dim=2, nbits=4 -> 8 bits = exactly one byte. Valid even though 2 isn't a
+        // multiple of 8: the guard checks dim * nbits, not dim alone.
+        let codec = codec_4bit(2);
+        let residuals = Array2::from_shape_vec((2, 2), vec![0.1, -0.2, 0.3, -0.4]).unwrap();
+
+        let packed = codec
+            .quantize_residuals(&residuals)
+            .expect("byte-aligned dim should quantize");
+        assert_eq!(packed.ncols(), 1); // 2 * 4 / 8 = 1 byte per row
     }
 }


### PR DESCRIPTION
## Problem

Found while testing #86: posting documents with embeddings whose dimension makes `dim * nbits` **not a multiple of 8** (e.g. a 3-dim toy embedding with `nbits=4`) crashed the indexing worker with a panic:

```
thread '<unnamed>' panicked at next-plaid/src/codec.rs:393:
index out of bounds: the len is 1 but the index is 1
```

`ResidualCodec::quantize_residuals` computes `packed_dim = dim * nbits / 8` (**floor** division) but the packing loop writes `dim * nbits` bits = `ceil(dim*nbits/8)` bytes. When `dim * nbits` isn't a multiple of 8, `packed_dim` is one byte too small and the loop indexes past the end of the row. The bit-packing format stores exactly `8 / nbits` dimensions per byte (and `decompress` reads whole bytes), so the codec **fundamentally only supports** dims where `dim * nbits % 8 == 0` — always true for real ColBERT dims (96, 128), but a panic for arbitrary inputs.

The panic happened deep inside a rayon worker, taking down the indexing task. Via the API (post-#104) it showed up as a panicked update batch rather than a normal error.

## Fix

Validate the constraint at the top of `quantize_residuals` and return a descriptive `Error::Codec` instead of writing out of bounds:

```
unsupported embedding dimension 3 for nbits=4: dim * nbits (12) must be a multiple of 8
```

This is a defensive hardening — it does **not** change the on-disk format or behavior for supported dims. (Supporting arbitrary dims would require a packing/unpacking format rewrite for partial trailing bytes, which isn't needed for real models.)

## Verification

- New unit tests: `quantize_rejects_unaligned_dim_instead_of_panicking` (dim=3 → `Err`, no panic) and `quantize_accepts_byte_aligned_dim` (dim=2, since `2*4=8` is valid even though 2 isn't a multiple of 8 — the guard checks `dim * nbits`, not `dim`).
- End-to-end through the API: re-running the original 3-dim/2-token `/update` now logs `update.batch.failed … Codec error: unsupported embedding dimension 3 …` with **0 panics**, and the server stays healthy (and the failure surfaces in `/health` via #104's failed-status tracking).
- Full `make ci-quick` green (fmt, clippy `-D warnings`, tests).