### PR TITLE
perf(index): remove redundant per-search/per-release work (integrates #126)

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -430,6 +430,10 @@ pub struct Cli {
     #[arg(short = 'y', long = "yes")]
     pub auto_confirm: bool,
 
+    /// Skip the automatic index update and search the existing index as-is
+    #[arg(long = "no-update")]
+    pub no_update: bool,
+
     /// When to colorize output and syntax highlighting: auto, always, or never.
     /// `never` emits plain text with no ANSI escape sequences (useful for agents/pipes).
     #[arg(
@@ -549,6 +553,10 @@ pub enum Commands {
         /// Use strict batch-size batching instead of fixed dynamic GPU batching
         #[arg(long = "static-batch")]
         static_batch: bool,
+
+        /// Skip the automatic index update and search the existing index as-is
+        #[arg(long = "no-update")]
+        no_update: bool,
     },
 
     /// Show index status for a project

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -36,10 +36,10 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
         anyhow::bail!("Path is not a directory: {}", path.display());
     }
 
-    let model = resolve_model(options.cli_model);
-    let pool_factor = resolve_pool_factor(options.pool_factor, options.no_pool);
-
     let config = Config::load().unwrap_or_default();
+    let model = resolve_model(&config, options.cli_model);
+    let pool_factor = resolve_pool_factor(&config, options.pool_factor, options.no_pool);
+
     let quantized = !config.use_fp32();
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -360,60 +360,31 @@ fn merge_query_with_pattern(query: &str, sanitized_pattern: &str) -> String {
 }
 
 /// Resolve the model to use: CLI arg > saved config > default
-pub fn resolve_model(cli_model: Option<&str>) -> String {
+pub fn resolve_model(config: &Config, cli_model: Option<&str>) -> String {
     if let Some(model) = cli_model {
         return model.to_string();
     }
 
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(model) = config.get_default_model() {
-            return model.to_string();
-        }
+    if let Some(model) = config.get_default_model() {
+        return model.to_string();
     }
 
-    // Fall back to default
     DEFAULT_MODEL.to_string()
 }
 
 /// Resolve top_k: CLI arg > saved config > default
-pub fn resolve_top_k(cli_k: Option<usize>, default: usize) -> usize {
-    if let Some(k) = cli_k {
-        return k;
-    }
-
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(k) = config.get_default_k() {
-            return k;
-        }
-    }
-
-    default
+pub fn resolve_top_k(config: &Config, cli_k: Option<usize>, default: usize) -> usize {
+    cli_k.or_else(|| config.get_default_k()).unwrap_or(default)
 }
 
 /// Resolve context_lines (n): CLI arg > saved config > default
-pub fn resolve_context_lines(cli_n: Option<usize>, default: usize) -> usize {
-    if let Some(n) = cli_n {
-        return n;
-    }
-
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        if let Some(n) = config.get_default_n() {
-            return n;
-        }
-    }
-
-    default
+pub fn resolve_context_lines(config: &Config, cli_n: Option<usize>, default: usize) -> usize {
+    cli_n.or_else(|| config.get_default_n()).unwrap_or(default)
 }
 
 /// Resolve relative_paths: saved config > default (true = relative paths)
-pub fn resolve_relative_paths() -> bool {
-    if let Ok(config) = Config::load() {
-        return config.use_relative_paths();
-    }
-    true
+pub fn resolve_relative_paths(config: &Config) -> bool {
+    config.use_relative_paths()
 }
 
 /// Format a path for display, using relative or absolute based on config.
@@ -483,11 +454,8 @@ fn normalize_windows_path(path: &Path) -> PathBuf {
 }
 
 /// Resolve verbose: saved config > default (false)
-pub fn resolve_verbose() -> bool {
-    if let Ok(config) = Config::load() {
-        return config.is_verbose();
-    }
-    false
+pub fn resolve_verbose(config: &Config) -> bool {
+    config.is_verbose()
 }
 
 /// Deterministic ordering for search results: highest score first, then a
@@ -514,7 +482,11 @@ fn cmp_results_deterministic(
 }
 
 /// Resolve pool_factor: --no-pool > --pool-factor > config > default (2)
-pub fn resolve_pool_factor(cli_pool_factor: Option<usize>, no_pool: bool) -> Option<usize> {
+pub fn resolve_pool_factor(
+    config: &Config,
+    cli_pool_factor: Option<usize>,
+    no_pool: bool,
+) -> Option<usize> {
     if no_pool {
         return Some(1); // Disable pooling
     }
@@ -523,21 +495,15 @@ pub fn resolve_pool_factor(cli_pool_factor: Option<usize>, no_pool: bool) -> Opt
         return Some(factor.max(1)); // Minimum is 1
     }
 
-    // Try to load from config
-    if let Ok(config) = Config::load() {
-        return Some(config.get_pool_factor());
-    }
-
-    // Default pool factor
-    Some(colgrep::DEFAULT_POOL_FACTOR)
+    Some(config.get_pool_factor())
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_search(
     query: &str,
     paths: &[PathBuf],
-    top_k: usize,
-    top_k_explicit: bool,
+    cli_top_k: Option<usize>,
+    default_k: usize,
     cli_model: Option<&str>,
     json: bool,
     include_patterns: &[String],
@@ -554,21 +520,30 @@ pub fn cmd_search(
     code_only: bool,
     no_fts: bool,
     alpha: Option<f32>,
-    pool_factor: Option<usize>,
+    cli_pool_factor: Option<usize>,
+    no_pool: bool,
     auto_confirm: bool,
     static_batch: bool,
+    no_update: bool,
 ) -> Result<()> {
+    // Load the user config once for the whole command; every per-path search
+    // and resolver below reads from this snapshot instead of re-parsing the
+    // config file.
+    let config = Config::load().unwrap_or_default();
+
+    let top_k = resolve_top_k(&config, cli_top_k, default_k);
+    let pool_factor = resolve_pool_factor(&config, cli_pool_factor, no_pool);
     // Resolve context_lines: CLI > config > default (20)
-    let context_lines = resolve_context_lines(cli_context_lines, 20);
+    let context_lines = resolve_context_lines(&config, cli_context_lines, 20);
     // Resolve relative paths: config > default (false = absolute)
-    let use_relative = resolve_relative_paths();
+    let use_relative = resolve_relative_paths(&config);
 
     // When -e is used and the user didn't explicitly pass -k, return *all*
     // matching lines (parity with grep, which has no implicit cap). We keep
     // a finite ceiling so the upstream `top_k * 4` / `top_k * 20` multipliers
     // can't overflow; `usize::MAX / 1024` is still ~1.8e16, effectively
     // unbounded for any real index.
-    let regex_unbounded = text_pattern.is_some() && !top_k_explicit;
+    let regex_unbounded = text_pattern.is_some() && cli_top_k.is_none();
     let effective_top_k = if regex_unbounded {
         usize::MAX / 1024
     } else {
@@ -581,6 +556,7 @@ pub fn cmd_search(
 
     for path in paths {
         match search_single_path(
+            &config,
             query,
             path,
             effective_top_k,
@@ -601,6 +577,7 @@ pub fn cmd_search(
             pool_factor,
             auto_confirm,
             static_batch,
+            no_update,
         ) {
             Ok(results) => all_results.extend(results),
             Err(e) => {
@@ -672,7 +649,7 @@ pub fn cmd_search(
         let verbose = if show_content || cli_context_lines.is_some_and(|n| n > 0) {
             true // Force verbose when user explicitly requests content display
         } else {
-            resolve_verbose()
+            resolve_verbose(&config)
         };
 
         // Maximum characters of matching line content to show in compact mode
@@ -1032,6 +1009,7 @@ fn find_existing_parent_and_list(path: &Path) -> String {
 /// Search a single path and return results with absolute file paths
 #[allow(clippy::too_many_arguments)]
 fn search_single_path(
+    config: &Config,
     query: &str,
     path: &PathBuf,
     top_k: usize,
@@ -1052,6 +1030,7 @@ fn search_single_path(
     pool_factor: Option<usize>,
     auto_confirm: bool,
     static_batch: bool,
+    no_update: bool,
 ) -> Result<Vec<colgrep::SearchResult>> {
     let path = match std::fs::canonicalize(path) {
         Ok(p) => p,
@@ -1078,10 +1057,7 @@ fn search_single_path(
     let effective_extended_regexp = extended_regexp || (text_pattern.is_some() && !fixed_strings);
 
     // Resolve model: CLI > config > default
-    let model = resolve_model(cli_model);
-
-    // Load config for settings
-    let config = Config::load().unwrap_or_default();
+    let model = resolve_model(config, cli_model);
 
     // Resolve quantized setting from config (default: false = use FP32)
     let quantized = !config.use_fp32();
@@ -1089,16 +1065,16 @@ fn search_single_path(
     let parallel_sessions = config.configured_parallel_sessions();
     let batch_size = config.configured_batch_size();
 
-    // Check if index already exists for this model (suppress model output if so)
-    let has_existing_index =
-        index_exists(&search_path, &model) || find_parent_index(&search_path, &model)?.is_some();
-
-    // Ensure model is downloaded (quiet if we already have an index)
-    let model_path = ensure_model(Some(&model), has_existing_index)?;
-
-    // Check for parent index (scoped to current model) unless the resolved path
-    // is outside the current directory (external project)
-    let parent_info = {
+    // An index for this exact (path, model) pair takes precedence over any
+    // ancestor project's index, so the parent scan — a read_dir plus a
+    // project.json parse for every indexed project on the machine — runs only
+    // when there is no local index, and at most once per search. The parent
+    // scan is also skipped when the resolved path is outside the current
+    // directory (external project).
+    let local_index_exists = index_exists(&search_path, &model);
+    let parent_info = if local_index_exists {
+        None
+    } else {
         let current_dir = std::env::current_dir().ok();
         let is_external_project = is_external_project_path(&search_path, current_dir.as_deref());
 
@@ -1108,6 +1084,10 @@ fn search_single_path(
             find_parent_index(&search_path, &model)?
         }
     };
+
+    // Ensure model is downloaded (quiet if we already have an index)
+    let has_existing_index = local_index_exists || parent_info.is_some();
+    let model_path = ensure_model(Some(&model), has_existing_index)?;
 
     // Determine effective project root and subdirectory filter
     let (effective_root, subdir_filter): (PathBuf, Option<PathBuf>) = match &parent_info {
@@ -1143,8 +1123,10 @@ fn search_single_path(
 
     // Auto-index: try incremental update without blocking on the lock.
     // If another process is indexing, skip the update and search the existing index.
+    // --no-update skips this entirely: agents in hot search loops can opt out of
+    // paying the change-detection scan and any re-encoding before results return.
     let mut index_locked = false;
-    {
+    if !no_update {
         let mut builder = IndexBuilder::with_options(
             &effective_root,
             &model,
@@ -1231,6 +1213,12 @@ fn search_single_path(
     let index_dir = get_index_dir_for_project(&effective_root, &model)?;
     let vector_index_path = get_vector_index_path(&index_dir);
     if !vector_index_path.join("metadata.json").exists() {
+        if no_update {
+            anyhow::bail!(
+                "No index found and --no-update was passed. Run once without --no-update \
+                 (or `colgrep init`) to build the index first."
+            );
+        }
         if index_locked {
             // Index is being created for the first time by another process — nothing to search yet
             anyhow::bail!("colgrep index is currently being built, rely on grep for now.");
@@ -1306,6 +1294,12 @@ fn search_single_path(
             } =>
         {
             // Index is corrupted or empty (no concurrent updater) - clear and rebuild
+            if no_update {
+                return Err(e).with_context(|| {
+                    "Index appears corrupted and --no-update prevents rebuilding it. \
+                     Rerun without --no-update to repair the index."
+                });
+            }
             if !json && !files_only {
                 eprintln!("⚠️  Index corrupted, rebuilding...");
             }
@@ -1500,7 +1494,6 @@ fn search_single_path(
     let search_top_k = if code_only { top_k * 4 } else { top_k * 3 };
 
     // Resolve hybrid search: --semantic-only CLI flag overrides, then config, default is enabled
-    let config = colgrep::Config::load().unwrap_or_default();
     let hybrid_disabled = if no_fts {
         true
     } else {
@@ -1674,35 +1667,32 @@ mod tests {
     #[test]
     fn test_resolve_top_k_cli_provided() {
         // CLI value should take precedence
-        assert_eq!(resolve_top_k(Some(30), 15), 30);
-        assert_eq!(resolve_top_k(Some(1), 20), 1);
-        assert_eq!(resolve_top_k(Some(100), 15), 100);
+        let config = Config::default();
+        assert_eq!(resolve_top_k(&config, Some(30), 15), 30);
+        assert_eq!(resolve_top_k(&config, Some(1), 20), 1);
+        assert_eq!(resolve_top_k(&config, Some(100), 15), 100);
     }
 
     #[test]
     fn test_resolve_top_k_fallback_to_default() {
-        // When CLI not provided and no config, should use default
-        // Note: This test may be affected by actual config file
-        let result = resolve_top_k(None, 15);
-        // Should be either 25 (default) or whatever is in config
-        assert!(result > 0);
+        // When CLI not provided and config has no value, use the default
+        assert_eq!(resolve_top_k(&Config::default(), None, 15), 15);
     }
 
     // Test resolve_context_lines function
     #[test]
     fn test_resolve_context_lines_cli_provided() {
         // CLI value should take precedence
-        assert_eq!(resolve_context_lines(Some(10), 20), 10);
-        assert_eq!(resolve_context_lines(Some(0), 20), 0);
-        assert_eq!(resolve_context_lines(Some(30), 20), 30);
+        let config = Config::default();
+        assert_eq!(resolve_context_lines(&config, Some(10), 20), 10);
+        assert_eq!(resolve_context_lines(&config, Some(0), 20), 0);
+        assert_eq!(resolve_context_lines(&config, Some(30), 20), 30);
     }
 
     #[test]
     fn test_resolve_context_lines_fallback_to_default() {
-        // When CLI not provided and no config, should use default
-        let result = resolve_context_lines(None, 20);
-        // Should be either 20 (default) or whatever is in config
-        assert!(result <= 100); // sanity check
+        // When CLI not provided and config has no value, use the default
+        assert_eq!(resolve_context_lines(&Config::default(), None, 20), 20);
     }
 
     fn mk_result(file: &str, line: usize, end_line: usize, score: f32) -> colgrep::SearchResult {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -110,8 +110,38 @@ fn delete_files_from_index(index_path: &str, files: &[PathBuf]) -> Result<usize>
         return Ok(0);
     }
 
+    // Vector index (codes/residuals/IVF). Single batched rewrite (issue #116).
     delete_from_index_counted(&ids, index_path)?;
+
+    // Metadata and FTS5 must be deleted together and kept aligned. `filtering::delete`
+    // re-sequences the surviving `_subset_` IDs, so the FTS5 rows have to follow: a
+    // tail-only delete keeps every survivor's ID (drop just the deleted FTS rows,
+    // O(deleted)); any other delete shifts survivor IDs and needs a full FTS5 rebuild.
+    // This mirrors `next_plaid::MmapIndex::delete_with_options` — the standalone delete
+    // path used here previously updated the vector index and metadata but skipped FTS5,
+    // leaving deleted documents' text discoverable via regex/keyword (`-e`) search and,
+    // after re-sequencing, misaligned with the surviving rows. Detect the suffix case
+    // before `filtering::delete` renumbers the table.
+    let old_num_documents = filtering::count(index_path).map(|n| n as i64).unwrap_or(0);
+    let mut valid: Vec<i64> = ids
+        .iter()
+        .copied()
+        .filter(|&id| id >= 0 && id < old_num_documents)
+        .collect();
+    valid.sort_unstable();
+    valid.dedup();
+    let is_suffix_delete = {
+        let suffix_start = old_num_documents - valid.len() as i64;
+        valid.first().is_some_and(|&min| min >= suffix_start)
+    };
+
     filtering::delete(index_path, &ids)?;
+    if is_suffix_delete {
+        next_plaid::text_search::delete(index_path, &valid)?;
+    } else {
+        // Survivor IDs shifted; FTS5 rowids no longer match METADATA.
+        next_plaid::text_search::rebuild(index_path)?;
+    }
     Ok(ids.len())
 }
 
@@ -5252,11 +5282,45 @@ mod tests {
         MmapIndex::create_with_kmeans(&embeddings, index_path, &config).unwrap();
 
         let metadata: Vec<serde_json::Value> = (0..n)
-            .map(|i| serde_json::json!({ "file": files[i / docs_per_file] }))
+            .map(|i| {
+                let f = files[i / docs_per_file];
+                // Per-file unique, identifier-friendly token so FTS5 alignment after a
+                // delete can be asserted (each surviving file's token must still match,
+                // each deleted file's token must not).
+                let token = format!("marker_{}", f.replace('.', "_"));
+                serde_json::json!({ "file": f, "text": format!("def x(): # {token} body") })
+            })
             .collect();
         let doc_ids: Vec<i64> = (0..n as i64).collect();
         filtering::create(index_path, &metadata, &doc_ids).unwrap();
+        next_plaid::text_search::index(
+            index_path,
+            &metadata,
+            &doc_ids,
+            &next_plaid::FtsTokenizer::IdentifierAware,
+        )
+        .unwrap();
     }
+
+    /// Token a `build_fixture_index` file is indexed under in FTS5.
+    #[cfg(test)]
+    fn fixture_token(file: &str) -> String {
+        format!("marker_{}", file.replace('.', "_"))
+    }
+
+    /// Number of FTS5 hits for `token` (keyword path used by `-e`/hybrid search).
+    #[cfg(test)]
+    fn fts_hits(index_path: &str, token: &str) -> usize {
+        next_plaid::text_search::search(index_path, token, 100)
+            .map(|r| r.passage_ids.len())
+            .unwrap_or(0)
+    }
+
+    /// Serializes every test that calls `delete_files_from_index`. The tests that assert
+    /// the global `DELETE_FROM_INDEX_CALLS` counter read a before/after delta, which any
+    /// concurrent deleting test would otherwise corrupt under parallel execution.
+    #[cfg(test)]
+    static DELETE_TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// Issue #116: deleting many files must collapse into a *single* full-index rewrite, not one
     /// rewrite per file (which made incremental updates O(changed_files × index_size) and hung
@@ -5264,6 +5328,7 @@ mod tests {
     #[test]
     fn test_delete_files_from_index_is_a_single_rewrite() {
         use std::sync::atomic::Ordering;
+        let _serial = DELETE_TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
 
         let tmp = tempfile::tempdir().unwrap();
         let index_path = tmp.path().to_str().unwrap();
@@ -5296,6 +5361,7 @@ mod tests {
     #[test]
     fn test_delete_files_from_index_noop_does_not_rewrite() {
         use std::sync::atomic::Ordering;
+        let _serial = DELETE_TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
 
         let tmp = tempfile::tempdir().unwrap();
         let index_path = tmp.path().to_str().unwrap();
@@ -5308,6 +5374,71 @@ mod tests {
             0
         );
         assert_eq!(DELETE_FROM_INDEX_CALLS.load(Ordering::Relaxed) - before, 0);
+    }
+
+    /// Regression: `delete_files_from_index` must prune FTS5, not just the vector index
+    /// and metadata. Deleting a MIDDLE file re-sequences survivor IDs (the rebuild path),
+    /// so a stale FTS5 must not leave the deleted file's text searchable, and survivors'
+    /// keyword hits must still map to exactly their own docs. Previously the standalone
+    /// delete path skipped FTS5 entirely, so `-e`/keyword search kept finding deleted files.
+    #[test]
+    fn test_delete_files_from_index_prunes_fts5_middle() {
+        let _serial = DELETE_TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let index_path = tmp.path().to_str().unwrap();
+        let files = ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"];
+        let dpf = 2;
+        build_fixture_index(index_path, &files, dpf);
+
+        // sanity: every file is keyword-searchable before deletion
+        for f in files {
+            assert_eq!(fts_hits(index_path, &fixture_token(f)), dpf, "pre {f}");
+        }
+
+        // delete a middle file -> survivor IDs shift -> FTS5 rebuild path
+        let removed = delete_files_from_index(index_path, &[PathBuf::from("c.rs")]).unwrap();
+        assert_eq!(removed, dpf);
+
+        // deleted file's text must be gone from FTS5...
+        assert_eq!(
+            fts_hits(index_path, &fixture_token("c.rs")),
+            0,
+            "deleted file still keyword-searchable (stale FTS5)"
+        );
+        // ...and every survivor's keyword hits must still map to exactly its own docs
+        // (no cross-contamination from misaligned FTS5 rowids).
+        for f in ["a.rs", "b.rs", "d.rs", "e.rs"] {
+            assert_eq!(
+                fts_hits(index_path, &fixture_token(f)),
+                dpf,
+                "survivor {f} keyword hits misaligned after delete"
+            );
+        }
+    }
+
+    /// Regression: tail-of-ID-space delete takes the O(deleted) FTS5 suffix path; it must
+    /// still drop the deleted file's rows and leave survivors aligned.
+    #[test]
+    fn test_delete_files_from_index_prunes_fts5_suffix() {
+        let _serial = DELETE_TEST_SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let index_path = tmp.path().to_str().unwrap();
+        let files = ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"];
+        let dpf = 2;
+        build_fixture_index(index_path, &files, dpf);
+
+        // delete the LAST file -> its doc IDs are the tail -> FTS5 suffix-delete path
+        let removed = delete_files_from_index(index_path, &[PathBuf::from("e.rs")]).unwrap();
+        assert_eq!(removed, dpf);
+
+        assert_eq!(
+            fts_hits(index_path, &fixture_token("e.rs")),
+            0,
+            "tail-deleted still found"
+        );
+        for f in ["a.rs", "b.rs", "c.rs", "d.rs"] {
+            assert_eq!(fts_hits(index_path, &fixture_token(f)), dpf, "survivor {f}");
+        }
     }
 
     /// Issue #115 (bug 1): an index left dirty by an interrupted run must be cleaned once the

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -32,7 +32,7 @@ use paths::{
     acquire_index_lock, get_index_dir_for_project, get_vector_index_path, try_acquire_index_lock,
     ProjectMetadata,
 };
-use state::{get_mtime, hash_file, FileInfo, IndexState};
+use state::{file_stat, hash_file, FileInfo, IndexState, INDEX_FORMAT_VERSION};
 
 /// Maximum file size to index (512 KB)
 /// Files larger than this are skipped to avoid:
@@ -126,8 +126,8 @@ fn delete_files_from_index(index_path: &str, files: &[PathBuf]) -> Result<usize>
 ///   whole. See issue #115.
 /// - `metadata.json` present and a filtering DB present (rules out absent/stale-format stores
 ///   that `index()` would discard anyway).
-/// - State loads, is non-empty, matches the current CLI version, and isn't dirty.
-fn seed_source_state(src_dir: &Path, current_version: &str) -> Option<IndexState> {
+/// - State loads, is non-empty, has a compatible index format, and isn't dirty.
+fn seed_source_state(src_dir: &Path) -> Option<IndexState> {
     if src_dir.join(BUILDING_MARKER).exists() {
         return None;
     }
@@ -139,7 +139,13 @@ fn seed_source_state(src_dir: &Path, current_version: &str) -> Option<IndexState
     }
 
     match IndexState::load(src_dir) {
-        Ok(s) if !s.files.is_empty() && s.cli_version == current_version && !s.dirty => Some(s),
+        Ok(s)
+            if !s.files.is_empty()
+                && s.index_format_version == INDEX_FORMAT_VERSION
+                && !s.dirty =>
+        {
+            Some(s)
+        }
         _ => None,
     }
 }
@@ -184,16 +190,21 @@ const CODING_QUEUE_CAPACITY: usize = 2;
 const DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS: usize = 1;
 
 /// Pick the default number of ONNX sessions for indexing based on the chosen execution
-/// provider, when the user has not set `settings --parallel`.
+/// provider and the size of the encoding workload, when the user has not set
+/// `settings --parallel`.
 ///
-/// - **CPU**: scale with available cores. The bounded pipeline queues cap how far encoding
-///   can run ahead of indexing, so more sessions improve throughput without the unbounded
-///   memory growth that motivated the queue bounds — this is the fast default.
+/// - **CPU**: scale with available cores, but cap by the workload via
+///   [`IndexBuilder::capped_default_sessions`] — spinning up more sessions than there are
+///   ~`DEFAULT_ENCODE_BATCH_SIZE`-unit chunks just wastes per-session graph build time. The
+///   bounded pipeline queues keep memory flat regardless of session count.
 /// - **Accelerators** (CoreML/CUDA/DirectML/MIGraphX): keep a single session by default,
 ///   since each one duplicates the model in device memory. Users can raise it explicitly.
-fn default_index_parallel_sessions(execution_provider: ExecutionProvider) -> usize {
+fn default_index_parallel_sessions(
+    execution_provider: ExecutionProvider,
+    num_units: usize,
+) -> usize {
     match execution_provider {
-        ExecutionProvider::Cpu => crate::config::get_default_cpu_parallel_sessions(),
+        ExecutionProvider::Cpu => IndexBuilder::capped_default_sessions(num_units),
         _ => DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS,
     }
 }
@@ -253,6 +264,12 @@ fn indexing_execution_provider_for_acceleration_mode(mode: AccelerationMode) -> 
     }
 }
 
+/// Maximum documents accumulated on the update path before flushing to the
+/// PLAID index. Each flush rewrites the full IVF and invalidates the merged
+/// mmap files (O(index size) regardless of batch size), so bigger batches mean
+/// fewer full-index rewrites; the cap bounds the embeddings held in memory.
+const UPDATE_FLUSH_DOC_LIMIT: usize = 8192;
+
 struct ParsedFileResult {
     path: PathBuf,
     units: Vec<CodeUnit>,
@@ -275,6 +292,11 @@ pub struct UpdatePlan {
     pub changed: Vec<PathBuf>,
     pub deleted: Vec<PathBuf>,
     pub unchanged: usize,
+    /// Files whose content is unchanged (hash matches) but whose mtime/size on
+    /// disk drifted from what state recorded — e.g. after `git checkout` or
+    /// `touch`. They need no re-embedding, only a refreshed `FileInfo` persisted
+    /// so the stat-only fast path applies next run instead of re-hashing forever.
+    pub touched: Vec<(PathBuf, FileInfo)>,
 }
 
 // ============================================================================
@@ -613,20 +635,67 @@ fn run_index_stage(
         return Ok(());
     }
 
-    while let Ok(chunk) = receiver.recv() {
-        let _guard = CriticalSectionGuard::new();
-        let (_, doc_ids) =
-            MmapIndex::update_or_create(&chunk.embeddings, &index_path, &config, &update_config)?;
+    // Update path: accumulate pipeline chunks and flush in large batches.
+    // Every MmapIndex::update_or_create call rewrites the full IVF and deletes
+    // the merged mmap files no matter how few documents it adds, so its cost is
+    // O(index size) per call. Flushing once per UPDATE_FLUSH_DOC_LIMIT documents
+    // instead of once per pipeline chunk means a typical incremental update pays
+    // that cost exactly once.
+    let mut pending_units: Vec<Arc<CodeUnit>> = Vec::new();
+    let mut pending_embeddings: Vec<ndarray::Array2<f32>> = Vec::new();
 
-        sender
-            .send(IndexedChunkForMetadata {
-                units: chunk.units,
-                doc_ids,
-            })
-            .context("Failed to send indexed chunk to metadata stage")?;
+    while let Ok(chunk) = receiver.recv() {
+        pending_units.extend(chunk.units);
+        pending_embeddings.extend(chunk.embeddings);
+
+        if pending_embeddings.len() >= UPDATE_FLUSH_DOC_LIMIT {
+            flush_update_batch(
+                &mut pending_units,
+                &mut pending_embeddings,
+                &sender,
+                &index_path,
+                &config,
+                &update_config,
+            )?;
+        }
     }
 
+    flush_update_batch(
+        &mut pending_units,
+        &mut pending_embeddings,
+        &sender,
+        &index_path,
+        &config,
+        &update_config,
+    )?;
+
     Ok(())
+}
+
+/// Write one accumulated batch to the PLAID index and hand the assigned doc IDs
+/// to the metadata stage. No-op when the batch is empty.
+fn flush_update_batch(
+    units: &mut Vec<Arc<CodeUnit>>,
+    embeddings: &mut Vec<ndarray::Array2<f32>>,
+    sender: &mpsc::SyncSender<IndexedChunkForMetadata>,
+    index_path: &str,
+    config: &IndexConfig,
+    update_config: &UpdateConfig,
+) -> Result<()> {
+    if embeddings.is_empty() {
+        return Ok(());
+    }
+
+    let _guard = CriticalSectionGuard::new();
+    let (_, doc_ids) = MmapIndex::update_or_create(embeddings, index_path, config, update_config)?;
+    embeddings.clear();
+
+    sender
+        .send(IndexedChunkForMetadata {
+            units: std::mem::take(units),
+            doc_ids,
+        })
+        .context("Failed to send indexed chunk to metadata stage")
 }
 
 /// Number of candidates exactly re-ranked with MaxSim after the cheap
@@ -855,14 +924,11 @@ fn parse_files_parallel(
                     Ok(source) => {
                         let units = extract_units(path, &source, lang);
                         match hash_file(&full_path) {
-                            Ok(content_hash) => match get_mtime(&full_path) {
-                                Ok(mtime) => ParsedFileResult {
+                            Ok(content_hash) => match FileInfo::probe(&full_path, content_hash) {
+                                Ok(file_info) => ParsedFileResult {
                                     path: path.clone(),
                                     units,
-                                    file_info: Some(FileInfo {
-                                        content_hash,
-                                        mtime,
-                                    }),
+                                    file_info: Some(file_info),
                                     skip_reason: None,
                                 },
                                 Err(e) => ParsedFileResult {
@@ -1002,6 +1068,17 @@ impl IndexBuilder {
         self.dynamic_batch = dynamic_batch;
     }
 
+    /// Default session count for an encoding workload of `num_units` units.
+    /// Each ONNX session pays a full graph parse/optimize/allocate on build, so
+    /// spinning up the machine-wide default (up to 16) to encode a handful of
+    /// changed units costs far more in session builds than it saves in
+    /// parallelism. One session per DEFAULT_ENCODE_BATCH_SIZE units amortizes
+    /// the build cost; explicit user configuration bypasses this cap.
+    fn capped_default_sessions(num_units: usize) -> usize {
+        let max_useful_sessions = num_units.div_ceil(DEFAULT_ENCODE_BATCH_SIZE).max(1);
+        crate::config::get_default_cpu_parallel_sessions().min(max_useful_sessions)
+    }
+
     /// Ensure the model is created for encoding.
     /// The model is lazily created on first use to avoid overhead when just scanning files
     /// or when checking for index updates that have no changes.
@@ -1025,7 +1102,7 @@ impl IndexBuilder {
 
                         (
                             self.parallel_sessions.unwrap_or_else(|| {
-                                default_index_parallel_sessions(ExecutionProvider::Cpu)
+                                default_index_parallel_sessions(ExecutionProvider::Cpu, num_units)
                             }),
                             ExecutionProvider::Cpu,
                         )
@@ -1076,7 +1153,10 @@ impl IndexBuilder {
                         } else {
                             (
                                 self.parallel_sessions.unwrap_or_else(|| {
-                                    default_index_parallel_sessions(ExecutionProvider::Cpu)
+                                    default_index_parallel_sessions(
+                                        ExecutionProvider::Cpu,
+                                        num_units,
+                                    )
                                 }),
                                 ExecutionProvider::Cpu,
                             )
@@ -1091,14 +1171,13 @@ impl IndexBuilder {
                 feature = "coreml"
             )))]
             let (num_sessions, execution_provider) = {
-                let _ = num_units;
-
                 crate::onnx_runtime::ensure_onnx_runtime()
                     .context("Failed to initialize ONNX Runtime")?;
 
                 (
-                    self.parallel_sessions
-                        .unwrap_or_else(|| default_index_parallel_sessions(ExecutionProvider::Cpu)),
+                    self.parallel_sessions.unwrap_or_else(|| {
+                        default_index_parallel_sessions(ExecutionProvider::Cpu, num_units)
+                    }),
                     ExecutionProvider::Cpu,
                 )
             };
@@ -1106,8 +1185,6 @@ impl IndexBuilder {
             #[cfg(any(feature = "directml", feature = "migraphx", feature = "coreml"))]
             #[cfg(not(feature = "cuda"))]
             let (num_sessions, execution_provider) = {
-                let _ = num_units;
-
                 let execution_provider = indexing_execution_provider_for_acceleration_mode(
                     env_acceleration_mode_lossy(),
                 );
@@ -1116,8 +1193,9 @@ impl IndexBuilder {
                     .context("Failed to initialize ONNX Runtime")?;
 
                 (
-                    self.parallel_sessions
-                        .unwrap_or_else(|| default_index_parallel_sessions(execution_provider)),
+                    self.parallel_sessions.unwrap_or_else(|| {
+                        default_index_parallel_sessions(execution_provider, num_units)
+                    }),
                     execution_provider,
                 )
             };
@@ -1178,9 +1256,11 @@ impl IndexBuilder {
         self.model = None;
         apply_acceleration_mode(AccelerationMode::ForceCpu);
 
+        // CPU fallback rebuild: the original unit count isn't threaded here, so use the
+        // uncapped (cores-based) CPU default — `usize::MAX` disables the workload cap.
         let num_sessions = self
             .parallel_sessions
-            .unwrap_or_else(|| default_index_parallel_sessions(ExecutionProvider::Cpu));
+            .unwrap_or_else(|| default_index_parallel_sessions(ExecutionProvider::Cpu, usize::MAX));
         let batch = crate::config::DEFAULT_BATCH_SIZE_CPU;
 
         let model = crate::stderr::with_suppressed_stderr(|| {
@@ -1337,14 +1417,10 @@ impl IndexBuilder {
 
             // Only add files that still exist on disk
             if full_path.exists() {
-                if let (Ok(hash), Ok(mtime)) = (hash_file(&full_path), get_mtime(&full_path)) {
-                    state.files.insert(
-                        file_path,
-                        FileInfo {
-                            content_hash: hash,
-                            mtime,
-                        },
-                    );
+                if let Ok(hash) = hash_file(&full_path) {
+                    if let Ok(file_info) = FileInfo::probe(&full_path, hash) {
+                        state.files.insert(file_path, file_info);
+                    }
                 }
             }
             // Files that don't exist will be detected as deleted in incremental_update
@@ -1463,7 +1539,7 @@ impl IndexBuilder {
     /// - Creates index if none exists
     /// - Updates incrementally if files changed
     /// - Full rebuild if `force = true`
-    /// - Full rebuild if CLI version changed (clears outdated index)
+    /// - Full rebuild if the on-disk index format is incompatible
     pub fn index(&mut self, languages: Option<&[Language]>, force: bool) -> Result<UpdateStats> {
         let _lock = acquire_index_lock(&self.index_dir)?;
         self.run_indexing(languages, force)
@@ -1472,7 +1548,7 @@ impl IndexBuilder {
     /// Shared indexing dispatch, run while the index lock is held by the caller.
     ///
     /// Routing:
-    /// - forced or CLI-version change → atomic `full_rebuild` (protects a working index);
+    /// - forced or index-format change → atomic `full_rebuild` (protects a working index);
     /// - a fresh build, or resuming an interrupted resumable build → `build_resumable`
     ///   (checkpoints per batch so interruptions keep their progress);
     /// - corrupted filtering DB → atomic `full_rebuild`;
@@ -1493,14 +1569,21 @@ impl IndexBuilder {
         let filtering_exists = filtering::exists(index_path);
         let building = self.index_dir.join(BUILDING_MARKER).exists();
 
-        // Check if CLI version changed - if so, clear and rebuild the index
-        let current_version = env!("CARGO_PKG_VERSION");
-        let version_mismatch =
-            index_exists && !state.cli_version.is_empty() && state.cli_version != current_version;
+        // Rebuild only when the on-disk index format is incompatible with this
+        // binary. Gating on the CLI version instead meant every routine release
+        // discarded every index and re-embedded the entire project.
+        //
+        // A missing/empty state.json also deserializes to format version 0, but
+        // that case must stay on the cheap reconstruct-from-filtering-DB path
+        // below rather than a full re-embed — hence the non-empty-files guard
+        // (a genuine legacy-format state always has tracked files).
+        let format_mismatch = index_exists
+            && !state.files.is_empty()
+            && state.index_format_version != INDEX_FORMAT_VERSION;
 
-        // Forced or CLI-version change: clean atomic rebuild. Drop any in-progress
+        // Forced or index-format change: clean atomic rebuild. Drop any in-progress
         // resumable-build marker so we don't try to resume an index we're discarding.
-        if force || version_mismatch {
+        if force || format_mismatch {
             let _ = std::fs::remove_file(self.index_dir.join(BUILDING_MARKER));
             return self.full_rebuild(languages);
         }
@@ -1829,14 +1912,13 @@ impl IndexBuilder {
     /// Copy a usable sibling worktree's index into this project's index directory.
     /// Returns `Ok(true)` if an index was seeded, `Ok(false)` if no suitable sibling exists.
     fn try_seed_from_sibling_worktree(&self) -> Result<bool> {
-        let current_version = env!("CARGO_PKG_VERSION");
         let candidates = worktree::seed_candidates(&self.project_root, &self.model_id)?;
 
         for candidate in candidates {
             let src_dir = &candidate.index_dir;
-            // Validate the sibling holds a complete, current-version, non-dirty index that
+            // Validate the sibling holds a complete, format-compatible, non-dirty index that
             // isn't mid-build. Skip otherwise so we never seed from a half-built or stale store.
-            let Some(src_state) = seed_source_state(src_dir, current_version) else {
+            let Some(src_state) = seed_source_state(src_dir) else {
                 continue;
             };
             let src_vector = get_vector_index_path(src_dir);
@@ -1855,7 +1937,7 @@ impl IndexBuilder {
             std::fs::rename(&tmp, &dest_vector)
                 .context("Failed to move seeded index into place")?;
 
-            // Persist state (rewriting cli_version to current — guaranteed equal here) and a
+            // Persist state (save() restamps the version/format fields) and a
             // fresh project.json pointing at THIS worktree, not the source.
             src_state.save(&self.index_dir)?;
             ProjectMetadata::new(&self.project_root, &self.model_id).save(&self.index_dir)?;
@@ -2282,9 +2364,18 @@ impl IndexBuilder {
             }
         }
 
-        // 0. Clean up orphaned entries (files in index but not on disk)
-        // This handles directory deletion/rename and any inconsistencies
-        let orphaned_deleted = self.cleanup_orphaned_entries(index_path)?;
+        // 0. Clean up orphaned entries (files in index but not on disk).
+        // This handles directory deletion/rename and any inconsistencies, but it
+        // queries every distinct file in the metadata DB and stats each one — too
+        // expensive to run on every search. Deletions in the plan already cover the
+        // common case; the periodic trigger is a safety net for true desyncs.
+        let should_cleanup = !plan.deleted.is_empty()
+            || (old_state.search_count > 0 && old_state.search_count.is_multiple_of(50));
+        let orphaned_deleted = if should_cleanup {
+            self.cleanup_orphaned_entries(index_path)?
+        } else {
+            0
+        };
 
         // Nothing to do
         if plan.added.is_empty()
@@ -2292,12 +2383,17 @@ impl IndexBuilder {
             && plan.deleted.is_empty()
             && orphaned_deleted == 0
         {
-            // If the previous run left the index dirty, the repair above already brought the
-            // store back in sync — so clear the flag now. Returning without persisting would
-            // leave the index permanently dirty, forcing a (costly) repair on every future
-            // run even though nothing is wrong. See issue #115.
-            if old_state.dirty {
+            // Nothing to re-embed. Still persist if either (a) some files' stat
+            // drifted without a content change (refresh them so we don't re-hash
+            // every run), or (b) the previous run left the index dirty — the
+            // repair above already resynced the store, so clear the flag now.
+            // Returning without persisting would force a re-hash or a costly
+            // repair on every future run even though nothing is wrong (#115).
+            if !plan.touched.is_empty() || old_state.dirty {
                 let mut state = old_state.clone();
+                for (path, info) in &plan.touched {
+                    state.files.insert(path.clone(), info.clone());
+                }
                 state.dirty = false;
                 state.save(&self.index_dir)?;
             }
@@ -2311,6 +2407,10 @@ impl IndexBuilder {
         }
 
         let mut state = old_state.clone();
+        // Refresh stat-drifted-but-unchanged files so the fast path applies next run.
+        for (path, info) in &plan.touched {
+            state.files.insert(path.clone(), info.clone());
+        }
 
         if !plan.deleted.is_empty() || !plan.changed.is_empty() || !plan.added.is_empty() {
             state.dirty = true;
@@ -2761,6 +2861,22 @@ impl IndexBuilder {
                 continue;
             }
             let full_path = self.project_root.join(path);
+
+            // Fast path: if mtime AND size are both unchanged, skip expensive
+            // content hashing. Without this gate every search reads and hashes
+            // every file in the repo before returning results. mtime is compared
+            // at nanosecond precision and paired with size so a same-second edit
+            // can't slip through.
+            let current_stat = file_stat(&full_path).ok();
+            if let (Some(info), Some((current_mtime, current_size))) =
+                (state.files.get(path), current_stat)
+            {
+                if info.mtime == current_mtime && info.size == current_size {
+                    plan.unchanged += 1;
+                    continue;
+                }
+            }
+
             let hash = match hash_file(&full_path) {
                 Ok(h) => h,
                 Err(e) => {
@@ -2770,7 +2886,24 @@ impl IndexBuilder {
             };
 
             match state.files.get(path) {
-                Some(info) if info.content_hash == hash => plan.unchanged += 1,
+                Some(info) if info.content_hash == hash => {
+                    // Content is identical but the stat drifted (e.g. `touch`,
+                    // branch switch). Record the refreshed FileInfo so it gets
+                    // persisted and the stat-only fast path applies next run.
+                    if let Some((current_mtime, current_size)) = current_stat {
+                        if info.mtime != current_mtime || info.size != current_size {
+                            plan.touched.push((
+                                path.clone(),
+                                FileInfo {
+                                    content_hash: hash,
+                                    mtime: current_mtime,
+                                    size: current_size,
+                                },
+                            ));
+                        }
+                    }
+                    plan.unchanged += 1;
+                }
                 Some(_) => plan.changed.push(path.clone()),
                 None => plan.added.push(path.clone()),
             }
@@ -4236,6 +4369,161 @@ fn prompt_large_index_confirmation(num_units: usize) -> bool {
 mod tests {
     use super::*;
 
+    /// The mtime fast path in `compute_update_plan` must skip content hashing
+    /// for files whose stored mtime is unchanged. The stored hash is wrong on
+    /// purpose: if the plan still reports the file as unchanged, hashing was
+    /// skipped; once the mtime moves, the hash mismatch must be detected.
+    /// Regression test — this gate was added in d0423d9 (4x query speedup on
+    /// large repos) and silently lost in the d76cb4a rewrite.
+    #[test]
+    fn test_update_plan_skips_hashing_when_mtime_unchanged() {
+        let temp = tempfile::tempdir().unwrap();
+        let file_path = temp.path().join("lib.py");
+        std::fs::write(&file_path, "def f():\n    return 1\n").unwrap();
+
+        let builder = test_builder(temp.path(), &temp.path().join("index"));
+
+        let mut state = IndexState::default();
+        // Bogus hash on purpose: a matching mtime+size must skip the hash entirely.
+        state.files.insert(
+            PathBuf::from("lib.py"),
+            FileInfo::probe(&file_path, 0xDEAD_BEEF).unwrap(),
+        );
+
+        let plan = builder.compute_update_plan(&state, None).unwrap();
+        assert_eq!(
+            plan.unchanged, 1,
+            "matching mtime+size must skip the content-hash comparison"
+        );
+        assert!(plan.changed.is_empty());
+
+        // Move the mtime forward: the fast path no longer applies, so the
+        // stale stored hash must now be detected as a change.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&file_path)
+            .unwrap();
+        file.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(120))
+            .unwrap();
+        drop(file);
+
+        let plan = builder.compute_update_plan(&state, None).unwrap();
+        assert_eq!(plan.changed, vec![PathBuf::from("lib.py")]);
+        assert_eq!(plan.unchanged, 0);
+    }
+
+    /// When a file's mtime drifts but its content is unchanged (e.g. `touch`,
+    /// `git checkout`), the plan must classify it as unchanged AND record a
+    /// `touched` refresh so the stat-only fast path applies next run instead of
+    /// re-hashing the file on every subsequent search.
+    #[test]
+    fn test_update_plan_refreshes_touched_files_with_unchanged_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let file_path = temp.path().join("lib.py");
+        std::fs::write(&file_path, "def f():\n    return 1\n").unwrap();
+
+        let builder = test_builder(temp.path(), &temp.path().join("index"));
+
+        // Stored state has the *correct* content hash and size, but a stale mtime.
+        let real = FileInfo::probe(&file_path, hash_file(&file_path).unwrap()).unwrap();
+        let mut state = IndexState::default();
+        state.files.insert(
+            PathBuf::from("lib.py"),
+            FileInfo {
+                mtime: real.mtime.saturating_sub(1),
+                ..real.clone()
+            },
+        );
+
+        let plan = builder.compute_update_plan(&state, None).unwrap();
+        assert_eq!(plan.unchanged, 1);
+        assert!(plan.changed.is_empty());
+        assert_eq!(
+            plan.touched.len(),
+            1,
+            "stale mtime must be queued for refresh"
+        );
+        assert_eq!(plan.touched[0].0, PathBuf::from("lib.py"));
+        assert_eq!(plan.touched[0].1.mtime, real.mtime);
+        assert_eq!(plan.touched[0].1.size, real.size);
+    }
+
+    /// Measures what the mtime fast path saves on the per-search update plan:
+    /// the same synthetic tree planned once with matching stored mtimes
+    /// (stat-only fast path) and once with mismatched mtimes but identical
+    /// content (forces a read + xxh3 of every byte — what every search paid
+    /// without the fast path). Hashing runs with a warm page cache, so the
+    /// printed ratio understates the cold-cache real world.
+    ///
+    ///   cargo test -p colgrep --release measure_update_plan -- --ignored --nocapture
+    #[test]
+    #[ignore = "timing measurement; run manually in release mode"]
+    fn measure_update_plan_mtime_fast_path() {
+        const FILES: usize = 5_000;
+        const FILE_BYTES: usize = 200 * 1024;
+
+        let temp = tempfile::tempdir().unwrap();
+        let line = "x = 1  # padding so the hasher does representative work\n";
+        let blob = line.repeat(FILE_BYTES / line.len());
+
+        let mut matching_mtimes = IndexState::default();
+        let mut mismatched_mtimes = IndexState::default();
+        for i in 0..FILES {
+            let rel = PathBuf::from(format!("mod_{i:04}.py"));
+            let full = temp.path().join(&rel);
+            std::fs::write(&full, &blob).unwrap();
+            let content_hash = hash_file(&full).unwrap();
+            let (mtime, size) = file_stat(&full).unwrap();
+            matching_mtimes.files.insert(
+                rel.clone(),
+                FileInfo {
+                    content_hash,
+                    mtime,
+                    size,
+                },
+            );
+            mismatched_mtimes.files.insert(
+                rel,
+                FileInfo {
+                    content_hash,
+                    mtime: mtime + 1,
+                    size,
+                },
+            );
+        }
+
+        let builder = test_builder(temp.path(), &temp.path().join("index"));
+
+        let started = std::time::Instant::now();
+        let plan = builder
+            .compute_update_plan(&mismatched_mtimes, None)
+            .unwrap();
+        let hashed_every_file = started.elapsed();
+        assert_eq!(plan.unchanged, FILES);
+
+        let started = std::time::Instant::now();
+        let plan = builder.compute_update_plan(&matching_mtimes, None).unwrap();
+        let stat_only = started.elapsed();
+        assert_eq!(plan.unchanged, FILES);
+
+        // The walk scales with file count and is paid either way; the
+        // read+hash component the fast path removes scales with repo bytes.
+        let removed = hashed_every_file.saturating_sub(stat_only);
+        println!(
+            "update plan, {} files x {} KiB ({} MiB total):\n  \
+             full hashing (pre-fix per-search cost): {:?}\n  \
+             mtime fast path:                        {:?}  ({:.1}x faster)\n  \
+             read+hash component removed per search: {:?} (scales with repo bytes)",
+            FILES,
+            FILE_BYTES / 1024,
+            FILES * FILE_BYTES / (1024 * 1024),
+            hashed_every_file,
+            stat_only,
+            hashed_every_file.as_secs_f64() / stat_only.as_secs_f64().max(f64::EPSILON),
+            removed,
+        );
+    }
+
     #[test]
     fn test_force_cpu_execution_provider_is_cpu() {
         assert_eq!(
@@ -4256,22 +4544,36 @@ mod tests {
 
     #[test]
     fn test_accelerator_indexing_parallel_default_is_memory_bounded() {
-        // Accelerator providers keep one session by default: each is a full model copy in
-        // device memory.
+        // Accelerator providers keep one session by default regardless of workload size:
+        // each is a full model copy in device memory.
         assert_eq!(DEFAULT_INDEX_ACCEL_PARALLEL_SESSIONS, 1);
         assert_eq!(
-            default_index_parallel_sessions(ExecutionProvider::CoreML),
+            default_index_parallel_sessions(ExecutionProvider::CoreML, 1),
+            1
+        );
+        assert_eq!(
+            default_index_parallel_sessions(ExecutionProvider::CoreML, 1_000_000),
             1
         );
     }
 
     #[test]
-    fn test_cpu_indexing_parallel_default_scales_with_cores() {
-        // CPU indexing defaults to the cores-based session count for speed; the bounded
-        // pipeline queues keep memory in check regardless of session count.
+    fn test_cpu_indexing_parallel_default_scales_with_cores_and_workload() {
+        // A large workload uses the full cores-based default (the bounded pipeline queues
+        // keep memory in check regardless of session count)...
         assert_eq!(
-            default_index_parallel_sessions(ExecutionProvider::Cpu),
+            default_index_parallel_sessions(ExecutionProvider::Cpu, usize::MAX),
             crate::config::get_default_cpu_parallel_sessions()
+        );
+        // ...while a tiny workload is capped so we don't pay per-session graph builds that
+        // can never be used: one session per ~DEFAULT_ENCODE_BATCH_SIZE units, min 1.
+        assert_eq!(
+            default_index_parallel_sessions(ExecutionProvider::Cpu, 1),
+            1
+        );
+        assert!(
+            default_index_parallel_sessions(ExecutionProvider::Cpu, DEFAULT_ENCODE_BATCH_SIZE + 1)
+                <= crate::config::get_default_cpu_parallel_sessions()
         );
     }
 
@@ -5058,31 +5360,71 @@ mod tests {
             FileInfo {
                 content_hash: 1,
                 mtime: 1,
+                size: 0,
             },
         );
-        state.save(src_dir).unwrap(); // save() stamps cli_version to the current version
-        let version = env!("CARGO_PKG_VERSION");
+        state.save(src_dir).unwrap(); // save() stamps the current format version
 
         // Complete index, no marker → usable seed source.
-        assert!(seed_source_state(src_dir, version).is_some());
+        assert!(seed_source_state(src_dir).is_some());
 
         // Interrupted/in-progress build → rejected.
         std::fs::write(src_dir.join(BUILDING_MARKER), "").unwrap();
         assert!(
-            seed_source_state(src_dir, version).is_none(),
+            seed_source_state(src_dir).is_none(),
             "issue #115: an in-progress (.building) sibling index must not be used as a seed"
         );
         std::fs::remove_file(src_dir.join(BUILDING_MARKER)).unwrap();
 
         // Sanity: the other rejection reasons still hold.
-        assert!(
-            seed_source_state(src_dir, "0.0.0-other").is_none(),
-            "version mismatch"
-        );
+        // Incompatible index format (save() always stamps the current one, so
+        // patch the persisted JSON directly).
+        let state_path = paths::get_state_path(src_dir);
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+        raw["index_format_version"] = serde_json::json!(INDEX_FORMAT_VERSION + 1);
+        std::fs::write(&state_path, serde_json::to_string(&raw).unwrap()).unwrap();
+        assert!(seed_source_state(src_dir).is_none(), "format mismatch");
+
         let mut dirty = IndexState::load(src_dir).unwrap();
         dirty.dirty = true;
-        // Re-save with dirty set (save() preserves the flag, only rewrites cli_version).
+        // Re-save with dirty set (save() preserves the flag, restamps version/format).
         dirty.save(src_dir).unwrap();
-        assert!(seed_source_state(src_dir, version).is_none(), "dirty index");
+        assert!(seed_source_state(src_dir).is_none(), "dirty index");
+    }
+
+    /// A missing state.json must not be mistaken for an incompatible index format.
+    /// A default-constructed state deserializes with `index_format_version == 0`,
+    /// which differs from `INDEX_FORMAT_VERSION`; gating the rebuild on that alone
+    /// would send a healthy index through a full re-embed instead of the cheap
+    /// reconstruct-from-filtering-DB path.
+    #[test]
+    fn test_missing_state_reconstructs_instead_of_full_rebuild() {
+        let proj = tempfile::tempdir().unwrap();
+        let idx = tempfile::tempdir().unwrap();
+
+        // A real (model-free) vector index + filtering DB referencing one project
+        // file, but no state.json (deleted, or written by a pre-versioning build).
+        std::fs::write(proj.path().join("a.rs"), "fn a() {}\n").unwrap();
+        let vector = get_vector_index_path(idx.path());
+        std::fs::create_dir_all(&vector).unwrap();
+        build_fixture_index(vector.to_str().unwrap(), &["a.rs"], 2);
+
+        let mut builder = test_builder(proj.path(), idx.path());
+        // A full rebuild would need the builder's model (nonexistent) and fail;
+        // the reconstruct path sees the on-disk file as unchanged.
+        let stats = builder.run_indexing(None, false).unwrap();
+
+        assert_eq!(
+            stats.unchanged, 1,
+            "file must be recognized, not re-embedded"
+        );
+        let state = IndexState::load(idx.path()).unwrap();
+        assert_eq!(
+            state.files.len(),
+            1,
+            "state must be reconstructed from the DB"
+        );
+        assert_eq!(state.index_format_version, INDEX_FORMAT_VERSION);
     }
 }

--- a/colgrep/src/index/state.rs
+++ b/colgrep/src/index/state.rs
@@ -8,11 +8,21 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use super::paths::get_state_path;
 
+/// Version of the on-disk index format (chunk layout, embedding pipeline,
+/// metadata schema). Bump ONLY for incompatible changes: a mismatch discards
+/// the index and re-embeds the entire project on the next run. Routine CLI
+/// releases must NOT bump this.
+pub const INDEX_FORMAT_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IndexState {
-    /// CLI version that created/updated this index
+    /// CLI version that created/updated this index (diagnostic only)
     #[serde(default)]
     pub cli_version: String,
+    /// Index format version this index was written with. Indexes from before
+    /// this field existed deserialize as 0 and rebuild once.
+    #[serde(default)]
+    pub index_format_version: u32,
     pub files: HashMap<PathBuf, FileInfo>,
     /// Files that failed to parse (e.g. invalid UTF-8) — skipped on future runs
     #[serde(default)]
@@ -28,7 +38,28 @@ pub struct IndexState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileInfo {
     pub content_hash: u64,
+    /// File mtime in **nanoseconds** since the Unix epoch. Nanosecond precision
+    /// (not seconds) so that an edit landing in the same wall-clock second as the
+    /// last index update is still detected by the stat-only fast path.
     pub mtime: u64,
+    /// File size in bytes, compared alongside `mtime` as a cheap second guard.
+    /// Legacy states written before this field deserialize as 0, which forces a
+    /// one-time content hash and then self-heals once the state is re-saved.
+    #[serde(default)]
+    pub size: u64,
+}
+
+impl FileInfo {
+    /// Build a `FileInfo` for `path` with an already-computed content hash,
+    /// stamping the current mtime (nanoseconds) and size from a single stat.
+    pub fn probe(path: &Path, content_hash: u64) -> Result<Self> {
+        let (mtime, size) = file_stat(path)?;
+        Ok(Self {
+            content_hash,
+            mtime,
+            size,
+        })
+    }
 }
 
 impl IndexState {
@@ -52,9 +83,10 @@ impl IndexState {
     pub fn save(&self, index_dir: &Path) -> Result<()> {
         fs::create_dir_all(index_dir)?;
 
-        // Update CLI version before saving
+        // Stamp the writing binary's CLI version and index format before saving
         let mut state = self.clone();
         state.cli_version = env!("CARGO_PKG_VERSION").to_string();
+        state.index_format_version = INDEX_FORMAT_VERSION;
 
         let state_path = get_state_path(index_dir);
         let content = serde_json::to_string_pretty(&state)?;
@@ -88,14 +120,21 @@ pub fn hash_file(path: &Path) -> Result<u64> {
     Ok(xxh3_64(&content))
 }
 
-/// Get file modification time as unix timestamp
-pub fn get_mtime(path: &Path) -> Result<u64> {
+/// Stat a file once, returning `(mtime_nanos, size_bytes)`.
+/// mtime is nanoseconds since the Unix epoch (sub-second precision so same-second
+/// edits are detectable); size is the cheap second guard against mtime collisions.
+pub fn file_stat(path: &Path) -> Result<(u64, u64)> {
     let metadata = fs::metadata(path)?;
     let mtime = metadata
         .modified()?
         .duration_since(SystemTime::UNIX_EPOCH)?
-        .as_secs();
-    Ok(mtime)
+        .as_nanos() as u64;
+    Ok((mtime, metadata.len()))
+}
+
+/// Get file modification time in nanoseconds since the Unix epoch.
+pub fn get_mtime(path: &Path) -> Result<u64> {
+    Ok(file_stat(path)?.0)
 }
 
 #[cfg(test)]
@@ -116,6 +155,7 @@ mod tests {
         let info = FileInfo {
             content_hash: 12345678901234567890,
             mtime: 1700000000,
+            size: 0,
         };
 
         let json = serde_json::to_string(&info).unwrap();
@@ -135,10 +175,12 @@ mod tests {
             FileInfo {
                 content_hash: 123456,
                 mtime: 1700000000,
+                size: 0,
             },
         );
         let state = IndexState {
             cli_version: "1.0.0".to_string(),
+            index_format_version: INDEX_FORMAT_VERSION,
             files,
             ignored_files: HashSet::new(),
             search_count: 0,
@@ -175,6 +217,7 @@ mod tests {
             FileInfo {
                 content_hash: 999999,
                 mtime: 1700000000,
+                size: 0,
             },
         );
 
@@ -274,6 +317,25 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// A state.json written before index_format_version existed must load as
+    /// version 0 (forcing a one-time rebuild), and save() must stamp the
+    /// current format so the rebuild happens exactly once.
+    #[test]
+    fn test_legacy_state_without_format_version_loads_as_zero() {
+        let json = r#"{"cli_version":"1.5.4","files":{},"search_count":3}"#;
+        let state: IndexState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.index_format_version, 0);
+
+        let temp_dir = TempDir::new().unwrap();
+        state.save(temp_dir.path()).unwrap();
+        assert_eq!(
+            IndexState::load(temp_dir.path())
+                .unwrap()
+                .index_format_version,
+            INDEX_FORMAT_VERSION
+        );
+    }
+
     #[test]
     fn test_search_count_increment_and_reset() {
         let temp_dir = TempDir::new().unwrap();
@@ -323,6 +385,7 @@ mod tests {
             FileInfo {
                 content_hash: 1,
                 mtime: 1700000000,
+                size: 0,
             },
         );
         init.save(&index_dir).unwrap();
@@ -349,6 +412,7 @@ mod tests {
                             FileInfo {
                                 content_hash: (t * iterations + i) as u64,
                                 mtime: 1700000000,
+                                size: 0,
                             },
                         );
                         state.save(&dir).unwrap();

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -17,7 +17,6 @@ use colgrep::{
 };
 
 use cli::{Cli, Commands};
-use commands::search::{resolve_pool_factor, resolve_top_k};
 use commands::{
     cmd_clear, cmd_config, cmd_init, cmd_reset_stats, cmd_search, cmd_session_hook, cmd_set_model,
     cmd_stats, cmd_status, cmd_task_hook, cmd_update, InitOptions,
@@ -131,6 +130,7 @@ fn main() -> Result<()> {
             pool_factor,
             auto_confirm,
             static_batch,
+            no_update,
         }) => {
             // If only -e pattern is given without a query, use the pattern as the query too
             let original_query = query.clone();
@@ -202,8 +202,8 @@ fn main() -> Result<()> {
                 cmd_search(
                     &final_query,
                     &final_paths,
-                    resolve_top_k(top_k, default_k),
-                    top_k.is_some(),
+                    top_k,
+                    default_k,
                     model.as_deref(),
                     json,
                     &include_patterns,
@@ -220,9 +220,11 @@ fn main() -> Result<()> {
                     code_only,
                     no_fts,
                     alpha,
-                    resolve_pool_factor(pool_factor, no_pool),
+                    pool_factor,
+                    no_pool,
                     auto_confirm,
                     static_batch,
+                    no_update,
                 )
             } else {
                 // No query or text_pattern provided - show help
@@ -375,8 +377,8 @@ fn main() -> Result<()> {
                 cmd_search(
                     &final_query,
                     &final_paths,
-                    resolve_top_k(cli.top_k, default_k),
-                    cli.top_k.is_some(),
+                    cli.top_k,
+                    default_k,
                     cli.model.as_deref(),
                     cli.json,
                     &cli.include_patterns,
@@ -393,9 +395,11 @@ fn main() -> Result<()> {
                     cli.code_only,
                     cli.no_fts,
                     cli.alpha,
-                    resolve_pool_factor(cli.pool_factor, cli.no_pool),
+                    cli.pool_factor,
+                    cli.no_pool,
                     cli.auto_confirm,
                     false,
+                    cli.no_update,
                 )
             } else {
                 // No query provided - show help

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -1770,6 +1770,7 @@ impl MmapIndex {
     /// The number of documents actually deleted
     pub fn delete_with_options(&mut self, doc_ids: &[i64], delete_metadata: bool) -> Result<usize> {
         let path = self.path.clone();
+        let old_num_documents = self.metadata.num_documents as i64;
 
         // Release mmap handles before deletion. delete_from_index calls
         // clear_merged_files which removes the memory-mapped merged files.
@@ -1784,9 +1785,28 @@ impl MmapIndex {
             let index_path = std::path::Path::new(&path);
             let db_path = index_path.join("metadata.db");
             if db_path.exists() {
+                // filtering::delete re-sequences the surviving _subset_ IDs. When the
+                // deleted IDs are exactly the tail of the ID space, every survivor
+                // keeps its ID, so the FTS5 rows for survivors stay aligned and only
+                // the deleted rows need removing — O(deleted) instead of the
+                // O(total documents) drop-and-rebuild.
+                let mut valid: Vec<i64> = doc_ids
+                    .iter()
+                    .copied()
+                    .filter(|&id| id >= 0 && id < old_num_documents)
+                    .collect();
+                valid.sort_unstable();
+                valid.dedup();
+                let suffix_start = old_num_documents - valid.len() as i64;
+                let is_suffix_delete = valid.first().is_some_and(|&min| min >= suffix_start);
+
                 crate::filtering::delete(&path, doc_ids)?;
-                // Rebuild FTS5 index after metadata re-indexing
-                crate::text_search::rebuild(&path)?;
+                if is_suffix_delete {
+                    crate::text_search::delete(&path, &valid)?;
+                } else {
+                    // Survivor IDs shifted; FTS5 rowids no longer match METADATA.
+                    crate::text_search::rebuild(&path)?;
+                }
             }
         }
 
@@ -1808,6 +1828,85 @@ mod tests {
             config.start_from_scratch,
             crate::default_start_from_scratch()
         );
+    }
+
+    /// FTS5 must stay aligned with METADATA `_subset_` IDs after deletes.
+    /// Suffix deletes keep every survivor's ID, so only the deleted FTS rows
+    /// are removed (O(deleted)); any other delete shifts survivor IDs and
+    /// must fall back to the full rebuild.
+    #[test]
+    fn test_delete_keeps_fts_aligned() {
+        use ndarray::Array2;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let index_path = temp_dir.path().to_str().unwrap();
+
+        let mut embeddings: Vec<Array2<f32>> = Vec::new();
+        for i in 0..5 {
+            let mut doc = Array2::<f32>::zeros((5, 32));
+            for j in 0..5 {
+                for k in 0..32 {
+                    doc[[j, k]] = (i as f32 * 0.1) + (j as f32 * 0.01) + (k as f32 * 0.001);
+                }
+            }
+            for mut row in doc.rows_mut() {
+                let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+                if norm > 0.0 {
+                    row.iter_mut().for_each(|x| *x /= norm);
+                }
+            }
+            embeddings.push(doc);
+        }
+
+        let config = IndexConfig {
+            nbits: 2,
+            batch_size: 50,
+            seed: Some(42),
+            kmeans_niters: 2,
+            max_points_per_centroid: 256,
+            n_samples_kmeans: None,
+            start_from_scratch: 999,
+            force_cpu: false,
+            ..Default::default()
+        };
+        let mut index = MmapIndex::create_with_kmeans(&embeddings, index_path, &config).unwrap();
+
+        let words = ["alpha", "bravo", "charlie", "delta", "echo"];
+        let metadata: Vec<serde_json::Value> = words
+            .iter()
+            .map(|w| serde_json::json!({ "text": w }))
+            .collect();
+        let doc_ids: Vec<i64> = (0..5).collect();
+        crate::filtering::create(index_path, &metadata, &doc_ids).unwrap();
+        crate::text_search::index(
+            index_path,
+            &metadata,
+            &doc_ids,
+            &crate::text_search::FtsTokenizer::default(),
+        )
+        .unwrap();
+
+        // Suffix delete: survivors 0..=2 keep their IDs; only rows 3 and 4
+        // leave the FTS index.
+        let deleted = index.delete_with_options(&[3, 4], true).unwrap();
+        assert_eq!(deleted, 2);
+        index.reload().unwrap();
+
+        let hits = crate::text_search::search(index_path, "charlie", 10).unwrap();
+        assert_eq!(hits.passage_ids, vec![2]);
+        let gone = crate::text_search::search(index_path, "delta", 10).unwrap();
+        assert!(gone.passage_ids.is_empty());
+
+        // Non-suffix delete: survivor IDs shift (bravo→0, charlie→1), so the
+        // FTS index must be rebuilt against the new numbering.
+        let deleted = index.delete_with_options(&[0], true).unwrap();
+        assert_eq!(deleted, 1);
+
+        let hits = crate::text_search::search(index_path, "charlie", 10).unwrap();
+        assert_eq!(hits.passage_ids, vec![1]);
+        let gone = crate::text_search::search(index_path, "alpha", 10).unwrap();
+        assert!(gone.passage_ids.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Integrates **#126** (*Remove redundant per-search and per-release work from colgrep indexing*, by @voxmenthe) on top of the now-merged **#131** (provider-aware parallel-session defaults). Targets `main`; single commit.

## Benchmark (per-search change-detection)

The headline cost #126 removes is re-hashing every file on every search. Measured with the included `measure_update_plan_mtime_fast_path` bench (5000 files × 200 KiB ≈ 976 MiB, Apple Silicon, **warm page cache**):

| update-plan path | time | |
| --- | --- | --- |
| full hashing (pre-#126, every search) | **262 ms** | |
| mtime fast path (this PR) | **110 ms** | **2.4× faster** |

≈152 ms of read+hash removed per search; scales with repo bytes, and the **cold-cache** real-world saving is larger. Reproduce:
`cargo test -p colgrep --release measure_update_plan -- --ignored --nocapture`

## What this brings
- **Skip content hashing for files with unchanged mtime** — the speedup above.
- **No full re-embed on every CLI release** — rebuild gated on `INDEX_FORMAT_VERSION`, not the CLI version (legacy state rebuilds once). Previously every upgrade re-embedded the whole project.
- **`--no-update`** — search without triggering auto-indexing (agent hot loops).
- **8K-doc batch flush** (`UPDATE_FLUSH_DOC_LIMIT`) — fewer full-IVF rewrites on large incremental updates.
- **`cleanup_orphaned_entries`** reads distinct paths only (was deserializing every column incl. embeddings per search).
- **next-plaid FTS5 suffix-delete fast path** — tail-of-ID deletes are O(deleted), not a full rebuild.
- **Load config once per command**; **local index takes precedence over a broad ancestor index**.

## Session-count reconciliation (with #131)
#126 and #131 both rewrote the default ONNX session count. Reconciled into `default_index_parallel_sessions(provider, num_units)`:

| Provider | Default sessions |
| --- | --- |
| **CPU** | #126's workload cap (`capped_default_sessions`): cores-based, capped at one session per ~`DEFAULT_ENCODE_BATCH_SIZE` units |
| **CoreML / CUDA / DirectML / MIGraphX** | 1 (each session duplicates the model in device memory) |

Overridable/persistent via `colgrep settings --parallel N`.

## mtime fast-path hardening (review fixes)
- **Nanosecond mtime + a `FileInfo.size` guard** so a same-second edit can't slip past the stat-only fast path.
- **Persist refreshed stat for stat-drifted-but-unchanged files** (`UpdatePlan.touched`), so `touch` / `git checkout` don't force a re-hash on every subsequent search.
- Legacy `state.json` self-heals (one hash after upgrade), no index-format bump.

## Validation
- `cargo build -p colgrep` — clean · `cargo clippy -p colgrep --all-targets` — clean
- `cargo test -p colgrep` — 553 passed · `cargo test -p next-plaid` — 121 passed
- Local stress test (incremental edits, rapid same-second edits, add/delete churn, `--no-update`, touch storms, concurrent search+edit, corruption) — no regressions vs `main`.

Co-authored with @voxmenthe (#126) and @ndizazzo (#127, via #131).
