### PR TITLE
Remove redundant per-search and per-release work from colgrep indexing

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -430,6 +430,10 @@ pub struct Cli {
     #[arg(short = 'y', long = "yes")]
     pub auto_confirm: bool,
 
+    /// Skip the automatic index update and search the existing index as-is
+    #[arg(long = "no-update")]
+    pub no_update: bool,
+
     /// When to colorize output and syntax highlighting: auto, always, or never.
     /// `never` emits plain text with no ANSI escape sequences (useful for agents/pipes).
     #[arg(
@@ -549,6 +553,10 @@ pub enum Commands {
         /// Use strict batch-size batching instead of fixed dynamic GPU batching
         #[arg(long = "static-batch")]
         static_batch: bool,
+
+        /// Skip the automatic index update and search the existing index as-is
+        #[arg(long = "no-update")]
+        no_update: bool,
     },
 
     /// Show index status for a project

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -36,10 +36,10 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
         anyhow::bail!("Path is not a directory: {}", path.display());
     }
 
-    let model = resolve_model(options.cli_model);
-    let pool_factor = resolve_pool_factor(options.pool_factor, options.no_pool);
-
     let config = Config::load().unwrap_or_default();
+    let model = resolve_model(&config, options.cli_model);
+    let pool_factor = resolve_pool_factor(&config, options.pool_factor, options.no_pool);
+
     let quantized = !config.use_fp32();
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -557,6 +557,7 @@ pub fn cmd_search(
     pool_factor: Option<usize>,
     auto_confirm: bool,
     static_batch: bool,
+    no_update: bool,
 ) -> Result<()> {
     // Resolve context_lines: CLI > config > default (20)
     let context_lines = resolve_context_lines(cli_context_lines, 20);
@@ -601,6 +602,7 @@ pub fn cmd_search(
             pool_factor,
             auto_confirm,
             static_batch,
+            no_update,
         ) {
             Ok(results) => all_results.extend(results),
             Err(e) => {
@@ -1052,6 +1054,7 @@ fn search_single_path(
     pool_factor: Option<usize>,
     auto_confirm: bool,
     static_batch: bool,
+    no_update: bool,
 ) -> Result<Vec<colgrep::SearchResult>> {
     let path = match std::fs::canonicalize(path) {
         Ok(p) => p,
@@ -1143,8 +1146,10 @@ fn search_single_path(
 
     // Auto-index: try incremental update without blocking on the lock.
     // If another process is indexing, skip the update and search the existing index.
+    // --no-update skips this entirely: agents in hot search loops can opt out of
+    // paying the change-detection scan and any re-encoding before results return.
     let mut index_locked = false;
-    {
+    if !no_update {
         let mut builder = IndexBuilder::with_options(
             &effective_root,
             &model,
@@ -1231,6 +1236,12 @@ fn search_single_path(
     let index_dir = get_index_dir_for_project(&effective_root, &model)?;
     let vector_index_path = get_vector_index_path(&index_dir);
     if !vector_index_path.join("metadata.json").exists() {
+        if no_update {
+            anyhow::bail!(
+                "No index found and --no-update was passed. Run once without --no-update \
+                 (or `colgrep init`) to build the index first."
+            );
+        }
         if index_locked {
             // Index is being created for the first time by another process — nothing to search yet
             anyhow::bail!("colgrep index is currently being built, rely on grep for now.");
@@ -1306,6 +1317,12 @@ fn search_single_path(
             } =>
         {
             // Index is corrupted or empty (no concurrent updater) - clear and rebuild
+            if no_update {
+                return Err(e).with_context(|| {
+                    "Index appears corrupted and --no-update prevents rebuilding it. \
+                     Rerun without --no-update to repair the index."
+                });
+            }
             if !json && !files_only {
                 eprintln!("⚠️  Index corrupted, rebuilding...");
             }

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -360,60 +360,31 @@ fn merge_query_with_pattern(query: &str, sanitized_pattern: &str) -> String {
 }
 
 /// Resolve the model to use: CLI arg > saved config > default
-pub fn resolve_model(cli_model: Option<&str>) -> String {
+pub fn resolve_model(config: &Config, cli_model: Option<&str>) -> String {
     if let Some(model) = cli_model {
         return model.to_string();
     }
 
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(model) = config.get_default_model() {
-            return model.to_string();
-        }
+    if let Some(model) = config.get_default_model() {
+        return model.to_string();
     }
 
-    // Fall back to default
     DEFAULT_MODEL.to_string()
 }
 
 /// Resolve top_k: CLI arg > saved config > default
-pub fn resolve_top_k(cli_k: Option<usize>, default: usize) -> usize {
-    if let Some(k) = cli_k {
-        return k;
-    }
-
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(k) = config.get_default_k() {
-            return k;
-        }
-    }
-
-    default
+pub fn resolve_top_k(config: &Config, cli_k: Option<usize>, default: usize) -> usize {
+    cli_k.or_else(|| config.get_default_k()).unwrap_or(default)
 }
 
 /// Resolve context_lines (n): CLI arg > saved config > default
-pub fn resolve_context_lines(cli_n: Option<usize>, default: usize) -> usize {
-    if let Some(n) = cli_n {
-        return n;
-    }
-
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(n) = config.get_default_n() {
-            return n;
-        }
-    }
-
-    default
+pub fn resolve_context_lines(config: &Config, cli_n: Option<usize>, default: usize) -> usize {
+    cli_n.or_else(|| config.get_default_n()).unwrap_or(default)
 }
 
 /// Resolve relative_paths: saved config > default (true = relative paths)
-pub fn resolve_relative_paths() -> bool {
-    if let Ok(config) = Config::load() {
-        return config.use_relative_paths();
-    }
-    true
+pub fn resolve_relative_paths(config: &Config) -> bool {
+    config.use_relative_paths()
 }
 
 /// Format a path for display, using relative or absolute based on config.
@@ -483,11 +454,8 @@ fn normalize_windows_path(path: &Path) -> PathBuf {
 }
 
 /// Resolve verbose: saved config > default (false)
-pub fn resolve_verbose() -> bool {
-    if let Ok(config) = Config::load() {
-        return config.is_verbose();
-    }
-    false
+pub fn resolve_verbose(config: &Config) -> bool {
+    config.is_verbose()
 }
 
 /// Deterministic ordering for search results: highest score first, then a
@@ -514,7 +482,11 @@ fn cmp_results_deterministic(
 }
 
 /// Resolve pool_factor: --no-pool > --pool-factor > config > default (2)
-pub fn resolve_pool_factor(cli_pool_factor: Option<usize>, no_pool: bool) -> Option<usize> {
+pub fn resolve_pool_factor(
+    config: &Config,
+    cli_pool_factor: Option<usize>,
+    no_pool: bool,
+) -> Option<usize> {
     if no_pool {
         return Some(1); // Disable pooling
     }
@@ -523,21 +495,15 @@ pub fn resolve_pool_factor(cli_pool_factor: Option<usize>, no_pool: bool) -> Opt
         return Some(factor.max(1)); // Minimum is 1
     }
 
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        return Some(config.get_pool_factor());
-    }
-
-    // Default pool factor
-    Some(colgrep::DEFAULT_POOL_FACTOR)
+    Some(config.get_pool_factor())
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_search(
     query: &str,
     paths: &[PathBuf],
-    top_k: usize,
-    top_k_explicit: bool,
+    cli_top_k: Option<usize>,
+    default_k: usize,
     cli_model: Option<&str>,
     json: bool,
     include_patterns: &[String],
@@ -554,22 +520,30 @@ pub fn cmd_search(
     code_only: bool,
     no_fts: bool,
     alpha: Option<f32>,
-    pool_factor: Option<usize>,
+    cli_pool_factor: Option<usize>,
+    no_pool: bool,
     auto_confirm: bool,
     static_batch: bool,
     no_update: bool,
 ) -> Result<()> {
+    // Load the user config once for the whole command; every per-path search
+    // and resolver below reads from this snapshot instead of re-parsing the
+    // config file.
+    let config = Config::load().unwrap_or_default();
+
+    let top_k = resolve_top_k(&config, cli_top_k, default_k);
+    let pool_factor = resolve_pool_factor(&config, cli_pool_factor, no_pool);
     // Resolve context_lines: CLI > config > default (20)
-    let context_lines = resolve_context_lines(cli_context_lines, 20);
+    let context_lines = resolve_context_lines(&config, cli_context_lines, 20);
     // Resolve relative paths: config > default (false = absolute)
-    let use_relative = resolve_relative_paths();
+    let use_relative = resolve_relative_paths(&config);
 
     // When -e is used and the user didn't explicitly pass -k, return *all*
     // matching lines (parity with grep, which has no implicit cap). We keep
     // a finite ceiling so the upstream `top_k * 4` / `top_k * 20` multipliers
     // can't overflow; `usize::MAX / 1024` is still ~1.8e16, effectively
     // unbounded for any real index.
-    let regex_unbounded = text_pattern.is_some() && !top_k_explicit;
+    let regex_unbounded = text_pattern.is_some() && cli_top_k.is_none();
     let effective_top_k = if regex_unbounded {
         usize::MAX / 1024
     } else {
@@ -582,6 +556,7 @@ pub fn cmd_search(
 
     for path in paths {
         match search_single_path(
+            &config,
             query,
             path,
             effective_top_k,
@@ -674,7 +649,7 @@ pub fn cmd_search(
         let verbose = if show_content || cli_context_lines.is_some_and(|n| n > 0) {
             true // Force verbose when user explicitly requests content display
         } else {
-            resolve_verbose()
+            resolve_verbose(&config)
         };
 
         // Maximum characters of matching line content to show in compact mode
@@ -1034,6 +1009,7 @@ fn find_existing_parent_and_list(path: &Path) -> String {
 /// Search a single path and return results with absolute file paths
 #[allow(clippy::too_many_arguments)]
 fn search_single_path(
+    config: &Config,
     query: &str,
     path: &PathBuf,
     top_k: usize,
@@ -1081,10 +1057,7 @@ fn search_single_path(
     let effective_extended_regexp = extended_regexp || (text_pattern.is_some() && !fixed_strings);
 
     // Resolve model: CLI > config > default
-    let model = resolve_model(cli_model);
-
-    // Load config for settings
-    let config = Config::load().unwrap_or_default();
+    let model = resolve_model(config, cli_model);
 
     // Resolve quantized setting from config (default: false = use FP32)
     let quantized = !config.use_fp32();
@@ -1517,7 +1490,6 @@ fn search_single_path(
     let search_top_k = if code_only { top_k * 4 } else { top_k * 3 };
 
     // Resolve hybrid search: --semantic-only CLI flag overrides, then config, default is enabled
-    let config = colgrep::Config::load().unwrap_or_default();
     let hybrid_disabled = if no_fts {
         true
     } else {
@@ -1691,35 +1663,32 @@ mod tests {
     #[test]
     fn test_resolve_top_k_cli_provided() {
         // CLI value should take precedence
-        assert_eq!(resolve_top_k(Some(30), 15), 30);
-        assert_eq!(resolve_top_k(Some(1), 20), 1);
-        assert_eq!(resolve_top_k(Some(100), 15), 100);
+        let config = Config::default();
+        assert_eq!(resolve_top_k(&config, Some(30), 15), 30);
+        assert_eq!(resolve_top_k(&config, Some(1), 20), 1);
+        assert_eq!(resolve_top_k(&config, Some(100), 15), 100);
     }
 
     #[test]
     fn test_resolve_top_k_fallback_to_default() {
-        // When CLI not provided and no config, should use default
-        // Note: This test may be affected by actual config file
-        let result = resolve_top_k(None, 15);
-        // Should be either 25 (default) or whatever is in config
-        assert!(result > 0);
+        // When CLI not provided and config has no value, use the default
+        assert_eq!(resolve_top_k(&Config::default(), None, 15), 15);
     }
 
     // Test resolve_context_lines function
     #[test]
     fn test_resolve_context_lines_cli_provided() {
         // CLI value should take precedence
-        assert_eq!(resolve_context_lines(Some(10), 20), 10);
-        assert_eq!(resolve_context_lines(Some(0), 20), 0);
-        assert_eq!(resolve_context_lines(Some(30), 20), 30);
+        let config = Config::default();
+        assert_eq!(resolve_context_lines(&config, Some(10), 20), 10);
+        assert_eq!(resolve_context_lines(&config, Some(0), 20), 0);
+        assert_eq!(resolve_context_lines(&config, Some(30), 20), 30);
     }
 
     #[test]
     fn test_resolve_context_lines_fallback_to_default() {
-        // When CLI not provided and no config, should use default
-        let result = resolve_context_lines(None, 20);
-        // Should be either 20 (default) or whatever is in config
-        assert!(result <= 100); // sanity check
+        // When CLI not provided and config has no value, use the default
+        assert_eq!(resolve_context_lines(&Config::default(), None, 20), 20);
     }
 
     fn mk_result(file: &str, line: usize, end_line: usize, score: f32) -> colgrep::SearchResult {

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1065,16 +1065,16 @@ fn search_single_path(
     let parallel_sessions = config.configured_parallel_sessions();
     let batch_size = config.configured_batch_size();
 
-    // Check if index already exists for this model (suppress model output if so)
-    let has_existing_index =
-        index_exists(&search_path, &model) || find_parent_index(&search_path, &model)?.is_some();
-
-    // Ensure model is downloaded (quiet if we already have an index)
-    let model_path = ensure_model(Some(&model), has_existing_index)?;
-
-    // Check for parent index (scoped to current model) unless the resolved path
-    // is outside the current directory (external project)
-    let parent_info = {
+    // An index for this exact (path, model) pair takes precedence over any
+    // ancestor project's index, so the parent scan — a read_dir plus a
+    // project.json parse for every indexed project on the machine — runs only
+    // when there is no local index, and at most once per search. The parent
+    // scan is also skipped when the resolved path is outside the current
+    // directory (external project).
+    let local_index_exists = index_exists(&search_path, &model);
+    let parent_info = if local_index_exists {
+        None
+    } else {
         let current_dir = std::env::current_dir().ok();
         let is_external_project = is_external_project_path(&search_path, current_dir.as_deref());
 
@@ -1084,6 +1084,10 @@ fn search_single_path(
             find_parent_index(&search_path, &model)?
         }
     };
+
+    // Ensure model is downloaded (quiet if we already have an index)
+    let has_existing_index = local_index_exists || parent_info.is_some();
+    let model_path = ensure_model(Some(&model), has_existing_index)?;
 
     // Determine effective project root and subdirectory filter
     let (effective_root, subdir_filter): (PathBuf, Option<PathBuf>) = match &parent_info {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2201,9 +2201,18 @@ impl IndexBuilder {
             }
         }
 
-        // 0. Clean up orphaned entries (files in index but not on disk)
-        // This handles directory deletion/rename and any inconsistencies
-        let orphaned_deleted = self.cleanup_orphaned_entries(index_path)?;
+        // 0. Clean up orphaned entries (files in index but not on disk).
+        // This handles directory deletion/rename and any inconsistencies, but it
+        // queries every distinct file in the metadata DB and stats each one — too
+        // expensive to run on every search. Deletions in the plan already cover the
+        // common case; the periodic trigger is a safety net for true desyncs.
+        let should_cleanup = !plan.deleted.is_empty()
+            || (old_state.search_count > 0 && old_state.search_count % 50 == 0);
+        let orphaned_deleted = if should_cleanup {
+            self.cleanup_orphaned_entries(index_path)?
+        } else {
+            0
+        };
 
         // Nothing to do
         if plan.added.is_empty()
@@ -2680,6 +2689,19 @@ impl IndexBuilder {
                 continue;
             }
             let full_path = self.project_root.join(path);
+
+            // Fast path: if mtime is unchanged, skip expensive content hashing.
+            // Without this gate every search reads and hashes every file in the
+            // repo before returning results.
+            if let Some(info) = state.files.get(path) {
+                if let Ok(current_mtime) = get_mtime(&full_path) {
+                    if info.mtime == current_mtime {
+                        plan.unchanged += 1;
+                        continue;
+                    }
+                }
+            }
+
             let hash = match hash_file(&full_path) {
                 Ok(h) => h,
                 Err(e) => {
@@ -4182,6 +4204,119 @@ fn prompt_large_index_confirmation(num_units: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The mtime fast path in `compute_update_plan` must skip content hashing
+    /// for files whose stored mtime is unchanged. The stored hash is wrong on
+    /// purpose: if the plan still reports the file as unchanged, hashing was
+    /// skipped; once the mtime moves, the hash mismatch must be detected.
+    /// Regression test — this gate was added in d0423d9 (4x query speedup on
+    /// large repos) and silently lost in the d76cb4a rewrite.
+    #[test]
+    fn test_update_plan_skips_hashing_when_mtime_unchanged() {
+        let temp = tempfile::tempdir().unwrap();
+        let file_path = temp.path().join("lib.py");
+        std::fs::write(&file_path, "def f():\n    return 1\n").unwrap();
+
+        let builder = test_builder(temp.path(), &temp.path().join("index"));
+
+        let mut state = IndexState::default();
+        state.files.insert(
+            PathBuf::from("lib.py"),
+            FileInfo {
+                content_hash: 0xDEAD_BEEF,
+                mtime: get_mtime(&file_path).unwrap(),
+            },
+        );
+
+        let plan = builder.compute_update_plan(&state, None).unwrap();
+        assert_eq!(
+            plan.unchanged, 1,
+            "matching mtime must skip the content-hash comparison"
+        );
+        assert!(plan.changed.is_empty());
+
+        // Move the mtime forward: the fast path no longer applies, so the
+        // stale stored hash must now be detected as a change.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&file_path)
+            .unwrap();
+        file.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(120))
+            .unwrap();
+        drop(file);
+
+        let plan = builder.compute_update_plan(&state, None).unwrap();
+        assert_eq!(plan.changed, vec![PathBuf::from("lib.py")]);
+        assert_eq!(plan.unchanged, 0);
+    }
+
+    /// Measures what the mtime fast path saves on the per-search update plan:
+    /// the same synthetic tree planned once with matching stored mtimes
+    /// (stat-only fast path) and once with mismatched mtimes but identical
+    /// content (forces a read + xxh3 of every byte — what every search paid
+    /// without the fast path). Hashing runs with a warm page cache, so the
+    /// printed ratio understates the cold-cache real world.
+    ///
+    ///   cargo test -p colgrep --release measure_update_plan -- --ignored --nocapture
+    #[test]
+    #[ignore = "timing measurement; run manually in release mode"]
+    fn measure_update_plan_mtime_fast_path() {
+        const FILES: usize = 5_000;
+        const FILE_BYTES: usize = 200 * 1024;
+
+        let temp = tempfile::tempdir().unwrap();
+        let line = "x = 1  # padding so the hasher does representative work\n";
+        let blob = line.repeat(FILE_BYTES / line.len());
+
+        let mut matching_mtimes = IndexState::default();
+        let mut mismatched_mtimes = IndexState::default();
+        for i in 0..FILES {
+            let rel = PathBuf::from(format!("mod_{i:04}.py"));
+            let full = temp.path().join(&rel);
+            std::fs::write(&full, &blob).unwrap();
+            let content_hash = hash_file(&full).unwrap();
+            let mtime = get_mtime(&full).unwrap();
+            matching_mtimes
+                .files
+                .insert(rel.clone(), FileInfo { content_hash, mtime });
+            mismatched_mtimes.files.insert(
+                rel,
+                FileInfo {
+                    content_hash,
+                    mtime: mtime + 1,
+                },
+            );
+        }
+
+        let builder = test_builder(temp.path(), &temp.path().join("index"));
+
+        let started = std::time::Instant::now();
+        let plan = builder.compute_update_plan(&mismatched_mtimes, None).unwrap();
+        let hashed_every_file = started.elapsed();
+        assert_eq!(plan.unchanged, FILES);
+
+        let started = std::time::Instant::now();
+        let plan = builder.compute_update_plan(&matching_mtimes, None).unwrap();
+        let stat_only = started.elapsed();
+        assert_eq!(plan.unchanged, FILES);
+
+        // The walk scales with file count and is paid either way; the
+        // read+hash component the fast path removes scales with repo bytes.
+        let removed = hashed_every_file.saturating_sub(stat_only);
+        println!(
+            "update plan, {} files x {} KiB ({} MiB total):\n  \
+             full hashing (pre-fix per-search cost): {:?}\n  \
+             mtime fast path:                        {:?}  ({:.1}x faster)\n  \
+             read+hash component removed per search: {:?} (scales with repo bytes)",
+            FILES,
+            FILE_BYTES / 1024,
+            FILES * FILE_BYTES / (1024 * 1024),
+            hashed_every_file,
+            stat_only,
+            hashed_every_file.as_secs_f64() / stat_only.as_secs_f64().max(f64::EPSILON),
+            removed,
+        );
+    }
 
     #[test]
     fn test_glob_simple_extension() {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -977,6 +977,17 @@ impl IndexBuilder {
         self.dynamic_batch = dynamic_batch;
     }
 
+    /// Default session count for an encoding workload of `num_units` units.
+    /// Each ONNX session pays a full graph parse/optimize/allocate on build, so
+    /// spinning up the machine-wide default (up to 16) to encode a handful of
+    /// changed units costs far more in session builds than it saves in
+    /// parallelism. One session per DEFAULT_ENCODE_BATCH_SIZE units amortizes
+    /// the build cost; explicit user configuration bypasses this cap.
+    fn capped_default_sessions(num_units: usize) -> usize {
+        let max_useful_sessions = num_units.div_ceil(DEFAULT_ENCODE_BATCH_SIZE).max(1);
+        crate::config::get_default_cpu_parallel_sessions().min(max_useful_sessions)
+    }
+
     /// Ensure the model is created for encoding.
     /// The model is lazily created on first use to avoid overhead when just scanning files
     /// or when checking for index updates that have no changes.
@@ -1000,7 +1011,7 @@ impl IndexBuilder {
 
                         (
                             self.parallel_sessions
-                                .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
+                                .unwrap_or_else(|| Self::capped_default_sessions(num_units)),
                             ExecutionProvider::Cpu,
                         )
                     }
@@ -1049,9 +1060,8 @@ impl IndexBuilder {
                             )
                         } else {
                             (
-                                self.parallel_sessions.unwrap_or_else(
-                                    crate::config::get_default_cpu_parallel_sessions,
-                                ),
+                                self.parallel_sessions
+                                    .unwrap_or_else(|| Self::capped_default_sessions(num_units)),
                                 ExecutionProvider::Cpu,
                             )
                         }
@@ -1065,14 +1075,12 @@ impl IndexBuilder {
                 feature = "coreml"
             )))]
             let (num_sessions, execution_provider) = {
-                let _ = num_units;
-
                 crate::onnx_runtime::ensure_onnx_runtime()
                     .context("Failed to initialize ONNX Runtime")?;
 
                 (
                     self.parallel_sessions
-                        .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
+                        .unwrap_or_else(|| Self::capped_default_sessions(num_units)),
                     ExecutionProvider::Cpu,
                 )
             };
@@ -1080,8 +1088,6 @@ impl IndexBuilder {
             #[cfg(any(feature = "directml", feature = "migraphx", feature = "coreml"))]
             #[cfg(not(feature = "cuda"))]
             let (num_sessions, execution_provider) = {
-                let _ = num_units;
-
                 crate::onnx_runtime::ensure_onnx_runtime()
                     .context("Failed to initialize ONNX Runtime")?;
 
@@ -1095,7 +1101,7 @@ impl IndexBuilder {
 
                 (
                     self.parallel_sessions
-                        .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
+                        .unwrap_or_else(|| Self::capped_default_sessions(num_units)),
                     provider,
                 )
             };

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -175,6 +175,12 @@ const POOLED_EMBEDDING_QUEUE_CAPACITY: usize = 4;
 /// (just unit refs + doc IDs, no embedding data).
 const METADATA_QUEUE_CAPACITY: usize = 8;
 
+/// Maximum documents accumulated on the update path before flushing to the
+/// PLAID index. Each flush rewrites the full IVF and invalidates the merged
+/// mmap files (O(index size) regardless of batch size), so bigger batches mean
+/// fewer full-index rewrites; the cap bounds the embeddings held in memory.
+const UPDATE_FLUSH_DOC_LIMIT: usize = 8192;
+
 struct ParsedFileResult {
     path: PathBuf,
     units: Vec<CodeUnit>,
@@ -535,20 +541,67 @@ fn run_index_stage(
         return Ok(());
     }
 
-    while let Ok(chunk) = receiver.recv() {
-        let _guard = CriticalSectionGuard::new();
-        let (_, doc_ids) =
-            MmapIndex::update_or_create(&chunk.embeddings, &index_path, &config, &update_config)?;
+    // Update path: accumulate pipeline chunks and flush in large batches.
+    // Every MmapIndex::update_or_create call rewrites the full IVF and deletes
+    // the merged mmap files no matter how few documents it adds, so its cost is
+    // O(index size) per call. Flushing once per UPDATE_FLUSH_DOC_LIMIT documents
+    // instead of once per pipeline chunk means a typical incremental update pays
+    // that cost exactly once.
+    let mut pending_units: Vec<Arc<CodeUnit>> = Vec::new();
+    let mut pending_embeddings: Vec<ndarray::Array2<f32>> = Vec::new();
 
-        sender
-            .send(IndexedChunkForMetadata {
-                units: chunk.units,
-                doc_ids,
-            })
-            .context("Failed to send indexed chunk to metadata stage")?;
+    while let Ok(chunk) = receiver.recv() {
+        pending_units.extend(chunk.units);
+        pending_embeddings.extend(chunk.embeddings);
+
+        if pending_embeddings.len() >= UPDATE_FLUSH_DOC_LIMIT {
+            flush_update_batch(
+                &mut pending_units,
+                &mut pending_embeddings,
+                &sender,
+                &index_path,
+                &config,
+                &update_config,
+            )?;
+        }
     }
 
+    flush_update_batch(
+        &mut pending_units,
+        &mut pending_embeddings,
+        &sender,
+        &index_path,
+        &config,
+        &update_config,
+    )?;
+
     Ok(())
+}
+
+/// Write one accumulated batch to the PLAID index and hand the assigned doc IDs
+/// to the metadata stage. No-op when the batch is empty.
+fn flush_update_batch(
+    units: &mut Vec<Arc<CodeUnit>>,
+    embeddings: &mut Vec<ndarray::Array2<f32>>,
+    sender: &mpsc::SyncSender<IndexedChunkForMetadata>,
+    index_path: &str,
+    config: &IndexConfig,
+    update_config: &UpdateConfig,
+) -> Result<()> {
+    if embeddings.is_empty() {
+        return Ok(());
+    }
+
+    let _guard = CriticalSectionGuard::new();
+    let (_, doc_ids) = MmapIndex::update_or_create(embeddings, index_path, config, update_config)?;
+    embeddings.clear();
+
+    sender
+        .send(IndexedChunkForMetadata {
+            units: std::mem::take(units),
+            doc_ids,
+        })
+        .context("Failed to send indexed chunk to metadata stage")
 }
 
 /// Number of candidates exactly re-ranked with MaxSim after the cheap

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2278,7 +2278,7 @@ impl IndexBuilder {
         // expensive to run on every search. Deletions in the plan already cover the
         // common case; the periodic trigger is a safety net for true desyncs.
         let should_cleanup = !plan.deleted.is_empty()
-            || (old_state.search_count > 0 && old_state.search_count % 50 == 0);
+            || (old_state.search_count > 0 && old_state.search_count.is_multiple_of(50));
         let orphaned_deleted = if should_cleanup {
             self.cleanup_orphaned_entries(index_path)?
         } else {
@@ -4347,9 +4347,13 @@ mod tests {
             std::fs::write(&full, &blob).unwrap();
             let content_hash = hash_file(&full).unwrap();
             let mtime = get_mtime(&full).unwrap();
-            matching_mtimes
-                .files
-                .insert(rel.clone(), FileInfo { content_hash, mtime });
+            matching_mtimes.files.insert(
+                rel.clone(),
+                FileInfo {
+                    content_hash,
+                    mtime,
+                },
+            );
             mismatched_mtimes.files.insert(
                 rel,
                 FileInfo {
@@ -4362,7 +4366,9 @@ mod tests {
         let builder = test_builder(temp.path(), &temp.path().join("index"));
 
         let started = std::time::Instant::now();
-        let plan = builder.compute_update_plan(&mismatched_mtimes, None).unwrap();
+        let plan = builder
+            .compute_update_plan(&mismatched_mtimes, None)
+            .unwrap();
         let hashed_every_file = started.elapsed();
         assert_eq!(plan.unchanged, FILES);
 
@@ -5217,9 +5223,16 @@ mod tests {
         // the reconstruct path sees the on-disk file as unchanged.
         let stats = builder.run_indexing(None, false).unwrap();
 
-        assert_eq!(stats.unchanged, 1, "file must be recognized, not re-embedded");
+        assert_eq!(
+            stats.unchanged, 1,
+            "file must be recognized, not re-embedded"
+        );
         let state = IndexState::load(idx.path()).unwrap();
-        assert_eq!(state.files.len(), 1, "state must be reconstructed from the DB");
+        assert_eq!(
+            state.files.len(),
+            1,
+            "state must be reconstructed from the DB"
+        );
         assert_eq!(state.index_format_version, INDEX_FORMAT_VERSION);
     }
 }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -32,7 +32,7 @@ use paths::{
     acquire_index_lock, get_index_dir_for_project, get_vector_index_path, try_acquire_index_lock,
     ProjectMetadata,
 };
-use state::{get_mtime, hash_file, FileInfo, IndexState};
+use state::{get_mtime, hash_file, FileInfo, IndexState, INDEX_FORMAT_VERSION};
 
 /// Maximum file size to index (512 KB)
 /// Files larger than this are skipped to avoid:
@@ -126,8 +126,8 @@ fn delete_files_from_index(index_path: &str, files: &[PathBuf]) -> Result<usize>
 ///   whole. See issue #115.
 /// - `metadata.json` present and a filtering DB present (rules out absent/stale-format stores
 ///   that `index()` would discard anyway).
-/// - State loads, is non-empty, matches the current CLI version, and isn't dirty.
-fn seed_source_state(src_dir: &Path, current_version: &str) -> Option<IndexState> {
+/// - State loads, is non-empty, has a compatible index format, and isn't dirty.
+fn seed_source_state(src_dir: &Path) -> Option<IndexState> {
     if src_dir.join(BUILDING_MARKER).exists() {
         return None;
     }
@@ -139,7 +139,13 @@ fn seed_source_state(src_dir: &Path, current_version: &str) -> Option<IndexState
     }
 
     match IndexState::load(src_dir) {
-        Ok(s) if !s.files.is_empty() && s.cli_version == current_version && !s.dirty => Some(s),
+        Ok(s)
+            if !s.files.is_empty()
+                && s.index_format_version == INDEX_FORMAT_VERSION
+                && !s.dirty =>
+        {
+            Some(s)
+        }
         _ => None,
     }
 }
@@ -1382,7 +1388,7 @@ impl IndexBuilder {
     /// - Creates index if none exists
     /// - Updates incrementally if files changed
     /// - Full rebuild if `force = true`
-    /// - Full rebuild if CLI version changed (clears outdated index)
+    /// - Full rebuild if the on-disk index format is incompatible
     pub fn index(&mut self, languages: Option<&[Language]>, force: bool) -> Result<UpdateStats> {
         let _lock = acquire_index_lock(&self.index_dir)?;
         self.run_indexing(languages, force)
@@ -1391,7 +1397,7 @@ impl IndexBuilder {
     /// Shared indexing dispatch, run while the index lock is held by the caller.
     ///
     /// Routing:
-    /// - forced or CLI-version change → atomic `full_rebuild` (protects a working index);
+    /// - forced or index-format change → atomic `full_rebuild` (protects a working index);
     /// - a fresh build, or resuming an interrupted resumable build → `build_resumable`
     ///   (checkpoints per batch so interruptions keep their progress);
     /// - corrupted filtering DB → atomic `full_rebuild`;
@@ -1412,14 +1418,21 @@ impl IndexBuilder {
         let filtering_exists = filtering::exists(index_path);
         let building = self.index_dir.join(BUILDING_MARKER).exists();
 
-        // Check if CLI version changed - if so, clear and rebuild the index
-        let current_version = env!("CARGO_PKG_VERSION");
-        let version_mismatch =
-            index_exists && !state.cli_version.is_empty() && state.cli_version != current_version;
+        // Rebuild only when the on-disk index format is incompatible with this
+        // binary. Gating on the CLI version instead meant every routine release
+        // discarded every index and re-embedded the entire project.
+        //
+        // A missing/empty state.json also deserializes to format version 0, but
+        // that case must stay on the cheap reconstruct-from-filtering-DB path
+        // below rather than a full re-embed — hence the non-empty-files guard
+        // (a genuine legacy-format state always has tracked files).
+        let format_mismatch = index_exists
+            && !state.files.is_empty()
+            && state.index_format_version != INDEX_FORMAT_VERSION;
 
-        // Forced or CLI-version change: clean atomic rebuild. Drop any in-progress
+        // Forced or index-format change: clean atomic rebuild. Drop any in-progress
         // resumable-build marker so we don't try to resume an index we're discarding.
-        if force || version_mismatch {
+        if force || format_mismatch {
             let _ = std::fs::remove_file(self.index_dir.join(BUILDING_MARKER));
             return self.full_rebuild(languages);
         }
@@ -1748,14 +1761,13 @@ impl IndexBuilder {
     /// Copy a usable sibling worktree's index into this project's index directory.
     /// Returns `Ok(true)` if an index was seeded, `Ok(false)` if no suitable sibling exists.
     fn try_seed_from_sibling_worktree(&self) -> Result<bool> {
-        let current_version = env!("CARGO_PKG_VERSION");
         let candidates = worktree::seed_candidates(&self.project_root, &self.model_id)?;
 
         for candidate in candidates {
             let src_dir = &candidate.index_dir;
-            // Validate the sibling holds a complete, current-version, non-dirty index that
+            // Validate the sibling holds a complete, format-compatible, non-dirty index that
             // isn't mid-build. Skip otherwise so we never seed from a half-built or stale store.
-            let Some(src_state) = seed_source_state(src_dir, current_version) else {
+            let Some(src_state) = seed_source_state(src_dir) else {
                 continue;
             };
             let src_vector = get_vector_index_path(src_dir);
@@ -1774,7 +1786,7 @@ impl IndexBuilder {
             std::fs::rename(&tmp, &dest_vector)
                 .context("Failed to move seeded index into place")?;
 
-            // Persist state (rewriting cli_version to current — guaranteed equal here) and a
+            // Persist state (save() restamps the version/format fields) and a
             // fresh project.json pointing at THIS worktree, not the source.
             src_state.save(&self.index_dir)?;
             ProjectMetadata::new(&self.project_root, &self.model_id).save(&self.index_dir)?;
@@ -5094,29 +5106,61 @@ mod tests {
                 mtime: 1,
             },
         );
-        state.save(src_dir).unwrap(); // save() stamps cli_version to the current version
-        let version = env!("CARGO_PKG_VERSION");
+        state.save(src_dir).unwrap(); // save() stamps the current format version
 
         // Complete index, no marker → usable seed source.
-        assert!(seed_source_state(src_dir, version).is_some());
+        assert!(seed_source_state(src_dir).is_some());
 
         // Interrupted/in-progress build → rejected.
         std::fs::write(src_dir.join(BUILDING_MARKER), "").unwrap();
         assert!(
-            seed_source_state(src_dir, version).is_none(),
+            seed_source_state(src_dir).is_none(),
             "issue #115: an in-progress (.building) sibling index must not be used as a seed"
         );
         std::fs::remove_file(src_dir.join(BUILDING_MARKER)).unwrap();
 
         // Sanity: the other rejection reasons still hold.
-        assert!(
-            seed_source_state(src_dir, "0.0.0-other").is_none(),
-            "version mismatch"
-        );
+        // Incompatible index format (save() always stamps the current one, so
+        // patch the persisted JSON directly).
+        let state_path = paths::get_state_path(src_dir);
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+        raw["index_format_version"] = serde_json::json!(INDEX_FORMAT_VERSION + 1);
+        std::fs::write(&state_path, serde_json::to_string(&raw).unwrap()).unwrap();
+        assert!(seed_source_state(src_dir).is_none(), "format mismatch");
+
         let mut dirty = IndexState::load(src_dir).unwrap();
         dirty.dirty = true;
-        // Re-save with dirty set (save() preserves the flag, only rewrites cli_version).
+        // Re-save with dirty set (save() preserves the flag, restamps version/format).
         dirty.save(src_dir).unwrap();
-        assert!(seed_source_state(src_dir, version).is_none(), "dirty index");
+        assert!(seed_source_state(src_dir).is_none(), "dirty index");
+    }
+
+    /// A missing state.json must not be mistaken for an incompatible index format.
+    /// A default-constructed state deserializes with `index_format_version == 0`,
+    /// which differs from `INDEX_FORMAT_VERSION`; gating the rebuild on that alone
+    /// would send a healthy index through a full re-embed instead of the cheap
+    /// reconstruct-from-filtering-DB path.
+    #[test]
+    fn test_missing_state_reconstructs_instead_of_full_rebuild() {
+        let proj = tempfile::tempdir().unwrap();
+        let idx = tempfile::tempdir().unwrap();
+
+        // A real (model-free) vector index + filtering DB referencing one project
+        // file, but no state.json (deleted, or written by a pre-versioning build).
+        std::fs::write(proj.path().join("a.rs"), "fn a() {}\n").unwrap();
+        let vector = get_vector_index_path(idx.path());
+        std::fs::create_dir_all(&vector).unwrap();
+        build_fixture_index(vector.to_str().unwrap(), &["a.rs"], 2);
+
+        let mut builder = test_builder(proj.path(), idx.path());
+        // A full rebuild would need the builder's model (nonexistent) and fail;
+        // the reconstruct path sees the on-disk file as unchanged.
+        let stats = builder.run_indexing(None, false).unwrap();
+
+        assert_eq!(stats.unchanged, 1, "file must be recognized, not re-embedded");
+        let state = IndexState::load(idx.path()).unwrap();
+        assert_eq!(state.files.len(), 1, "state must be reconstructed from the DB");
+        assert_eq!(state.index_format_version, INDEX_FORMAT_VERSION);
     }
 }

--- a/colgrep/src/index/state.rs
+++ b/colgrep/src/index/state.rs
@@ -298,7 +298,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         state.save(temp_dir.path()).unwrap();
         assert_eq!(
-            IndexState::load(temp_dir.path()).unwrap().index_format_version,
+            IndexState::load(temp_dir.path())
+                .unwrap()
+                .index_format_version,
             INDEX_FORMAT_VERSION
         );
     }

--- a/colgrep/src/index/state.rs
+++ b/colgrep/src/index/state.rs
@@ -8,11 +8,21 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use super::paths::get_state_path;
 
+/// Version of the on-disk index format (chunk layout, embedding pipeline,
+/// metadata schema). Bump ONLY for incompatible changes: a mismatch discards
+/// the index and re-embeds the entire project on the next run. Routine CLI
+/// releases must NOT bump this.
+pub const INDEX_FORMAT_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IndexState {
-    /// CLI version that created/updated this index
+    /// CLI version that created/updated this index (diagnostic only)
     #[serde(default)]
     pub cli_version: String,
+    /// Index format version this index was written with. Indexes from before
+    /// this field existed deserialize as 0 and rebuild once.
+    #[serde(default)]
+    pub index_format_version: u32,
     pub files: HashMap<PathBuf, FileInfo>,
     /// Files that failed to parse (e.g. invalid UTF-8) — skipped on future runs
     #[serde(default)]
@@ -52,9 +62,10 @@ impl IndexState {
     pub fn save(&self, index_dir: &Path) -> Result<()> {
         fs::create_dir_all(index_dir)?;
 
-        // Update CLI version before saving
+        // Stamp the writing binary's CLI version and index format before saving
         let mut state = self.clone();
         state.cli_version = env!("CARGO_PKG_VERSION").to_string();
+        state.index_format_version = INDEX_FORMAT_VERSION;
 
         let state_path = get_state_path(index_dir);
         let content = serde_json::to_string_pretty(&state)?;
@@ -139,6 +150,7 @@ mod tests {
         );
         let state = IndexState {
             cli_version: "1.0.0".to_string(),
+            index_format_version: INDEX_FORMAT_VERSION,
             files,
             ignored_files: HashSet::new(),
             search_count: 0,
@@ -272,6 +284,23 @@ mod tests {
     fn test_get_mtime_nonexistent() {
         let result = get_mtime(Path::new("/nonexistent/file.txt"));
         assert!(result.is_err());
+    }
+
+    /// A state.json written before index_format_version existed must load as
+    /// version 0 (forcing a one-time rebuild), and save() must stamp the
+    /// current format so the rebuild happens exactly once.
+    #[test]
+    fn test_legacy_state_without_format_version_loads_as_zero() {
+        let json = r#"{"cli_version":"1.5.4","files":{},"search_count":3}"#;
+        let state: IndexState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.index_format_version, 0);
+
+        let temp_dir = TempDir::new().unwrap();
+        state.save(temp_dir.path()).unwrap();
+        assert_eq!(
+            IndexState::load(temp_dir.path()).unwrap().index_format_version,
+            INDEX_FORMAT_VERSION
+        );
     }
 
     #[test]

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -131,6 +131,7 @@ fn main() -> Result<()> {
             pool_factor,
             auto_confirm,
             static_batch,
+            no_update,
         }) => {
             // If only -e pattern is given without a query, use the pattern as the query too
             let original_query = query.clone();
@@ -223,6 +224,7 @@ fn main() -> Result<()> {
                     resolve_pool_factor(pool_factor, no_pool),
                     auto_confirm,
                     static_batch,
+                    no_update,
                 )
             } else {
                 // No query or text_pattern provided - show help
@@ -396,6 +398,7 @@ fn main() -> Result<()> {
                     resolve_pool_factor(cli.pool_factor, cli.no_pool),
                     cli.auto_confirm,
                     false,
+                    cli.no_update,
                 )
             } else {
                 // No query provided - show help

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -17,7 +17,6 @@ use colgrep::{
 };
 
 use cli::{Cli, Commands};
-use commands::search::{resolve_pool_factor, resolve_top_k};
 use commands::{
     cmd_clear, cmd_config, cmd_init, cmd_reset_stats, cmd_search, cmd_session_hook, cmd_set_model,
     cmd_stats, cmd_status, cmd_task_hook, cmd_update, InitOptions,
@@ -203,8 +202,8 @@ fn main() -> Result<()> {
                 cmd_search(
                     &final_query,
                     &final_paths,
-                    resolve_top_k(top_k, default_k),
-                    top_k.is_some(),
+                    top_k,
+                    default_k,
                     model.as_deref(),
                     json,
                     &include_patterns,
@@ -221,7 +220,8 @@ fn main() -> Result<()> {
                     code_only,
                     no_fts,
                     alpha,
-                    resolve_pool_factor(pool_factor, no_pool),
+                    pool_factor,
+                    no_pool,
                     auto_confirm,
                     static_batch,
                     no_update,
@@ -377,8 +377,8 @@ fn main() -> Result<()> {
                 cmd_search(
                     &final_query,
                     &final_paths,
-                    resolve_top_k(cli.top_k, default_k),
-                    cli.top_k.is_some(),
+                    cli.top_k,
+                    default_k,
                     cli.model.as_deref(),
                     cli.json,
                     &cli.include_patterns,
@@ -395,7 +395,8 @@ fn main() -> Result<()> {
                     cli.code_only,
                     cli.no_fts,
                     cli.alpha,
-                    resolve_pool_factor(cli.pool_factor, cli.no_pool),
+                    cli.pool_factor,
+                    cli.no_pool,
                     cli.auto_confirm,
                     false,
                     cli.no_update,

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -1770,6 +1770,7 @@ impl MmapIndex {
     /// The number of documents actually deleted
     pub fn delete_with_options(&mut self, doc_ids: &[i64], delete_metadata: bool) -> Result<usize> {
         let path = self.path.clone();
+        let old_num_documents = self.metadata.num_documents as i64;
 
         // Release mmap handles before deletion. delete_from_index calls
         // clear_merged_files which removes the memory-mapped merged files.
@@ -1784,9 +1785,28 @@ impl MmapIndex {
             let index_path = std::path::Path::new(&path);
             let db_path = index_path.join("metadata.db");
             if db_path.exists() {
+                // filtering::delete re-sequences the surviving _subset_ IDs. When the
+                // deleted IDs are exactly the tail of the ID space, every survivor
+                // keeps its ID, so the FTS5 rows for survivors stay aligned and only
+                // the deleted rows need removing — O(deleted) instead of the
+                // O(total documents) drop-and-rebuild.
+                let mut valid: Vec<i64> = doc_ids
+                    .iter()
+                    .copied()
+                    .filter(|&id| id >= 0 && id < old_num_documents)
+                    .collect();
+                valid.sort_unstable();
+                valid.dedup();
+                let suffix_start = old_num_documents - valid.len() as i64;
+                let is_suffix_delete = valid.first().is_some_and(|&min| min >= suffix_start);
+
                 crate::filtering::delete(&path, doc_ids)?;
-                // Rebuild FTS5 index after metadata re-indexing
-                crate::text_search::rebuild(&path)?;
+                if is_suffix_delete {
+                    crate::text_search::delete(&path, &valid)?;
+                } else {
+                    // Survivor IDs shifted; FTS5 rowids no longer match METADATA.
+                    crate::text_search::rebuild(&path)?;
+                }
             }
         }
 
@@ -1808,6 +1828,85 @@ mod tests {
             config.start_from_scratch,
             crate::default_start_from_scratch()
         );
+    }
+
+    /// FTS5 must stay aligned with METADATA `_subset_` IDs after deletes.
+    /// Suffix deletes keep every survivor's ID, so only the deleted FTS rows
+    /// are removed (O(deleted)); any other delete shifts survivor IDs and
+    /// must fall back to the full rebuild.
+    #[test]
+    fn test_delete_keeps_fts_aligned() {
+        use ndarray::Array2;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let index_path = temp_dir.path().to_str().unwrap();
+
+        let mut embeddings: Vec<Array2<f32>> = Vec::new();
+        for i in 0..5 {
+            let mut doc = Array2::<f32>::zeros((5, 32));
+            for j in 0..5 {
+                for k in 0..32 {
+                    doc[[j, k]] = (i as f32 * 0.1) + (j as f32 * 0.01) + (k as f32 * 0.001);
+                }
+            }
+            for mut row in doc.rows_mut() {
+                let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 {
+                    row.iter_mut().for_each(|x| *x /= norm);
+                }
+            }
+            embeddings.push(doc);
+        }
+
+        let config = IndexConfig {
+            nbits: 2,
+            batch_size: 50,
+            seed: Some(42),
+            kmeans_niters: 2,
+            max_points_per_centroid: 256,
+            n_samples_kmeans: None,
+            start_from_scratch: 999,
+            force_cpu: false,
+            ..Default::default()
+        };
+        let mut index = MmapIndex::create_with_kmeans(&embeddings, index_path, &config).unwrap();
+
+        let words = ["alpha", "bravo", "charlie", "delta", "echo"];
+        let metadata: Vec<serde_json::Value> = words
+            .iter()
+            .map(|w| serde_json::json!({ "text": w }))
+            .collect();
+        let doc_ids: Vec<i64> = (0..5).collect();
+        crate::filtering::create(index_path, &metadata, &doc_ids).unwrap();
+        crate::text_search::index(
+            index_path,
+            &metadata,
+            &doc_ids,
+            &crate::text_search::FtsTokenizer::default(),
+        )
+        .unwrap();
+
+        // Suffix delete: survivors 0..=2 keep their IDs; only rows 3 and 4
+        // leave the FTS index.
+        let deleted = index.delete_with_options(&[3, 4], true).unwrap();
+        assert_eq!(deleted, 2);
+        index.reload().unwrap();
+
+        let hits = crate::text_search::search(index_path, "charlie", 10).unwrap();
+        assert_eq!(hits.passage_ids, vec![2]);
+        let gone = crate::text_search::search(index_path, "delta", 10).unwrap();
+        assert!(gone.passage_ids.is_empty());
+
+        // Non-suffix delete: survivor IDs shift (bravo→0, charlie→1), so the
+        // FTS index must be rebuilt against the new numbering.
+        let deleted = index.delete_with_options(&[0], true).unwrap();
+        assert_eq!(deleted, 1);
+
+        let hits = crate::text_search::search(index_path, "charlie", 10).unwrap();
+        assert_eq!(hits.passage_ids, vec![1]);
+        let gone = crate::text_search::search(index_path, "alpha", 10).unwrap();
+        assert!(gone.passage_ids.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
When used on large repos, colgrep pays substantial costs on every search and update that buy nothing: every query re-reads and re-hashes every source file before returning results, every routine release discards every index on the machine, and every incremental update rewrites the index once per changed file. This has been annoying me, and this PR removes some of that redundant work.

Each of my commits preserves behavior. Search results, ranking, and the on-disk index layout are all unchanged.

## Commits

1. **Skip content hashing for files with unchanged mtime.** Restores the stat-only fast path from d0423d9 that was lost in the d76cb4a pipeline rewrite; without it every search reads and xxh3-hashes the entire repo. Also stops running orphan cleanup (a `SELECT DISTINCT` over every indexed file plus one stat each) on every search — it now runs only when the plan contains deletions, or every 50th search.
2. **Rebuild indexes on format changes, not on every CLI release.** `IndexState` now persists an `index_format_version`; rebuilds happen only when that constant is deliberately bumped, instead of whenever `cli_version` differs (which, with frequent patch releases via the auto-updating Homebrew tap, meant routinely re-embedding every project on the machine). Pre-existing indexes rebuild one final time; a missing `state.json` still takes the cheap reconstruct-from-DB path rather than a re-embed.
3. **Add `--no-update` to skip auto-indexing during search.** For agents issuing many queries in a row, the per-query change-detection scan is pure overhead. All three write paths are gated: the staleness check, the missing-index build, and the corrupt-index recovery rebuild.
4. **Flush incremental updates in 8K-doc batches.** The update path accumulated one index write per changed file; it now batches embeddings and flushes at a document threshold, collapsing N small rewrites into a few large ones.
5. **next-plaid: skip the full FTS5 rebuild when deleted docs are the ID-space tail.** Suffix deletes (the common truncate/re-add pattern) now delete the affected FTS rows directly instead of re-tokenizing the entire corpus; non-suffix deletes still rebuild because positional IDs renumber survivors.
6. **Size the default ONNX session count to the encoding workload.** Small updates no longer spin up the full default session pool to encode a handful of chunks.
7. **Load the user config once per command.** Each search re-parsed `config.json` up to seven-plus times across the `resolve_*` helpers and `search_single_path`; everything now reads one snapshot.
8. **Scan for a parent index only when the search path has none.** The parent-directory walk is skipped entirely when a local index already exists.

## Does it actually help?

For the headline claim (commit 1) I've added a committed measurement, ignored by default:

```
cargo test -p colgrep --release measure_update_plan -- --ignored --nocapture
```

On an Apple-silicon laptop with a warm page cache:

```
update plan, 5000 files x 200 KiB (976 MiB total):
  full hashing (pre-fix per-search cost): 522ms
  mtime fast path:                        131ms  (4.0x faster)
  read+hash component removed per search: 392ms (scales with repo bytes)
```

The 4.0x independently reproduces the "~4x query speedup" reported by d0423d9 when this fast path was first introduced. The measurement is conservative: hashing is timed against a warm page cache, and the eliminated component grows linearly with repo size (and worsens cold).

The other changes are pinned behaviorally: batched deletes assert exactly one index rewrite for N files (`test_delete_files_from_index_is_a_single_rewrite`), suffix deletes assert FTS survivor alignment without a rebuild (`test_delete_keeps_fts_aligned`), and the format-version change carries regression tests for both rebuild-once and reconstruct-instead-of-rebuild semantics.

## Known limitation (pre-existing, not addressed here)

colgrep's delete path renumbers metadata `_subset_` IDs without touching the FTS5 tables, so non-suffix deletes can leave FTS rowids misaligned with survivors (surfacing later as the non-fatal "FTS indexing failed" warning). The structural fix is stable document IDs, which I'm planning as a follow-up PR.
