### PR TITLE
Add a Nix flake with packages for colgrep and a devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,166 @@
+{
+  description = "colgrep";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [ "x86_64-linux" ];
+      forAllSystems = lib.genAttrs systems;
+
+      pkgsFor = { system, cudaSupport, cudaCapabilities ? [] }:
+        import nixpkgs {
+          inherit system;
+          config = {
+            inherit cudaSupport cudaCapabilities;
+            allowUnfree = cudaSupport;
+            cudaForwardCompat = true;
+          };
+        };
+
+      mkColgrep = pkgs:
+        let
+          cudaSupport = pkgs.config.cudaSupport or false;
+          runtimeLibraryPath = lib.makeLibraryPath ([
+            pkgs.onnxruntime
+          ] ++ lib.optionals cudaSupport [
+            pkgs.linuxPackages.nvidia_x11
+            pkgs.cudaPackages.cudatoolkit
+            pkgs.cudaPackages.cudnn
+          ]);
+        in
+        pkgs.rustPlatform.buildRustPackage {
+          __structuredAttrs = true;
+          strictDeps = true;
+          
+          pname = "colgrep";
+          version = (lib.importTOML ./Cargo.toml).workspace.package.version;
+
+          src = ./.;
+
+          buildAndTestSubdir = "colgrep";
+          cargoLock.lockFile = ./Cargo.lock;
+
+          buildNoDefaultFeatures = true;
+          buildFeatures = lib.optionals cudaSupport [ "cuda" ];
+          doCheck = false;
+
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.makeWrapper
+          ];
+
+          buildInputs = [
+            pkgs.onnxruntime
+            pkgs.openssl
+            pkgs.curl
+          ] ++ lib.optionals cudaSupport [
+            pkgs.linuxPackages.nvidia_x11
+            pkgs.cudaPackages.cudatoolkit
+            pkgs.cudaPackages.cudnn
+          ];
+
+          env = {
+            ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+            ORT_PREFER_DYNAMIC_LINK = "1";
+            ORT_SKIP_DOWNLOAD = "1";
+          } // lib.optionalAttrs cudaSupport {
+            CUDA_HOME = "${pkgs.cudaPackages.cudatoolkit}";
+            CUDA_PATH = "${pkgs.cudaPackages.cudatoolkit}";
+          };
+
+          postFixup = ''
+            wrapProgram $out/bin/colgrep \
+              --prefix LD_LIBRARY_PATH : ${runtimeLibraryPath} \
+              --set-default ORT_DYLIB_PATH ${pkgs.onnxruntime}/lib/libonnxruntime.so \
+              --set-default ORT_LIB_LOCATION ${pkgs.onnxruntime}/lib \
+              --set-default ORT_PREFER_DYNAMIC_LINK 1 \
+              --set-default ORT_SKIP_DOWNLOAD 1
+          '';
+
+          meta = {
+            description = "Semantic code search powered by ColBERT";
+            homepage = "https://github.com/lightonai/next-plaid/tree/main/colgrep";
+            license = lib.licenses.asl20;
+            mainProgram = "colgrep";
+          };
+        };
+
+      mkDevShell = pkgs:
+        let
+          cudaSupport = pkgs.config.cudaSupport or false;
+          libraryPath = lib.makeLibraryPath ([
+            pkgs.onnxruntime
+          ] ++ lib.optionals cudaSupport [
+            pkgs.linuxPackages.nvidia_x11
+            pkgs.cudaPackages.cudatoolkit
+            pkgs.cudaPackages.cudnn
+          ]);
+        in
+        pkgs.mkShell {
+          packages = [
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.rustfmt
+            pkgs.clippy
+            pkgs.pkg-config
+            pkgs.onnxruntime
+            pkgs.openssl
+            pkgs.curl
+          ] ++ lib.optionals cudaSupport [
+            pkgs.cudaPackages.cudatoolkit
+            pkgs.cudaPackages.cudnn
+          ];
+
+          env = {
+            ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+            ORT_PREFER_DYNAMIC_LINK = "1";
+            ORT_SKIP_DOWNLOAD = "1";
+          } // lib.optionalAttrs cudaSupport {
+            CUDA_HOME = "${pkgs.cudaPackages.cudatoolkit}";
+            CUDA_PATH = "${pkgs.cudaPackages.cudatoolkit}";
+            RUSTFLAGS = "-L native=${pkgs.linuxPackages.nvidia_x11}/lib";
+          };
+
+          shellHook = ''
+            export LD_LIBRARY_PATH="${libraryPath}:''${LD_LIBRARY_PATH:-}"
+          '';
+        };
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = pkgsFor { inherit system; cudaSupport = false; };
+          pkgsCuda = pkgsFor { inherit system; cudaSupport = true; };
+        in
+        {
+          colgrep = mkColgrep pkgs;
+          colgrep-cuda = mkColgrep pkgsCuda;
+
+          default = self.packages.${system}.colgrep;
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = pkgsFor { inherit system; cudaSupport = false; };
+          pkgsCuda = pkgsFor { inherit system; cudaSupport = true; };
+        in
+        {
+          default = mkDevShell pkgs;
+          cuda = mkDevShell pkgsCuda;
+        });
+
+      lib = {
+        mkPackagesWithCudaCapabilities = capabilities: forAllSystems (system:
+          let
+            pkgs = pkgsFor { inherit system; cudaSupport = true; cudaCapabilities = capabilities; };
+          in
+          {
+            colgrep = mkColgrep pkgs;
+          });
+      };
+    };
+}


### PR DESCRIPTION
Adds a basic `flake.nix` which provides:

- `colgrep` and `colgrep-cuda` packages
- A dev shell with the necessary environment to build colgrep
- A library function to build special packages set (only colgrep for now) with a specific cuda capabilities set, using the existing nix cuda pattern

This can be used by developers to quickly obtain a development environment using Nix, and can be used like so to add a specific colgrep package to a flake-based Nix environment like NixOS, home-manager, etc like so:

```nix
inputs = {
   // ...
   next-plaid = {
       url = "github:lightonai/next-plaid";
       inputs.nixpkgs.follows = "nixpkgs";
   };
};

outputs = inputs@{ self, nixpkgs, ... }:
let
    nextplaid-pkgs = (input.next-plaid.lib.mkPackagesWithCudaCapabilities [ "7.5" ]).${system};
in
{
    // ...
    // or wherever else packages are specified in one's config
    home.packages = [
        // ...
        nextplaid-pkgs.colgrep
    ];
};
```

It currently uses a semi-ugly wrapper style where we just inject environment variables. Ideally, the Rust packages that pull in the libs that need this wrapping (onnx-runtime, cuda libs) could be modified to allow link-time dynamic linking for these, which would then allow Nix's RPATH patching to let them link against the location of the libs in the Nix store without the need for wrapping with env vars. But, this isn't necessarily the end of the world for now.