### PR TITLE
feat(index): provider-aware default for parallel indexing sessions (builds on #127)

### DIFF
--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -247,7 +247,8 @@ colgrep settings --fp32
 # Set embedding pool factor (2 = 50% smaller index, 1 = full precision)
 colgrep settings --pool-factor 2
 
-# Set parallel encoding sessions (default: CPU count, max 16)
+# Set parallel encoding sessions (persists across sessions and all indexes)
+# Default: CPU count (max 16) on CPU; 1 on GPU/CoreML. Use 0 to reset to auto.
 colgrep settings --parallel 8
 
 # Set batch size per session (default: 1 for CPU, 64 for CUDA)
@@ -262,6 +263,38 @@ colgrep settings --verbose
 # Reset a value to default (pass 0)
 colgrep settings --k 0 --n 0
 ```
+
+### Indexing Speed vs. Memory
+
+Cold indexing encodes every code unit with the ColBERT model. colgrep runs several ONNX
+sessions in parallel to speed this up, and the pipeline queues between encoding and index
+writing are bounded so memory stays flat regardless of repo size.
+
+The number of parallel sessions is the main speed/memory knob, and it is a **persistent
+setting** — set it once and it applies to every future `colgrep` run and every index:
+
+```bash
+# Use more sessions for faster indexing on multi-core machines
+colgrep settings --parallel 8
+
+# Use a single session to minimise memory (recommended on GPU/CoreML,
+# where each session is a full copy of the model in device memory)
+colgrep settings --parallel 1
+
+# Reset to the automatic default
+colgrep settings --parallel 0
+```
+
+Default when unset (`--parallel 0`):
+
+| Execution provider      | Default sessions          | Why                                                              |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------- |
+| CPU                     | CPU core count (max 16)   | Fastest; bounded queues keep memory in check even at many cores  |
+| GPU / CoreML / DirectML | 1                         | Each session duplicates the model in device memory               |
+
+On a CPU build, raising sessions speeds up cold indexing roughly linearly with cores at only
+a modest, bounded memory increase. On accelerator builds the trade-off is steeper, so the
+default stays at 1 — raise it explicitly with `--parallel` if you have the device memory.
 
 ### Hybrid Search
 

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -164,10 +164,75 @@ const SMALL_BATCH_CPU_THRESHOLD: usize = 300;
 /// disk I/O falls behind.
 const POOLED_EMBEDDING_QUEUE_CAPACITY: usize = 4;
 
+/// Bounded channel capacity for upstream pipeline stages.
+/// Tokenized chunks and raw token-level embeddings can be large on codebases with many
+/// long functions. Keeping these queues bounded makes back-pressure propagate all the way
+/// to parsing instead of letting encoding run far ahead of indexing.
+const PIPELINE_QUEUE_CAPACITY: usize = 2;
+
+/// Bounded channel capacity for chunks waiting on initial-create coding.
+/// During first index creation the coding thread waits for k-means before compressing chunks,
+/// so this queue must stay small or pooled embeddings pile up in memory.
+const CODING_QUEUE_CAPACITY: usize = 2;
+
+/// Default ONNX sessions for indexing when the user has not configured `settings --parallel`.
+/// Extra sessions duplicate model/runtime memory and are especially costly during cold builds.
+const DEFAULT_INDEX_PARALLEL_SESSIONS: usize = 1;
+
 /// Bounded channel capacity between the index and metadata stages.
 /// Larger than the pooled queue because metadata rows are lightweight
 /// (just unit refs + doc IDs, no embedding data).
 const METADATA_QUEUE_CAPACITY: usize = 8;
+
+fn compiled_accelerated_execution_provider() -> Option<ExecutionProvider> {
+    if cfg!(feature = "cuda") {
+        Some(ExecutionProvider::Cuda)
+    } else if cfg!(feature = "tensorrt") {
+        Some(ExecutionProvider::TensorRT)
+    } else if cfg!(feature = "coreml") {
+        Some(ExecutionProvider::CoreML)
+    } else if cfg!(feature = "directml") {
+        Some(ExecutionProvider::DirectML)
+    } else if cfg!(feature = "migraphx") {
+        Some(ExecutionProvider::MIGraphX)
+    } else {
+        None
+    }
+}
+
+fn execution_provider_for_acceleration_mode(mode: AccelerationMode) -> ExecutionProvider {
+    match mode {
+        AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
+        AccelerationMode::ForceGpu => {
+            compiled_accelerated_execution_provider().unwrap_or(ExecutionProvider::Cuda)
+        }
+        AccelerationMode::Auto => {
+            compiled_accelerated_execution_provider().unwrap_or(ExecutionProvider::Cpu)
+        }
+    }
+}
+
+#[cfg(all(
+    not(feature = "cuda"),
+    any(feature = "coreml", feature = "directml", feature = "migraphx")
+))]
+fn indexing_execution_provider_for_acceleration_mode(mode: AccelerationMode) -> ExecutionProvider {
+    match mode {
+        AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
+        AccelerationMode::ForceGpu => {
+            compiled_accelerated_execution_provider().unwrap_or(ExecutionProvider::Cuda)
+        }
+        AccelerationMode::Auto if cfg!(feature = "coreml") => {
+            // CoreML retains substantial per-shape state during bulk document encoding.
+            // Keep Auto indexing memory-bounded; users can still opt into CoreML with
+            // --force-gpu, and search query encoding continues to prefer CoreML.
+            ExecutionProvider::Cpu
+        }
+        AccelerationMode::Auto => {
+            compiled_accelerated_execution_provider().unwrap_or(ExecutionProvider::Cpu)
+        }
+    }
+}
 
 struct ParsedFileResult {
     path: PathBuf,
@@ -336,7 +401,7 @@ fn prepare_deduplicated_chunk(unit_chunk: &[SortedUnit]) -> PreparedChunk {
 
 fn run_encode_stage(
     receiver: mpsc::Receiver<TokenizedChunk>,
-    sender: mpsc::Sender<RawEncodedChunk>,
+    sender: mpsc::SyncSender<RawEncodedChunk>,
     model: Colbert,
 ) -> Result<()> {
     while let Ok(chunk) = receiver.recv() {
@@ -356,7 +421,7 @@ fn run_encode_stage(
 
 fn run_tokenize_stage(
     receiver: mpsc::Receiver<PreparedChunk>,
-    sender: mpsc::Sender<TokenizedChunk>,
+    sender: mpsc::SyncSender<TokenizedChunk>,
     model: Colbert,
 ) -> Result<()> {
     while let Ok(chunk) = receiver.recv() {
@@ -468,7 +533,7 @@ fn run_index_stage(
         // chunk's embeddings into residual codes. All encoded chunks are collected
         // in memory and written to disk in a single atomic operation at the end,
         // which avoids a partially-written index if the process is interrupted.
-        let (dedup_tx, dedup_rx) = mpsc::sync_channel::<ChunkForCoding>(8);
+        let (dedup_tx, dedup_rx) = mpsc::sync_channel::<ChunkForCoding>(CODING_QUEUE_CAPACITY);
         let coding_index_path = index_path.clone();
         let coding_config = initial_create_config.clone();
         let coding_force_cpu = update_config.force_cpu;
@@ -666,9 +731,9 @@ fn run_chunk_pipeline(
         pb,
     } = pipeline;
 
-    let (tokenize_tx, tokenize_rx) = mpsc::channel::<PreparedChunk>();
-    let (encode_tx, encode_rx) = mpsc::channel::<TokenizedChunk>();
-    let (pool_tx, pool_rx) = mpsc::channel::<RawEncodedChunk>();
+    let (tokenize_tx, tokenize_rx) = mpsc::sync_channel::<PreparedChunk>(PIPELINE_QUEUE_CAPACITY);
+    let (encode_tx, encode_rx) = mpsc::sync_channel::<TokenizedChunk>(PIPELINE_QUEUE_CAPACITY);
+    let (pool_tx, pool_rx) = mpsc::sync_channel::<RawEncodedChunk>(PIPELINE_QUEUE_CAPACITY);
     let (index_tx, index_rx) =
         mpsc::sync_channel::<PooledChunkForIndex>(POOLED_EMBEDDING_QUEUE_CAPACITY);
     let (metadata_tx, metadata_rx) =
@@ -941,7 +1006,7 @@ impl IndexBuilder {
 
                         (
                             self.parallel_sessions
-                                .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
+                                .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
                             ExecutionProvider::Cpu,
                         )
                     }
@@ -990,9 +1055,8 @@ impl IndexBuilder {
                             )
                         } else {
                             (
-                                self.parallel_sessions.unwrap_or_else(
-                                    crate::config::get_default_cpu_parallel_sessions,
-                                ),
+                                self.parallel_sessions
+                                    .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
                                 ExecutionProvider::Cpu,
                             )
                         }
@@ -1013,7 +1077,7 @@ impl IndexBuilder {
 
                 (
                     self.parallel_sessions
-                        .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
+                        .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
                     ExecutionProvider::Cpu,
                 )
             };
@@ -1023,21 +1087,17 @@ impl IndexBuilder {
             let (num_sessions, execution_provider) = {
                 let _ = num_units;
 
+                let execution_provider = indexing_execution_provider_for_acceleration_mode(
+                    env_acceleration_mode_lossy(),
+                );
+
                 crate::onnx_runtime::ensure_onnx_runtime()
                     .context("Failed to initialize ONNX Runtime")?;
 
-                let provider = if cfg!(feature = "directml") {
-                    ExecutionProvider::DirectML
-                } else if cfg!(feature = "migraphx") {
-                    ExecutionProvider::MIGraphX
-                } else {
-                    ExecutionProvider::CoreML
-                };
-
                 (
                     self.parallel_sessions
-                        .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions),
-                    provider,
+                        .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
+                    execution_provider,
                 )
             };
 
@@ -1099,7 +1159,7 @@ impl IndexBuilder {
 
         let num_sessions = self
             .parallel_sessions
-            .unwrap_or_else(crate::config::get_default_cpu_parallel_sessions);
+            .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS);
         let batch = crate::config::DEFAULT_BATCH_SIZE_CPU;
 
         let model = crate::stderr::with_suppressed_stderr(|| {
@@ -3307,21 +3367,7 @@ impl Searcher {
         let index_path = vector_dir.to_str().unwrap().to_string();
 
         let acceleration_mode = env_acceleration_mode_lossy();
-        let execution_provider = match acceleration_mode {
-            AccelerationMode::ForceGpu => ExecutionProvider::Cuda,
-            AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
-            AccelerationMode::Auto => {
-                if cfg!(feature = "coreml") {
-                    ExecutionProvider::CoreML
-                } else if cfg!(feature = "directml") {
-                    ExecutionProvider::DirectML
-                } else if cfg!(feature = "migraphx") {
-                    ExecutionProvider::MIGraphX
-                } else {
-                    ExecutionProvider::Cpu
-                }
-            }
-        };
+        let execution_provider = execution_provider_for_acceleration_mode(acceleration_mode);
 
         #[cfg(feature = "cuda")]
         match acceleration_mode {
@@ -3387,21 +3433,7 @@ impl Searcher {
         let index_path = vector_dir.to_str().unwrap().to_string();
 
         let acceleration_mode = env_acceleration_mode_lossy();
-        let execution_provider = match acceleration_mode {
-            AccelerationMode::ForceGpu => ExecutionProvider::Cuda,
-            AccelerationMode::ForceCpu => ExecutionProvider::Cpu,
-            AccelerationMode::Auto => {
-                if cfg!(feature = "coreml") {
-                    ExecutionProvider::CoreML
-                } else if cfg!(feature = "directml") {
-                    ExecutionProvider::DirectML
-                } else if cfg!(feature = "migraphx") {
-                    ExecutionProvider::MIGraphX
-                } else {
-                    ExecutionProvider::Cpu
-                }
-            }
-        };
+        let execution_provider = execution_provider_for_acceleration_mode(acceleration_mode);
 
         #[cfg(feature = "cuda")]
         match acceleration_mode {
@@ -4182,6 +4214,38 @@ fn prompt_large_index_confirmation(num_units: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_force_cpu_execution_provider_is_cpu() {
+        assert_eq!(
+            execution_provider_for_acceleration_mode(AccelerationMode::ForceCpu),
+            ExecutionProvider::Cpu
+        );
+    }
+
+    #[test]
+    fn test_auto_execution_provider_uses_compiled_accelerator_or_cpu() {
+        let expected = compiled_accelerated_execution_provider().unwrap_or(ExecutionProvider::Cpu);
+
+        assert_eq!(
+            execution_provider_for_acceleration_mode(AccelerationMode::Auto),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_indexing_parallel_default_is_memory_bounded() {
+        assert_eq!(DEFAULT_INDEX_PARALLEL_SESSIONS, 1);
+    }
+
+    #[test]
+    #[cfg(all(feature = "coreml", not(feature = "cuda")))]
+    fn test_auto_indexing_provider_avoids_coreml() {
+        assert_eq!(
+            indexing_execution_provider_for_acceleration_mode(AccelerationMode::Auto),
+            ExecutionProvider::Cpu
+        );
+    }
 
     #[test]
     fn test_glob_simple_extension() {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -175,9 +175,28 @@ const PIPELINE_QUEUE_CAPACITY: usize = 2;
 /// so this queue must stay small or pooled embeddings pile up in memory.
 const CODING_QUEUE_CAPACITY: usize = 2;
 
-/// Default ONNX sessions for indexing when the user has not configured `settings --parallel`.
-/// Extra sessions duplicate model/runtime memory and are especially costly during cold builds.
-const DEFAULT_INDEX_PARALLEL_SESSIONS: usize = 1;
+/// Default ONNX sessions for indexing on accelerator providers (CoreML/DirectML/MIGraphX)
+/// when the user has not configured `settings --parallel`. On these providers every session
+/// is a full model copy held in device memory, so default to a single session and let users
+/// opt into more with `--parallel`. CPU indexing uses [`default_index_parallel_sessions`]
+/// instead, which scales with cores because CPU encoding cannot run ahead of the bounded
+/// pipeline queues (so extra sessions add throughput at modest, bounded memory cost).
+const DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS: usize = 1;
+
+/// Pick the default number of ONNX sessions for indexing based on the chosen execution
+/// provider, when the user has not set `settings --parallel`.
+///
+/// - **CPU**: scale with available cores. The bounded pipeline queues cap how far encoding
+///   can run ahead of indexing, so more sessions improve throughput without the unbounded
+///   memory growth that motivated the queue bounds — this is the fast default.
+/// - **Accelerators** (CoreML/CUDA/DirectML/MIGraphX): keep a single session by default,
+///   since each one duplicates the model in device memory. Users can raise it explicitly.
+fn default_index_parallel_sessions(execution_provider: ExecutionProvider) -> usize {
+    match execution_provider {
+        ExecutionProvider::Cpu => crate::config::get_default_cpu_parallel_sessions(),
+        _ => DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS,
+    }
+}
 
 /// Bounded channel capacity between the index and metadata stages.
 /// Larger than the pooled queue because metadata rows are lightweight
@@ -1005,8 +1024,9 @@ impl IndexBuilder {
                             .context("Failed to initialize ONNX Runtime")?;
 
                         (
-                            self.parallel_sessions
-                                .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
+                            self.parallel_sessions.unwrap_or_else(|| {
+                                default_index_parallel_sessions(ExecutionProvider::Cpu)
+                            }),
                             ExecutionProvider::Cpu,
                         )
                     }
@@ -1055,8 +1075,9 @@ impl IndexBuilder {
                             )
                         } else {
                             (
-                                self.parallel_sessions
-                                    .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
+                                self.parallel_sessions.unwrap_or_else(|| {
+                                    default_index_parallel_sessions(ExecutionProvider::Cpu)
+                                }),
                                 ExecutionProvider::Cpu,
                             )
                         }
@@ -1077,7 +1098,7 @@ impl IndexBuilder {
 
                 (
                     self.parallel_sessions
-                        .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
+                        .unwrap_or_else(|| default_index_parallel_sessions(ExecutionProvider::Cpu)),
                     ExecutionProvider::Cpu,
                 )
             };
@@ -1096,7 +1117,7 @@ impl IndexBuilder {
 
                 (
                     self.parallel_sessions
-                        .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS),
+                        .unwrap_or_else(|| default_index_parallel_sessions(execution_provider)),
                     execution_provider,
                 )
             };
@@ -1159,7 +1180,7 @@ impl IndexBuilder {
 
         let num_sessions = self
             .parallel_sessions
-            .unwrap_or(DEFAULT_INDEX_PARALLEL_SESSIONS);
+            .unwrap_or_else(|| default_index_parallel_sessions(ExecutionProvider::Cpu));
         let batch = crate::config::DEFAULT_BATCH_SIZE_CPU;
 
         let model = crate::stderr::with_suppressed_stderr(|| {
@@ -4234,8 +4255,24 @@ mod tests {
     }
 
     #[test]
-    fn test_indexing_parallel_default_is_memory_bounded() {
-        assert_eq!(DEFAULT_INDEX_PARALLEL_SESSIONS, 1);
+    fn test_accelerator_indexing_parallel_default_is_memory_bounded() {
+        // Accelerator providers keep one session by default: each is a full model copy in
+        // device memory.
+        assert_eq!(DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS, 1);
+        assert_eq!(
+            default_index_parallel_sessions(ExecutionProvider::CoreML),
+            1
+        );
+    }
+
+    #[test]
+    fn test_cpu_indexing_parallel_default_scales_with_cores() {
+        // CPU indexing defaults to the cores-based session count for speed; the bounded
+        // pipeline queues keep memory in check regardless of session count.
+        assert_eq!(
+            default_index_parallel_sessions(ExecutionProvider::Cpu),
+            crate::config::get_default_cpu_parallel_sessions()
+        );
     }
 
     #[test]

--- a/next-plaid-onnx/src/lib.rs
+++ b/next-plaid-onnx/src/lib.rs
@@ -1112,6 +1112,7 @@ impl Colbert {
                     false,
                     true,
                     piece_indices,
+                    None,
                 )?);
             }
 
@@ -1170,6 +1171,7 @@ impl Colbert {
                     false,
                     true,
                     piece_indices,
+                    Some(shape.planned_len),
                 )?);
             }
         }
@@ -1658,9 +1660,10 @@ struct FixedDynamicShape {
 }
 
 fn build_fixed_dynamic_shapes(batch_size: usize, document_length: usize) -> Vec<FixedDynamicShape> {
-    let total_budget = batch_size.max(1).saturating_mul(document_length.max(1));
+    let max_len = document_length.max(1);
+    let total_budget = batch_size.max(1).saturating_mul(max_len);
     let mut shapes = Vec::new();
-    let mut planned_len = round_up_len_for_planning(document_length.max(1));
+    let mut planned_len = round_up_len_for_planning(max_len).min(max_len);
     let min_planned_len = 128.min(planned_len.max(1));
 
     loop {
@@ -1677,7 +1680,8 @@ fn build_fixed_dynamic_shapes(batch_size: usize, document_length: usize) -> Vec<
             break;
         }
 
-        let next_len = round_up_len_for_planning((planned_len / 2).max(min_planned_len));
+        let next_len =
+            round_up_len_for_planning((planned_len / 2).max(min_planned_len)).min(max_len);
         if next_len == planned_len {
             break;
         }
@@ -1785,6 +1789,7 @@ fn prepare_batch_from_tokenized_documents(
     is_query: bool,
     filter_skiplist: bool,
     original_input_indices: Vec<usize>,
+    pad_to_len: Option<usize>,
 ) -> Result<PreparedDocumentBatch> {
     let (prefix_str, prefix_token_id_opt, max_length) = if is_query {
         (
@@ -1819,6 +1824,9 @@ fn prepare_batch_from_tokenized_documents(
             doc.ids.len() + 1
         };
         batch_max_len = batch_max_len.max(effective_len);
+    }
+    if let Some(pad_to_len) = pad_to_len {
+        batch_max_len = batch_max_len.max(pad_to_len.min(max_length));
     }
     if is_query && config.do_query_expansion {
         batch_max_len = max_length;
@@ -2431,6 +2439,27 @@ mod tests {
         assert_eq!(format!("{}", ExecutionProvider::CoreML), "CoreML");
         assert_eq!(format!("{}", ExecutionProvider::DirectML), "DirectML");
         assert_eq!(format!("{}", ExecutionProvider::MIGraphX), "MIGraphX");
+    }
+
+    #[test]
+    fn test_fixed_dynamic_shapes_do_not_exceed_document_length() {
+        let shapes = build_fixed_dynamic_shapes(1, 300);
+
+        assert!(!shapes.is_empty());
+        assert!(shapes.iter().all(|shape| shape.planned_len <= 300));
+        assert_eq!(shapes.last().unwrap().planned_len, 300);
+    }
+
+    #[test]
+    fn test_fixed_dynamic_shapes_preserve_token_budget() {
+        let batch_size = 4;
+        let document_length = 300;
+        let budget = batch_size * document_length;
+        let shapes = build_fixed_dynamic_shapes(batch_size, document_length);
+
+        assert!(shapes
+            .iter()
+            .all(|shape| shape.docs * shape.planned_len <= budget));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Builds on #127 (by @ndizazzo) and keeps all of its improvements, with one refinement to the parallel-session default so cold indexing is **fast by default on every build** while staying memory-safe on accelerators.

### Kept from #127
- **Bounded pipeline queues** — caps the cold-index memory growth (confirmed free: at 11 sessions, bounded == unbounded in wall time).
- **Honor `FORCE_CPU` for accelerator builds during indexing** — previously ignored.
- **Auto-mode indexing routes to CPU** instead of CoreML.
- **next-plaid-onnx fixed-dynamic-shape clamp + batch padding** (correctness + minor efficiency).

### What this PR changes
#127 hard-defaulted indexing to a **single ONNX session**. That's correct for accelerators (each session is a full model copy in device memory) but throws away ~3–4× throughput on CPU — and Auto-mode indexing runs on CPU on every platform. This makes the default **provider-aware**:

| Indexing provider | Default sessions | Rationale |
| --- | --- | --- |
| CPU | core count (max 16) | Fastest; bounded queues keep memory flat regardless of session count |
| CoreML / CUDA / DirectML / MIGraphX | 1 | Each session duplicates the model in device memory |

Fully overridable and **persistent across sessions and all indexes** via the existing `colgrep settings --parallel N` (`--parallel 0` resets to the auto default). Documented in `colgrep/README.md`.

### Benchmarks (cold index of `colgrep/`, ~31.7K LOC, M-series 11-core, `clear` before each run)

**Provider-aware default = fastest on both paths:**

| Build / provider | 1 session | cores (11) |
| --- | --- | --- |
| CPU (Accelerate) | 43 s / 2.3 GB | **12 s / 4.6 GB** |
| CoreML (`--force-gpu`) | **133 s / 6.7 GB** | 240 s / 23.5 GB |

- On **CPU**, more sessions are ~3.7× faster at modest, bounded memory.
- On **CoreML**, the ANE is a single shared device, so extra sessions don't parallelize — they only contend and duplicate the model (→ 23.5 GB). 1 session is both faster and far lighter.
- CoreML indexing is much slower than CPU for this small, dynamic-shape, `batch_size=1` encoder workload, which is why Auto-mode indexing stays on CPU.

### Validation
- `cargo test -p colgrep` — 549 passed
- `cargo clippy -p colgrep --all-targets` — clean
- `make ci-quick` (next-plaid fmt/clippy/tests) — clean
- New unit tests for both default branches (CPU scales with cores; accelerators stay at 1)

Supersedes #127. Co-authored with @ndizazzo (original author of the cold-index memory bounds).
