### PR TITLE
fix(colgrep): redirect subdirectory init/status to parent index

### DIFF
--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -44,15 +44,21 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);
 
-    // Check if index already exists (for the currently selected model)
-    let has_existing_index =
-        index_exists(&path, &model) || find_parent_index(&path, &model)?.is_some();
+    // Check if path is inside an already-indexed parent project
+    let parent_info = find_parent_index(&path, &model)?;
+    let effective_root = match &parent_info {
+        Some(info) => info.project_path.clone(),
+        None => path.clone(),
+    };
+
+    // Check if index already exists for the effective root
+    let has_existing_index = index_exists(&effective_root, &model);
 
     // Ensure model is downloaded
     let model_path = ensure_model(Some(&model), has_existing_index)?;
 
     let mut builder = IndexBuilder::with_options(
-        &path,
+        &effective_root,
         &model,
         &model_path,
         quantized,
@@ -72,18 +78,30 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
 
     let changes = stats.added + stats.changed + stats.deleted;
     if changes > 0 {
-        eprintln!(
-            "Indexed {} (added: {}, changed: {}, deleted: {}, unchanged: {})",
-            path.display(),
-            stats.added,
-            stats.changed,
-            stats.deleted,
-            stats.unchanged,
-        );
+        if let Some(ref info) = parent_info {
+            eprintln!(
+                "Indexed {} (subdir: {}) (added: {}, changed: {}, deleted: {}, unchanged: {})",
+                info.project_path.display(),
+                info.relative_subdir.display(),
+                stats.added,
+                stats.changed,
+                stats.deleted,
+                stats.unchanged,
+            );
+        } else {
+            eprintln!(
+                "Indexed {} (added: {}, changed: {}, deleted: {}, unchanged: {})",
+                effective_root.display(),
+                stats.added,
+                stats.changed,
+                stats.deleted,
+                stats.unchanged,
+            );
+        }
     } else {
         eprintln!(
             "Index is up to date for {} ({} files)",
-            path.display(),
+            effective_root.display(),
             stats.unchanged
         );
     }

--- a/colgrep/src/commands/status.rs
+++ b/colgrep/src/commands/status.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-use colgrep::{get_index_dir_for_project, index_exists, Config, DEFAULT_MODEL};
+use colgrep::{find_parent_index, get_index_dir_for_project, index_exists, Config, DEFAULT_MODEL};
 
 pub fn cmd_status(path: &PathBuf) -> Result<()> {
     let path = std::fs::canonicalize(path)?;
@@ -12,14 +12,29 @@ pub fn cmd_status(path: &PathBuf) -> Result<()> {
         .and_then(|c| c.get_default_model().map(|s| s.to_string()))
         .unwrap_or_else(|| DEFAULT_MODEL.to_string());
 
-    if !index_exists(&path, &model) {
+    let direct_exists = index_exists(&path, &model);
+    let parent_info = if !direct_exists {
+        find_parent_index(&path, &model)?
+    } else {
+        None
+    };
+
+    if !direct_exists && parent_info.is_none() {
         println!("No index found for {} [{}]", path.display(), model);
         println!("Run `colgrep <query>` to create one.");
         return Ok(());
     }
 
-    let index_dir = get_index_dir_for_project(&path, &model)?;
+    let (_display_path, index_dir) = match &parent_info {
+        Some(info) => (info.project_path.clone(), info.index_dir.clone()),
+        None => (path.clone(), get_index_dir_for_project(&path, &model)?),
+    };
+
     println!("Project: {}", path.display());
+    if let Some(ref info) = parent_info {
+        println!("  Parent project: {}", info.project_path.display());
+        println!("  Subdirectory:   {}", info.relative_subdir.display());
+    }
     println!("Model:   {}", model);
     println!("Index:   {}", index_dir.display());
     println!();

--- a/colgrep/src/commands/status.rs
+++ b/colgrep/src/commands/status.rs
@@ -25,15 +25,18 @@ pub fn cmd_status(path: &PathBuf) -> Result<()> {
         return Ok(());
     }
 
-    let (_display_path, index_dir) = match &parent_info {
-        Some(info) => (info.project_path.clone(), info.index_dir.clone()),
-        None => (path.clone(), get_index_dir_for_project(&path, &model)?),
+    let index_dir = match &parent_info {
+        Some(info) => info.index_dir.clone(),
+        None => get_index_dir_for_project(&path, &model)?,
     };
 
-    println!("Project: {}", path.display());
     if let Some(ref info) = parent_info {
-        println!("  Parent project: {}", info.project_path.display());
-        println!("  Subdirectory:   {}", info.relative_subdir.display());
+        // Running from a subdirectory: show the actual indexed project first,
+        // then where the user is within it.
+        println!("Project: {}", info.project_path.display());
+        println!("  Subdirectory: {}", info.relative_subdir.display());
+    } else {
+        println!("Project: {}", path.display());
     }
     println!("Model:   {}", model);
     println!("Index:   {}", index_dir.display());


### PR DESCRIPTION
When colgrep init or colgrep status was run from a subdirectory of an already-indexed project, the subdirectory path was passed directly to the IndexBuilder, causing a completely new and separate index to be created (init) or reporting 'No index found' (status).

Now both commands check for an existing parent index via find_parent_index() and redirect operations to the parent project root, matching the pattern already used by search_single_path().

- init: uses effective_root from parent project path for IndexBuilder
- status: falls back to find_parent_index when direct lookup fails
- Display messages show parent project and subdirectory relationship when redirecting

Disclaimer: This commit was authored with assistance from an LLM.