### PR TITLE
feat(colgrep): honor XDG_DATA_HOME on macOS

### DIFF
--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -515,6 +515,8 @@ Indexes are stored outside the project directory:
 | macOS    | `~/Library/Application Support/colgrep/indices/` |
 | Windows  | `%APPDATA%\colgrep\indices\`                     |
 
+`XDG_DATA_HOME` is honored on all platforms, including macOS — set it to keep your colgrep data under `~/.local/share` (or anywhere else) on macOS too.
+
 Each project gets a directory named `{project}-{hash8}`. Inside:
 
 - `index/` &mdash; PLAID vector index + SQLite metadata

--- a/colgrep/src/index/paths.rs
+++ b/colgrep/src/index/paths.rs
@@ -62,6 +62,19 @@ impl ProjectMetadata {
     }
 }
 
+/// Base data directory, honoring `XDG_DATA_HOME` on all platforms (including
+/// macOS, where `dirs::data_dir()` ignores it by design — see
+/// <https://codeberg.org/dirs/dirs-rs/issues/56>).
+/// Falls back to `dirs::data_dir()` (platform default) when unset or empty.
+pub fn xdg_data_home_or_default() -> Result<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg));
+        }
+    }
+    dirs::data_dir().context("Could not determine data directory")
+}
+
 /// Get the base colgrep data directory (XDG_DATA_HOME/colgrep or platform equivalent).
 ///
 /// Honours the `COLGREP_DATA_DIR` env var so concurrent benchmark
@@ -73,8 +86,7 @@ pub fn get_colgrep_data_dir() -> Result<PathBuf> {
             return Ok(PathBuf::from(env_dir));
         }
     }
-    let data_dir = dirs::data_dir().context("Could not determine data directory")?;
-    Ok(data_dir.join("colgrep").join("indices"))
+    Ok(xdg_data_home_or_default()?.join("colgrep").join("indices"))
 }
 
 /// Compute the index directory name for a (project_path, model) pair.

--- a/colgrep/src/install/claude_code.rs
+++ b/colgrep/src/install/claude_code.rs
@@ -24,8 +24,9 @@ use super::SKILL_MD;
 
 /// Get the marketplace directory path (in user's data directory)
 fn get_marketplace_dir() -> Result<PathBuf> {
-    let data_dir = dirs::data_dir().context("Could not determine data directory")?;
-    Ok(data_dir.join("colgrep").join("claude-marketplace"))
+    Ok(crate::index::paths::xdg_data_home_or_default()?
+        .join("colgrep")
+        .join("claude-marketplace"))
 }
 
 /// Create the full marketplace directory structure with all files

--- a/colgrep/src/install/uninstall.rs
+++ b/colgrep/src/install/uninstall.rs
@@ -11,8 +11,7 @@ use super::{uninstall_claude_code, uninstall_codex, uninstall_hermes, uninstall_
 
 /// Get the colgrep data directory (contains indices and config)
 fn get_colgrep_data_dir() -> Result<PathBuf> {
-    let data_dir = dirs::data_dir().context("Could not determine data directory")?;
-    Ok(data_dir.join("colgrep"))
+    Ok(crate::index::paths::xdg_data_home_or_default()?.join("colgrep"))
 }
 
 /// Get the colgrep cache directory (contains ONNX runtime)


### PR DESCRIPTION
Hi,

This is a follow-up on Issue #123 which I opened because the `dirs` crate intentionally ignores XDG env vars on macOS (see codeberg.org/dirs/dirs-rs/issues/56), so colgrep's index, marketplace, and uninstall paths landed under `~/Library/Application Support` regardless of `XDG_DATA_HOME`. As I mentioned in the issue, _preventing_ the use of XDG goes way beyond anything Apple mentions, let alone recommends, and as the `README` and env-var table already advertised `XDG_DATA_HOME` as supported, I reached out!

In practice, I added a small helper in `index::paths` that returns the XDG value when set and falls back to `dirs::data_dir()` otherwise, and simply route the three `dirs::data_dir()` call sites through it so the index location, the Claude Code marketplace dir, and the uninstall sweep all agree.

Closes #123

Thanks!

PS: tests pass (with cargo nextest run), and I get the expected behavior locally:

```console
ls ~/.local/share/colgrep/indices/
tmux-copyrat-5171936c
```