### PR TITLE
Add `cuda-13` build feature; make `--force-gpu` truly force the GPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "fastkmeans-rs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4488640442526b76eea0097d0d807b61deb98e45a76c8454a471029df70167"
+checksum = "d1528732c31bd517b4df7a2796adcad4502c2e501694c2141c1e6a6df5f3e80a"
 dependencies = [
  "accelerate-src",
  "blas-src 0.10.0",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -110,8 +110,17 @@ tempfile = "3"
 
 [features]
 default = []
-# Model inference acceleration (ONNX Runtime execution providers)
-cuda = ["next-plaid-onnx/cuda", "next-plaid/cuda"]
+# Model inference acceleration (ONNX Runtime execution providers).
+# cudarc (the k-means/codec path) binds one CUDA major at compile time, so pick
+# the one matching the host and DO NOT enable both `cuda` and `cuda-13`:
+#   * `cuda`    -> CUDA 11.8 / 12.x  (default, unchanged behaviour)
+#   * `cuda-13` -> CUDA 13.x
+# The ONNX encode path (next-plaid-onnx/cuda) is version-agnostic at build time
+# (ORT is loaded dynamically), so both variants share it.
+cuda = ["_cuda", "next-plaid-onnx/cuda", "next-plaid/cuda"]
+cuda-13 = ["_cuda", "next-plaid-onnx/cuda", "next-plaid/cuda-13"]
+# Internal: gates colgrep's CUDA code; reached via `cuda` or `cuda-13`.
+_cuda = []
 coreml = ["next-plaid-onnx/coreml"]
 tensorrt = ["next-plaid-onnx/tensorrt"]
 directml = ["next-plaid-onnx/directml"]

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 use crate::acceleration::{env_acceleration_mode_lossy, AccelerationMode};
 use crate::index::paths::get_colgrep_data_dir;
 
@@ -29,14 +29,14 @@ pub const DEFAULT_BATCH_SIZE_GPU: usize = 64;
 
 /// Default batch size - use GPU default when CUDA is enabled AND available, CPU otherwise
 /// Note: At compile time we set the GPU default, but at runtime we check cuDNN availability
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub const DEFAULT_BATCH_SIZE: usize = DEFAULT_BATCH_SIZE_GPU;
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 pub const DEFAULT_BATCH_SIZE: usize = DEFAULT_BATCH_SIZE_CPU;
 
 /// Get the effective default batch size at runtime.
 /// When CUDA feature is enabled but cuDNN is not available, returns CPU default.
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub fn get_default_batch_size() -> usize {
     match env_acceleration_mode_lossy() {
         AccelerationMode::ForceCpu => DEFAULT_BATCH_SIZE_CPU,
@@ -51,7 +51,7 @@ pub fn get_default_batch_size() -> usize {
     }
 }
 
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 pub fn get_default_batch_size() -> usize {
     DEFAULT_BATCH_SIZE_CPU
 }
@@ -65,7 +65,7 @@ pub fn get_default_cpu_parallel_sessions() -> usize {
 
 /// Get the effective default parallel sessions at runtime.
 /// When CUDA feature is enabled but cuDNN is not available, returns CPU default.
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub fn get_default_parallel_sessions() -> usize {
     match env_acceleration_mode_lossy() {
         AccelerationMode::ForceCpu => get_default_cpu_parallel_sessions(),
@@ -80,7 +80,7 @@ pub fn get_default_parallel_sessions() -> usize {
     }
 }
 
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 pub fn get_default_parallel_sessions() -> usize {
     get_default_cpu_parallel_sessions()
 }
@@ -250,11 +250,11 @@ impl Config {
     /// Check if FP32 (non-quantized) model should be used
     /// Defaults to true when cuda feature is enabled (better CUDA performance with FP32)
     pub fn use_fp32(&self) -> bool {
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         {
             self.fp32.unwrap_or(true)
         }
-        #[cfg(not(feature = "cuda"))]
+        #[cfg(not(feature = "_cuda"))]
         {
             self.fp32.unwrap_or(false)
         }
@@ -653,7 +653,7 @@ mod tests {
         assert_eq!(MAX_PARALLEL_SESSIONS_CPU, 16);
 
         let sessions = get_default_parallel_sessions();
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         let expected = match env_acceleration_mode_lossy() {
             AccelerationMode::ForceCpu => std::thread::available_parallelism()
                 .map(|p| p.get())
@@ -671,7 +671,7 @@ mod tests {
                 }
             }
         };
-        #[cfg(not(feature = "cuda"))]
+        #[cfg(not(feature = "_cuda"))]
         let expected = std::thread::available_parallelism()
             .map(|p| p.get())
             .unwrap_or(16)

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -21,7 +21,7 @@ use next_plaid_onnx::{pool_document_embeddings, Colbert, ExecutionProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 use crate::acceleration::apply_acceleration_mode;
 use crate::acceleration::{env_acceleration_mode_lossy, AccelerationMode};
 use crate::embed::build_embedding_text;
@@ -192,7 +192,7 @@ const DEFAULT_ENCODE_BATCH_SIZE: usize = 64;
 
 /// Threshold for forcing CPU encoding even when CUDA is available.
 /// For small batches (< this many units), CPU is faster due to GPU initialization overhead.
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 const SMALL_BATCH_CPU_THRESHOLD: usize = 300;
 /// Bounded channel capacity between the pool and index stages.
 /// Kept small (4 chunks) to limit memory: each chunk holds full embeddings
@@ -245,7 +245,7 @@ fn default_index_parallel_sessions(
 const METADATA_QUEUE_CAPACITY: usize = 8;
 
 fn compiled_accelerated_execution_provider() -> Option<ExecutionProvider> {
-    if cfg!(feature = "cuda") {
+    if cfg!(feature = "_cuda") {
         Some(ExecutionProvider::Cuda)
     } else if cfg!(feature = "tensorrt") {
         Some(ExecutionProvider::TensorRT)
@@ -273,7 +273,7 @@ fn execution_provider_for_acceleration_mode(mode: AccelerationMode) -> Execution
 }
 
 #[cfg(all(
-    not(feature = "cuda"),
+    not(feature = "_cuda"),
     any(feature = "coreml", feature = "directml", feature = "migraphx")
 ))]
 fn indexing_execution_provider_for_acceleration_mode(mode: AccelerationMode) -> ExecutionProvider {
@@ -1119,10 +1119,10 @@ impl IndexBuilder {
     ///   available, as GPU initialization overhead outweighs the benefits for small workloads.
     fn ensure_model_created(&mut self, num_units: usize) -> Result<()> {
         if self.model.is_none() {
-            #[cfg(feature = "cuda")]
+            #[cfg(feature = "_cuda")]
             let acceleration_mode = env_acceleration_mode_lossy();
 
-            #[cfg(feature = "cuda")]
+            #[cfg(feature = "_cuda")]
             let (num_sessions, execution_provider) = {
                 match acceleration_mode {
                     AccelerationMode::ForceCpu => {
@@ -1195,7 +1195,7 @@ impl IndexBuilder {
                 }
             };
             #[cfg(not(any(
-                feature = "cuda",
+                feature = "_cuda",
                 feature = "directml",
                 feature = "migraphx",
                 feature = "coreml"
@@ -1213,7 +1213,7 @@ impl IndexBuilder {
             };
 
             #[cfg(any(feature = "directml", feature = "migraphx", feature = "coreml"))]
-            #[cfg(not(feature = "cuda"))]
+            #[cfg(not(feature = "_cuda"))]
             let (num_sessions, execution_provider) = {
                 let execution_provider = indexing_execution_provider_for_acceleration_mode(
                     env_acceleration_mode_lossy(),
@@ -1269,7 +1269,7 @@ impl IndexBuilder {
     }
 
     /// Check if the current model is using GPU execution.
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "_cuda")]
     fn is_using_gpu(&self) -> bool {
         self.model
             .as_ref()
@@ -1281,7 +1281,7 @@ impl IndexBuilder {
     /// Uses `dynamic_batch(false)` because CPU encoding processes fixed-size batches
     /// sequentially — the token-budget bucketing of dynamic batch only helps GPU
     /// where plan reuse across similar shapes reduces kernel launch overhead.
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "_cuda")]
     fn rebuild_model_for_cpu(&mut self) -> Result<()> {
         self.model = None;
         apply_acceleration_mode(AccelerationMode::ForceCpu);
@@ -1343,7 +1343,7 @@ impl IndexBuilder {
             },
         );
 
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         if let Err(gpu_err) = result {
             if self.is_using_gpu() {
                 let accel = env_acceleration_mode_lossy();
@@ -2317,7 +2317,7 @@ impl IndexBuilder {
             // Ensure model is created before encoding (lazy initialization)
             self.ensure_model_created(all_units.len())?;
 
-            #[cfg(feature = "cuda")]
+            #[cfg(feature = "_cuda")]
             if !crate::onnx_runtime::is_cudnn_available()
                 && std::env::var("_COLGREP_CUDNN_NOTICE").is_err()
             {
@@ -3553,7 +3553,7 @@ impl Searcher {
         let acceleration_mode = env_acceleration_mode_lossy();
         let execution_provider = execution_provider_for_acceleration_mode(acceleration_mode);
 
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         match acceleration_mode {
             AccelerationMode::ForceGpu => apply_acceleration_mode(AccelerationMode::ForceGpu),
             AccelerationMode::ForceCpu | AccelerationMode::Auto => {
@@ -3563,7 +3563,7 @@ impl Searcher {
 
         crate::onnx_runtime::ensure_onnx_runtime().context("Failed to initialize ONNX Runtime")?;
 
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         if matches!(acceleration_mode, AccelerationMode::ForceGpu) {
             if !crate::onnx_runtime::is_cudnn_available() {
                 anyhow::bail!("FORCE_GPU is set, but cuDNN was not initialized");
@@ -3619,7 +3619,7 @@ impl Searcher {
         let acceleration_mode = env_acceleration_mode_lossy();
         let execution_provider = execution_provider_for_acceleration_mode(acceleration_mode);
 
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         match acceleration_mode {
             AccelerationMode::ForceGpu => apply_acceleration_mode(AccelerationMode::ForceGpu),
             AccelerationMode::ForceCpu | AccelerationMode::Auto => {
@@ -3629,7 +3629,7 @@ impl Searcher {
 
         crate::onnx_runtime::ensure_onnx_runtime().context("Failed to initialize ONNX Runtime")?;
 
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         if matches!(acceleration_mode, AccelerationMode::ForceGpu) {
             if !crate::onnx_runtime::is_cudnn_available() {
                 anyhow::bail!("FORCE_GPU is set, but cuDNN was not initialized");
@@ -4608,7 +4608,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "coreml", not(feature = "cuda")))]
+    #[cfg(all(feature = "coreml", not(feature = "_cuda")))]
     fn test_auto_indexing_provider_avoids_coreml() {
         assert_eq!(
             indexing_execution_provider_for_acceleration_mode(AccelerationMode::Auto),

--- a/colgrep/src/onnx_runtime.rs
+++ b/colgrep/src/onnx_runtime.rs
@@ -9,23 +9,23 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Global flag indicating whether cuDNN is available (only relevant when cuda feature is enabled)
-#[cfg(all(feature = "cuda", target_os = "linux"))]
+#[cfg(all(feature = "_cuda", target_os = "linux"))]
 static CUDNN_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 /// Check if cuDNN is available at runtime.
 /// This should be called AFTER ensure_onnx_runtime() to get accurate results.
-#[cfg(all(feature = "cuda", target_os = "linux"))]
+#[cfg(all(feature = "_cuda", target_os = "linux"))]
 pub fn is_cudnn_available() -> bool {
     *CUDNN_AVAILABLE.get().unwrap_or(&false)
 }
 
 /// On Windows, ONNX Runtime handles cuDNN loading itself.
-#[cfg(all(feature = "cuda", not(target_os = "linux")))]
+#[cfg(all(feature = "_cuda", not(target_os = "linux")))]
 pub fn is_cudnn_available() -> bool {
     true
 }
 
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 pub fn is_cudnn_available() -> bool {
     false // Not applicable - CUDA feature not enabled
 }
@@ -42,9 +42,9 @@ const ORT_LIB_NAME: &str = "libonnxruntime.so";
 const ORT_LIB_NAME: &str = "onnxruntime.dll";
 
 /// Subdirectory name for caching (gpu vs cpu)
-#[cfg(any(feature = "cuda", feature = "directml"))]
+#[cfg(any(feature = "_cuda", feature = "directml"))]
 const ORT_CACHE_SUBDIR: &str = "gpu";
-#[cfg(not(any(feature = "cuda", feature = "directml")))]
+#[cfg(not(any(feature = "_cuda", feature = "directml")))]
 const ORT_CACHE_SUBDIR: &str = "cpu";
 
 /// Ensure ONNX Runtime is available.
@@ -62,7 +62,7 @@ pub fn ensure_onnx_runtime() -> Result<PathBuf> {
     // For CUDA builds on Linux, check if we need to re-exec with cuDNN in LD_LIBRARY_PATH
     // This is only needed on Linux because it caches LD_LIBRARY_PATH at process startup
     // Skip CUDA setup if COLGREP_FORCE_CPU is set (CPU-only mode)
-    #[cfg(all(target_os = "linux", feature = "cuda"))]
+    #[cfg(all(target_os = "linux", feature = "_cuda"))]
     if crate::acceleration::env_acceleration_mode_lossy()
         != crate::acceleration::AccelerationMode::ForceCpu
     {
@@ -142,7 +142,7 @@ pub fn ensure_onnx_runtime() -> Result<PathBuf> {
     }
 
     // 2. Search common locations (skip for CUDA - we want our managed GPU version)
-    #[cfg(not(feature = "cuda"))]
+    #[cfg(not(feature = "_cuda"))]
     if let Some(path) = find_onnx_runtime() {
         pin_runtime_library(&path);
         return Ok(path);
@@ -162,7 +162,7 @@ fn pin_runtime_library(path: &Path) {
         prepend_ld_library_path(parent);
     }
 
-    #[cfg(all(target_os = "linux", feature = "cuda"))]
+    #[cfg(all(target_os = "linux", feature = "_cuda"))]
     {
         // Check for cuDNN availability (result is stored in CUDNN_AVAILABLE)
         let _ = check_cudnn_available();
@@ -170,7 +170,7 @@ fn pin_runtime_library(path: &Path) {
 }
 
 /// Find the cuDNN library directory (without setting any global state)
-#[cfg(all(target_os = "linux", feature = "cuda"))]
+#[cfg(all(target_os = "linux", feature = "_cuda"))]
 fn find_cudnn_directory() -> Option<PathBuf> {
     let search_dirs = get_cudnn_search_dirs();
 
@@ -217,7 +217,7 @@ fn prepend_ld_library_path(dir: &Path) {
 }
 
 /// Get all directories to search for cuDNN library (Linux only)
-#[cfg(all(target_os = "linux", feature = "cuda"))]
+#[cfg(all(target_os = "linux", feature = "_cuda"))]
 fn get_cudnn_search_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
@@ -304,7 +304,7 @@ fn get_cudnn_search_dirs() -> Vec<PathBuf> {
 /// Also stores the result in CUDNN_AVAILABLE for later queries.
 /// Only used on Linux where we need to manually set up LD_LIBRARY_PATH.
 /// On Windows, ONNX Runtime handles cuDNN detection automatically.
-#[cfg(all(target_os = "linux", feature = "cuda"))]
+#[cfg(all(target_os = "linux", feature = "_cuda"))]
 fn check_cudnn_available() -> bool {
     // Library names to search for (in order of preference)
     let cudnn_lib_names = [
@@ -369,7 +369,7 @@ fn is_valid_ort_dylib(path: &Path) -> bool {
 }
 
 /// Search for ONNX Runtime in common locations
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 fn find_onnx_runtime() -> Option<PathBuf> {
     let search_paths = get_search_paths();
     let mut rejected: Vec<PathBuf> = Vec::new();
@@ -447,7 +447,7 @@ fn find_onnx_runtime() -> Option<PathBuf> {
 }
 
 /// Get list of paths to search for ONNX Runtime
-#[cfg(not(feature = "cuda"))]
+#[cfg(not(feature = "_cuda"))]
 fn get_search_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
@@ -539,22 +539,22 @@ fn download_onnx_runtime() -> Result<PathBuf> {
     let lib_path = cache_dir.join(ORT_LIB_NAME);
 
     // Already cached - check if all required files exist
-    #[cfg(all(feature = "cuda", target_os = "linux"))]
+    #[cfg(all(feature = "_cuda", target_os = "linux"))]
     let already_cached = lib_path.exists()
         && cache_dir
             .join("libonnxruntime_providers_shared.so")
             .exists()
         && cache_dir.join("libonnxruntime_providers_cuda.so").exists();
 
-    #[cfg(all(feature = "cuda", target_os = "windows"))]
+    #[cfg(all(feature = "_cuda", target_os = "windows"))]
     let already_cached = lib_path.exists()
         && cache_dir.join("onnxruntime_providers_shared.dll").exists()
         && cache_dir.join("onnxruntime_providers_cuda.dll").exists();
 
-    #[cfg(all(feature = "directml", not(feature = "cuda")))]
+    #[cfg(all(feature = "directml", not(feature = "_cuda")))]
     let already_cached = lib_path.exists();
 
-    #[cfg(not(any(feature = "cuda", feature = "directml")))]
+    #[cfg(not(any(feature = "_cuda", feature = "directml")))]
     let already_cached = lib_path.exists();
 
     if already_cached {
@@ -565,11 +565,11 @@ fn download_onnx_runtime() -> Result<PathBuf> {
 
     let (url, files_to_extract) = get_download_info()?;
 
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "_cuda")]
     eprintln!("⚙️  Runtime: ONNX {} (GPU/CUDA)", ORT_VERSION);
-    #[cfg(all(feature = "directml", not(feature = "cuda")))]
+    #[cfg(all(feature = "directml", not(feature = "_cuda")))]
     eprintln!("⚙️  Runtime: ONNX {} (GPU/DirectML)", ORT_VERSION);
-    #[cfg(not(any(feature = "cuda", feature = "directml")))]
+    #[cfg(not(any(feature = "_cuda", feature = "directml")))]
     eprintln!("⚙️  Runtime: ONNX {} (CPU)", ORT_VERSION);
 
     // Download archive
@@ -596,7 +596,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
         target_os = "windows",
         target_arch = "x86_64",
         feature = "directml",
-        not(feature = "cuda")
+        not(feature = "_cuda")
     ))]
     return Ok((
         format!(
@@ -614,7 +614,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
         target_os = "windows",
         target_arch = "x86_64",
         feature = "directml",
-        not(feature = "cuda")
+        not(feature = "_cuda")
     )))]
     {
         let base = format!(
@@ -648,7 +648,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
         );
 
         // Linux x86_64 - supports both CPU and GPU
-        #[cfg(all(target_os = "linux", target_arch = "x86_64", feature = "cuda"))]
+        #[cfg(all(target_os = "linux", target_arch = "x86_64", feature = "_cuda"))]
         let (archive, files) = {
             let archive_name = format!("onnxruntime-linux-x64-gpu-{}", ORT_VERSION);
             (
@@ -670,7 +670,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
             )
         };
 
-        #[cfg(all(target_os = "linux", target_arch = "x86_64", not(feature = "cuda")))]
+        #[cfg(all(target_os = "linux", target_arch = "x86_64", not(feature = "_cuda")))]
         let (archive, files) = (
             format!("onnxruntime-linux-x64-{}.tgz", ORT_VERSION),
             vec![(
@@ -696,7 +696,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
         );
 
         // Windows - supports both CPU and GPU
-        #[cfg(all(target_os = "windows", target_arch = "x86_64", feature = "cuda"))]
+        #[cfg(all(target_os = "windows", target_arch = "x86_64", feature = "_cuda"))]
         let (archive, files) = {
             let archive_name = format!("onnxruntime-win-x64-gpu-{}", ORT_VERSION);
             (
@@ -721,7 +721,7 @@ fn get_download_info() -> Result<(String, Vec<FileToExtract>)> {
         #[cfg(all(
             target_os = "windows",
             target_arch = "x86_64",
-            not(any(feature = "cuda", feature = "directml"))
+            not(any(feature = "_cuda", feature = "directml"))
         ))]
         let (archive, files) = (
             format!("onnxruntime-win-x64-{}.zip", ORT_VERSION),

--- a/next-plaid-api/Cargo.toml
+++ b/next-plaid-api/Cargo.toml
@@ -60,7 +60,11 @@ accelerate = ["next-plaid/accelerate"]
 mkl = ["next-plaid/mkl"]
 metal_gpu = ["next-plaid/metal_gpu"]
 model = ["dep:next-plaid-onnx"]
+# CUDA acceleration — pick the major matching the host, don't enable both.
+#   * `cuda`    -> CUDA 11.8 / 12.x  (default, unchanged behaviour)
+#   * `cuda-13` -> CUDA 13.x
 cuda = ["model", "next-plaid-onnx/cuda", "next-plaid/cuda"]
+cuda-13 = ["model", "next-plaid-onnx/cuda", "next-plaid/cuda-13"]
 
 [dev-dependencies]
 reqwest = { version = "0.13", features = ["json"] }

--- a/next-plaid-onnx/src/lib.rs
+++ b/next-plaid-onnx/src/lib.rs
@@ -403,12 +403,21 @@ fn configure_cuda(builder: SessionBuilder) -> Result<SessionBuilder> {
         return Ok(builder);
     }
 
+    // When the GPU is forced we must guarantee the session actually runs on CUDA.
+    // ORT registers execution providers best-effort by default: a CUDA EP that
+    // fails to initialize is silently dropped and the session quietly runs on the
+    // CPU. `error_on_failure()` turns that silent fallback into a hard error so
+    // `--force-gpu` cannot end up on the CPU.
+    let force_gpu = is_force_gpu();
+
     // Wrap CUDA initialization in catch_cuda_panic to handle panics from stub/invalid libraries
     // without printing the default panic message to stderr
     let cuda_result = catch_cuda_panic(std::panic::AssertUnwindSafe(|| {
-        builder
-            .clone()
-            .with_execution_providers([configured_cuda_execution_provider().build()])
+        let mut cuda_ep = configured_cuda_execution_provider().build();
+        if force_gpu {
+            cuda_ep = cuda_ep.error_on_failure();
+        }
+        builder.clone().with_execution_providers([cuda_ep])
     }));
 
     match cuda_result {
@@ -418,6 +427,12 @@ fn configure_cuda(builder: SessionBuilder) -> Result<SessionBuilder> {
             )
         }),
         Err(_) => {
+            if force_gpu {
+                anyhow::bail!(
+                    "FORCE_GPU is set but the CUDA execution provider could not be initialized \
+                     (invalid/stub CUDA library, or missing cuDNN?). Refusing to fall back to CPU."
+                );
+            }
             eprintln!("[next-plaid-onnx] CUDA init panicked (invalid/stub library?), falling back to CPU");
             Ok(builder)
         }

--- a/next-plaid/Cargo.toml
+++ b/next-plaid/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ndarray-npy = "0.9.1"
-fastkmeans-rs = "1.0.6"
+fastkmeans-rs = "1.0.7"
 memmap2 = "0.9"
 fs2 = "0.4"
 half = "2.4"
@@ -40,8 +40,10 @@ regex = "1.11"
 # `fancy-regex` powers the SQLite REGEXP UDF so chunk filtering supports
 # lookaround and backreferences in addition to the standard regex syntax.
 fancy-regex = "0.13"
+# The CUDA major-version binding (`cuda-11080` / `cuda-13000`) is selected by
+# the `cuda` / `cuda-13` features below, not pinned here — cudarc binds a single
+# CUDA major at compile time.
 cudarc = { version = "0.19", default-features = false, features = [
-    "cuda-11080",
     "cublas",
     "dynamic-loading",
     "nvrtc",
@@ -73,4 +75,12 @@ mkl = [
     "fastkmeans-rs/mkl",
 ]
 metal_gpu = ["fastkmeans-rs/metal_gpu"]
-cuda = ["fastkmeans-rs/cuda", "dep:cudarc"]
+# CUDA acceleration. cudarc binds one CUDA major at compile time, so pick the
+# one matching the target host and DO NOT enable both:
+#   * `cuda`    -> CUDA 11.8 / 12.x  (default, unchanged behaviour)
+#   * `cuda-13` -> CUDA 13.x
+cuda = ["_cuda", "fastkmeans-rs/cuda", "cudarc/cuda-11080"]
+cuda-13 = ["_cuda", "fastkmeans-rs/cuda-13", "cudarc/cuda-13000"]
+# Internal: pulls in cudarc + gates the CUDA code. Always go through `cuda` or
+# `cuda-13` (which also select the cudarc version); don't enable this directly.
+_cuda = ["dep:cudarc"]

--- a/next-plaid/src/codec.rs
+++ b/next-plaid/src/codec.rs
@@ -259,7 +259,7 @@ impl ResidualCodec {
     /// Centroid indices of shape `[N]`
     pub fn compress_into_codes(&self, embeddings: &Array2<f32>) -> Array1<usize> {
         // Try CUDA acceleration if available
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         {
             let force_gpu = crate::is_force_gpu();
             if let Some(ctx) = crate::cuda::get_global_context() {

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -296,7 +296,7 @@ pub fn encode_index_chunk(
     let doclens: Vec<i64> = embeddings.iter().map(|d| d.nrows() as i64).collect();
     let total_tokens: usize = doclens.iter().sum::<i64>() as usize;
 
-    #[cfg(not(feature = "cuda"))]
+    #[cfg(not(feature = "_cuda"))]
     let _ = force_cpu;
 
     let mut batch_embeddings = Array2::<f32>::zeros((total_tokens, embedding_dim));
@@ -310,7 +310,7 @@ pub fn encode_index_chunk(
     }
 
     let (batch_codes, batch_residuals) = {
-        #[cfg(feature = "cuda")]
+        #[cfg(feature = "_cuda")]
         {
             let force_gpu = crate::is_force_gpu();
             if !force_cpu {
@@ -345,7 +345,7 @@ pub fn encode_index_chunk(
                 compress_and_residuals_cpu(&batch_embeddings, codec)
             }
         }
-        #[cfg(not(feature = "cuda"))]
+        #[cfg(not(feature = "_cuda"))]
         {
             compress_and_residuals_cpu(&batch_embeddings, codec)
         }
@@ -738,7 +738,7 @@ pub fn create_index_files(
         // BATCH: Compress embeddings and compute residuals
         // Try CUDA fused operation first, fall back to CPU (skip CUDA if force_cpu is set)
         let (batch_codes, batch_residuals) = {
-            #[cfg(feature = "cuda")]
+            #[cfg(feature = "_cuda")]
             {
                 let force_gpu = crate::is_force_gpu();
                 if !config.force_cpu {
@@ -770,7 +770,7 @@ pub fn create_index_files(
                     compress_and_residuals_cpu(&batch_embeddings, &codec)
                 }
             }
-            #[cfg(not(feature = "cuda"))]
+            #[cfg(not(feature = "_cuda"))]
             {
                 compress_and_residuals_cpu(&batch_embeddings, &codec)
             }
@@ -935,7 +935,7 @@ pub fn create_index_with_kmeans_files(
 
     // Pre-initialize CUDA if available (first init can take 10-20s due to driver initialization)
     // Skip if force_cpu is set to avoid unnecessary initialization overhead
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "_cuda")]
     if !config.force_cpu {
         if crate::is_force_gpu() {
             crate::cuda::get_global_context()

--- a/next-plaid/src/kmeans.rs
+++ b/next-plaid/src/kmeans.rs
@@ -16,7 +16,7 @@ use crate::maxsim;
 
 pub use fastkmeans_rs::{kmeans_double_chunked, FastKMeans, KMeansConfig, KMeansError};
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub use fastkmeans_rs::FastKMeansCuda;
 
 #[cfg(feature = "metal_gpu")]
@@ -94,7 +94,7 @@ fn compute_centroids_cpu(
 /// # Returns
 ///
 /// The centroids array of shape `[num_centroids, dim]`
-#[cfg(not(any(feature = "cuda", feature = "metal_gpu")))]
+#[cfg(not(any(feature = "_cuda", feature = "metal_gpu")))]
 pub fn compute_centroids(
     embeddings: &ArrayView2<f32>,
     num_centroids: usize,
@@ -106,7 +106,7 @@ pub fn compute_centroids(
 }
 
 /// Compute centroids from a set of embeddings using CUDA (or CPU if force_cpu is true or CUDA fails).
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub fn compute_centroids(
     embeddings: &ArrayView2<f32>,
     num_centroids: usize,
@@ -156,7 +156,7 @@ pub fn compute_centroids(
 }
 
 /// Compute centroids from a set of embeddings using Metal GPU (or CPU if force_cpu is true).
-#[cfg(all(feature = "metal_gpu", not(feature = "cuda")))]
+#[cfg(all(feature = "metal_gpu", not(feature = "_cuda")))]
 pub fn compute_centroids(
     embeddings: &ArrayView2<f32>,
     num_centroids: usize,
@@ -328,7 +328,7 @@ pub fn compute_kmeans(
     };
 
     // Run k-means (CPU implementation)
-    #[cfg(not(any(feature = "cuda", feature = "metal_gpu")))]
+    #[cfg(not(any(feature = "_cuda", feature = "metal_gpu")))]
     let centroids = {
         let mut kmeans = FastKMeans::with_config(kmeans_config);
         kmeans
@@ -342,7 +342,7 @@ pub fn compute_kmeans(
     };
 
     // Run k-means (CUDA with automatic CPU fallback, catching panics)
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "_cuda")]
     let centroids = if config.force_cpu || crate::cuda::is_cuda_broken() {
         // Use CPU if force_cpu is set or CUDA has been determined to be broken
         // Use kmeans_double_chunked directly to avoid FastKMeans::train() which
@@ -386,7 +386,7 @@ pub fn compute_kmeans(
     };
 
     // Run k-means (Metal GPU with CPU fallback when force_cpu is true)
-    #[cfg(all(feature = "metal_gpu", not(feature = "cuda")))]
+    #[cfg(all(feature = "metal_gpu", not(feature = "_cuda")))]
     let centroids = if config.force_cpu {
         let mut kmeans = FastKMeans::with_config(kmeans_config);
         kmeans

--- a/next-plaid/src/lib.rs
+++ b/next-plaid/src/lib.rs
@@ -13,7 +13,7 @@ extern crate blas_src;
 extern crate openblas_src;
 
 pub mod codec;
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub mod cuda;
 pub mod delete;
 pub mod embeddings;
@@ -61,7 +61,7 @@ pub fn default_start_from_scratch() -> usize {
     })
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "_cuda")]
 pub use cuda::{clear_cuda_broken, is_cuda_broken, mark_cuda_broken, CudaContext};
 
 /// Check if GPU-only mode is forced via environment variable.


### PR DESCRIPTION
Depends on **lightonai/fastkmeans-rs#9** — merge & publish `fastkmeans-rs 1.0.7` to crates.io **before** this (CI here can't resolve the dep until then).

## 1. `cuda-13` build option

`cudarc` binds exactly **one** CUDA major version at compile time (cuBLAS/NVRTC SONAMEs `.so.12` vs `.so.13` + bindings differ), so one binary can't serve both CUDA 12 and 13. We expose the choice as a feature instead of hard-pinning `cuda-11080`:

| feature | CUDA | notes |
|---|---|---|
| `cuda` | 11.8 / 12.x | **unchanged** — existing users/CI unaffected |
| `cuda-13` | 13.x | new; hosts where only `.so.13` exists (driver 580 / toolkit 13.x) |
| `_cuda` | — | internal gate, compiles the CUDA code; don't enable directly |

- cudarc's dependency line no longer pins a version; `cuda` / `cuda-13` select it plus the matching `fastkmeans-rs` feature.
- All `next-plaid` + `colgrep` `#[cfg(feature = "cuda")]` gates now key off `_cuda`, so they build under either major (`next-plaid-onnx` is unchanged — the ONNX EP is version-agnostic at build time).
- Wired through `next-plaid`, `colgrep` and `next-plaid-api`. Enabling both `cuda` and `cuda-13` fails to compile by design.

Build matrix validated: `cargo build` for default / `cuda` / `cuda-13` all pass; `cuda,cuda-13` fails as expected.

## 2. `--force-gpu` must not silently run on CPU

ORT registers execution providers **best-effort** — a CUDA EP that fails to initialize is silently dropped and the session quietly runs on CPU, so `--force-gpu` could still encode on the CPU. Now, when the GPU is forced:

- the CUDA EP is registered with `error_on_failure()` (ORT errors instead of falling back), and
- the CUDA-init panic branch hard-errors instead of returning a CPU builder.

## Validation (CUDA-13 H100, driver 580.126.09)

- `colgrep init … --force-gpu` (built `--features cuda-13`) → `🤖 Model: … (CUDA)`, indexes on GPU, no fallback.
- `CUDA_VISIBLE_DEVICES="" … --force-gpu` → **hard error** (`FORCE_GPU is set, but the CUDA execution provider was not initialized`), no silent CPU run.

## Follow-ups (not in this PR)

- `next-plaid-api/Dockerfile` CUDA image still targets CUDA 12; a `cuda-13` image would use the new feature.
- Release CI could ship a second `colgrep` artifact built with `cuda-13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)