### PR TITLE
feat(index): log resume progress when continuing an interrupted build

### DIFF
--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -1735,6 +1735,16 @@ impl IndexBuilder {
             .cloned()
             .collect();
 
+        // A prior run already committed some files — resume from there rather than re-embedding
+        // them. The committed files are excluded from `todo` above, so they are never recomputed.
+        if !state.files.is_empty() {
+            eprintln!(
+                "📋 Resuming interrupted build: {} files already indexed, {} remaining",
+                state.files.len(),
+                todo.len()
+            );
+        }
+
         // Parse the remaining files (cheap relative to embedding) and build the call graph
         // over them so `called_by` is populated for this build's units.
         let pb = ProgressBar::new(todo.len() as u64);


### PR DESCRIPTION
## Summary

When a resumable build resumes after an interruption (timeout, Ctrl-C, crash), it now prints a one-line summary of how much work is being skipped:

```
📋 Resuming interrupted build: 100 files already indexed, 200 remaining
```

The already-committed files are excluded from the `todo` set in `build_resumable`, so they are never re-parsed or re-embedded. Previously a resume looked identical to a fresh build from the outside, which made it hard to tell that prior work was being reused. This just surfaces the existing behavior.

## Why

Came out of verifying the resumable-build guarantee end-to-end. I generated a ~12,000-unit synthetic repo (300 files) and interrupted indexing mid-build, both ways:

| Interrupt | Committed at cut | After resume | Re-encoded on resume |
|---|---|---|---|
| **SIGKILL** (hard crash) | 100 files / 4,100 docs | 300 files / 12,300 docs | only the 200 remaining files |
| **SIGINT** (graceful Ctrl-C) | 100 files / 4,100 docs | 300 files / 12,300 docs | only the 200 remaining files |

In both cases:
- The resume re-embedded **only** the not-yet-committed files — the 100 already-committed files were skipped entirely.
- The fully-committed chunk files were left **byte-identical** across the resume (only the trailing *partial* chunk was reopened to append new docs).
- The final index was **identical to a clean full build** — same file count (300) and document count (12,300), no duplication, no loss — and searched correctly.

So the build correctly resumes from the last checkpoint and never recomputes committed work.

## Testing

- `cargo build -p colgrep`, `cargo fmt`/`clippy -D warnings` clean (pre-commit CI passed)
- Manual SIGKILL + SIGINT interrupt/resume cycles as above