### PR TITLE
fix(cuda): fall back to CUBIN when the driver rejects JIT'd PTX (codec)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "fastkmeans-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1528732c31bd517b4df7a2796adcad4502c2e501694c2141c1e6a6df5f3e80a"
+checksum = "5888b90549aa08d81b3eda1d779ec8523d36a1bc256f89a3e12e0d3087b0a25c"
 dependencies = [
  "accelerate-src",
  "blas-src 0.10.0",

--- a/next-plaid/Cargo.toml
+++ b/next-plaid/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ndarray-npy = "0.9.1"
-fastkmeans-rs = "1.0.7"
+fastkmeans-rs = "1.0.8"
 memmap2 = "0.9"
 fs2 = "0.4"
 half = "2.4"

--- a/next-plaid/src/cuda.rs
+++ b/next-plaid/src/cuda.rs
@@ -19,8 +19,11 @@ use cudarc::cublas::{CudaBlas, Gemm, GemmConfig};
 use cudarc::driver::{
     CudaContext as CudarcContext, CudaFunction, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
 };
-use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
+use cudarc::nvrtc::{
+    compile_ptx_with_opts, result as nvrtc_result, sys as nvrtc_sys, CompileOptions, Ptx,
+};
 use ndarray::{Array1, ArrayView2};
+use std::ffi::{c_char, CStr, CString};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -233,26 +236,97 @@ extern "C" __global__ void gather_subtract_kernel(
 }
 "#;
 
+/// Compile the kernels to a CUBIN (SASS) image for the device architecture and
+/// wrap it as a [`Ptx`] image so it can be handed to `load_module`.
+///
+/// Loading a CUBIN goes through `cuModuleLoadData` directly and skips the
+/// driver's PTX -> SASS JIT step, which sidesteps `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
+/// on hosts whose driver is older than the NVRTC toolkit that built the kernels
+/// (e.g. a CUDA 13.1 toolkit running against a CUDA 13.0 driver). The CUBIN is
+/// tied to the exact device architecture passed in `options`
+/// (e.g. `--gpu-architecture=sm_90`); that is fine here because it is compiled at
+/// runtime for the detected device and is only reached as an automatic fallback
+/// when the driver rejects the JIT-compiled PTX.
+fn compile_kernels_cubin(src: &str, options: &[String]) -> Result<Ptx> {
+    let csrc = CString::new(src)
+        .map_err(|e| Error::Codec(format!("CUDA kernel source contains a NUL byte: {e}")))?;
+    let prog = nvrtc_result::create_program(&csrc, None)
+        .map_err(|e| Error::Codec(format!("Failed to create NVRTC program: {e:?}")))?;
+
+    // SAFETY: `prog` is a valid handle from `create_program`; it is destroyed on
+    // every exit path below.
+    if let Err(e) = unsafe { nvrtc_result::compile_program(prog, options) } {
+        let log = unsafe { nvrtc_result::get_program_log(prog) }
+            .map(|raw| {
+                unsafe { CStr::from_ptr(raw.as_ptr()) }
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_default();
+        unsafe {
+            let _ = nvrtc_result::destroy_program(prog);
+        }
+        return Err(Error::Codec(format!(
+            "Failed to compile CUDA kernels to CUBIN: {e:?}\n{log}"
+        )));
+    }
+
+    let cubin = unsafe {
+        let mut size: usize = 0;
+        nvrtc_sys::nvrtcGetCUBINSize(prog, &mut size as *mut usize)
+            .result()
+            .map_err(|e| Error::Codec(format!("nvrtcGetCUBINSize failed: {e:?}")))?;
+        let mut buf = vec![0 as c_char; size];
+        nvrtc_sys::nvrtcGetCUBIN(prog, buf.as_mut_ptr())
+            .result()
+            .map_err(|e| Error::Codec(format!("nvrtcGetCUBIN failed: {e:?}")))?;
+        buf.into_iter().map(|b| b as u8).collect::<Vec<u8>>()
+    };
+
+    unsafe {
+        let _ = nvrtc_result::destroy_program(prog);
+    }
+
+    Ok(Ptx::from_binary(cubin))
+}
+
 /// Compile and load CUDA kernels, returning the kernel functions.
 ///
 /// Targets the device's actual compute capability to avoid
 /// `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` when the NVRTC compiler is newer
 /// than the installed driver.
 fn load_kernels(device: &Arc<CudarcContext>) -> Result<(CudaFunction, CudaFunction)> {
-    let opts = match device.compute_capability() {
-        Ok((major, minor)) => CompileOptions {
-            options: vec![format!("--gpu-architecture=sm_{}{}", major, minor)],
-            ..Default::default()
-        },
-        Err(_) => CompileOptions::default(),
+    // Architecture flag for the device, e.g. "--gpu-architecture=sm_90".
+    let arch_options: Vec<String> = match device.compute_capability() {
+        Ok((major, minor)) => vec![format!("--gpu-architecture=sm_{}{}", major, minor)],
+        Err(_) => Vec::new(),
     };
 
+    // Default path: JIT-compile PTX through the driver. If the driver rejects
+    // that PTX -- most commonly CUDA_ERROR_UNSUPPORTED_PTX_VERSION when the NVRTC
+    // toolkit is newer than the installed driver -- transparently fall back to a
+    // device-specific CUBIN, which is loaded directly and skips the PTX JIT. This
+    // keeps the GPU path working with no configuration; CPU fallback (handled by
+    // the caller) only happens if both routes fail.
+    let opts = CompileOptions {
+        options: arch_options.clone(),
+        ..Default::default()
+    };
     let ptx = compile_ptx_with_opts(CUDA_KERNELS, opts)
         .map_err(|e| Error::Codec(format!("Failed to compile CUDA kernels: {:?}", e)))?;
 
-    let module = device
-        .load_module(ptx)
-        .map_err(|e| Error::Codec(format!("Failed to load CUDA module: {:?}", e)))?;
+    let module = match device.load_module(ptx) {
+        Ok(module) => module,
+        Err(ptx_err) => {
+            let cubin = compile_kernels_cubin(CUDA_KERNELS, &arch_options)?;
+            device.load_module(cubin).map_err(|e| {
+                Error::Codec(format!(
+                    "Failed to load CUDA module as PTX ({:?}) and as CUBIN ({:?})",
+                    ptx_err, e
+                ))
+            })?
+        }
+    };
 
     let argmax_func = module
         .load_function("argmax_kernel")


### PR DESCRIPTION
Companion to **lightonai/fastkmeans-rs#10** — same CUBIN fallback, for next-plaid's residual **codec**.

## Problem

The codec JIT-compiles its argmax/gather-subtract kernels to **PTX**. On a host whose driver is older than the NVRTC toolkit (e.g. **CUDA 13.1 toolkit / 13.0 driver**), the driver rejects the PTX (`CUDA_ERROR_UNSUPPORTED_PTX_VERSION`) and the GPU codec path dies (or silently drops to CPU in auto mode).

## Fix

Mirror the fastkmeans-rs fallback: attempt PTX first (unchanged), and **only on failure** recompile the kernels to a device-specific **CUBIN (SASS)** (`nvrtcGetCUBIN` + `cuModuleLoadData`), skipping the driver's PTX JIT.

## Safety / backward-compat (colgrep ships on Windows/macOS/CPU too)

- **CUDA-only**: code is in `next-plaid/src/cuda.rs`, gated by `cfg(feature = "_cuda")`. The release matrix builds CUDA **only on Linux**; Windows (DirectML), macOS (CoreML/Metal) and CPU never compile this code.
- **Strictly additive**: PTX-first and unchanged; CUBIN only on PTX-load failure — it can only fix currently-broken hosts, never regress a working one.
- Builds verified: default (no CUDA), `--features cuda` (CUDA 11.8/12.x), `--features cuda-13`; clippy + rustfmt clean.

## Validation (H100, 13.1 toolkit / 13.0 driver, no 13.0 NVRTC present)

- Context probe: kernels load via CUBIN fallback (`CUDA CONTEXT OK`).
- `colgrep init --force-gpu` indexes on the GPU end-to-end with both codec and (patched) k-means going through CUBIN — zero NVRTC workaround.

## Scope

This PR now delivers the **full** GPU fix for colgrep:
- codec CUBIN fallback (this diff), and
- `fastkmeans-rs` dependency bumped to **1.0.8** (k-means CUBIN fallback).

Together the encode + k-means + codec paths run on the GPU on hosts whose driver
is older than the NVRTC toolkit (e.g. CUDA 13.1 toolkit / 13.0 driver) with **no
manual NVRTC workaround**. CUDA-only and strictly additive — non-CUDA platforms
(Windows/macOS/CPU) and working GPU hosts are unaffected.