### PR TITLE
fix(colgrep): worktree seeding served stale sibling embeddings and could copy a torn store

### DIFF
--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2028,6 +2028,22 @@ impl IndexBuilder {
 
         for candidate in candidates {
             let src_dir = &candidate.index_dir;
+            // Never-indexed siblings have no index dir; skip before locking so the
+            // lock file doesn't create one as a side effect.
+            if !src_dir.exists() {
+                continue;
+            }
+            // Hold the SIBLING's lock across validation and copy, so a sibling
+            // update can't start mid-copy and leave us a torn seed (the
+            // `.building`/dirty checks below only see the state at read time).
+            // Non-blocking on purpose: a busy sibling is mid-update and would be
+            // rejected as dirty anyway, and never waiting on a foreign lock while
+            // holding our own rules out lock-order deadlocks (two fresh worktrees
+            // seeding from each other both skip instead of waiting). Lock errors
+            // (e.g. permissions) just skip the candidate — seeding is best-effort.
+            let Some(_sibling_lock) = try_acquire_index_lock(src_dir).ok().flatten() else {
+                continue;
+            };
             // Validate the sibling holds a complete, format-compatible, non-dirty index that
             // isn't mid-build. Skip otherwise so we never seed from a half-built or stale store.
             let Some(mut src_state) = seed_source_state(src_dir) else {

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -196,6 +196,36 @@ fn seed_source_state(src_dir: &Path) -> Option<IndexState> {
     }
 }
 
+/// Rebase per-file records seeded from a sibling worktree onto this worktree's files.
+///
+/// The seeded records carry the SOURCE branch's content hashes — they describe what
+/// the copied embeddings were computed from, so they must be kept, and a record may
+/// only take this worktree's mtime/size when the local content actually matches that
+/// hash. Stamping mtime/size unconditionally would let `compute_update_plan`'s
+/// mtime+size fast path skip the hash check and serve the sibling branch's stale
+/// embeddings for files that differ between the branches. For files whose content
+/// differs (or can't be read), zero the stats so the fast path is guaranteed to miss
+/// and the first update re-hashes and re-embeds them (size 0 is the established
+/// "force a one-time content hash" sentinel, see `FileInfo::size`).
+fn rebase_seeded_file_stats(
+    project_root: &Path,
+    files: &mut std::collections::HashMap<PathBuf, FileInfo>,
+) {
+    for (path, info) in files.iter_mut() {
+        let full = project_root.join(path);
+        match (file_stat(&full), hash_file(&full)) {
+            (Ok((mtime, size)), Ok(hash)) if hash == info.content_hash => {
+                info.mtime = mtime;
+                info.size = size;
+            }
+            _ => {
+                info.mtime = 0;
+                info.size = 0;
+            }
+        }
+    }
+}
+
 /// Threshold for switching to higher pool factor (fewer embeddings per doc).
 /// When encoding more than this many units, use LARGE_BATCH_POOL_FACTOR.
 const LARGE_BATCH_THRESHOLD: usize = 10_000;
@@ -2019,18 +2049,7 @@ impl IndexBuilder {
             std::fs::rename(&tmp, &dest_vector)
                 .context("Failed to move seeded index into place")?;
 
-            // Refresh stats to match this worktree's files. The content hashes
-            // from the source are still valid (same git content), but mtimes
-            // differ because git checkout stamps files with the current time.
-            // Without this, the mtime fast path would miss on every file and
-            // trigger a full content-hash pass on the first search.
-            for (path, info) in src_state.files.iter_mut() {
-                let full = self.project_root.join(path);
-                if let Ok((mtime, size)) = file_stat(&full) {
-                    info.mtime = mtime;
-                    info.size = size;
-                }
-            }
+            rebase_seeded_file_stats(&self.project_root, &mut src_state.files);
 
             // Persist state (save() restamps the version/format fields) and a
             // fresh project.json pointing at THIS worktree, not the source.
@@ -5792,6 +5811,65 @@ mod tests {
         // Re-save with dirty set (save() preserves the flag, restamps version/format).
         dirty.save(src_dir).unwrap();
         assert!(seed_source_state(src_dir).is_none(), "dirty index");
+    }
+
+    /// Seeded records may only adopt this worktree's mtime/size when the local
+    /// content matches the sibling's hash. A file that differs between the
+    /// branches must be left with zeroed stats so the mtime+size fast path in
+    /// compute_update_plan misses and the hash check (→ re-embed) runs;
+    /// stamping stats unconditionally used to mark such files unchanged and
+    /// serve the sibling branch's stale embeddings for them.
+    #[test]
+    fn test_rebase_seeded_stats_keeps_differing_files_stale() {
+        let proj = tempfile::tempdir().unwrap();
+        std::fs::write(proj.path().join("same.rs"), "fn same() {}\n").unwrap();
+        std::fs::write(proj.path().join("differs.rs"), "fn local_version() {}\n").unwrap();
+
+        let mut files: HashMap<PathBuf, FileInfo> = HashMap::new();
+        // Sibling hash matches local content.
+        files.insert(
+            PathBuf::from("same.rs"),
+            FileInfo {
+                content_hash: hash_file(&proj.path().join("same.rs")).unwrap(),
+                mtime: 42,
+                size: 42,
+            },
+        );
+        // Sibling indexed different content for this path.
+        files.insert(
+            PathBuf::from("differs.rs"),
+            FileInfo {
+                content_hash: 0xDEAD_BEEF,
+                mtime: 42,
+                size: 42,
+            },
+        );
+        // Sibling-only file, absent in this worktree.
+        files.insert(
+            PathBuf::from("missing.rs"),
+            FileInfo {
+                content_hash: 7,
+                mtime: 42,
+                size: 42,
+            },
+        );
+
+        rebase_seeded_file_stats(proj.path(), &mut files);
+
+        let same = &files[&PathBuf::from("same.rs")];
+        let (mtime, size) = file_stat(&proj.path().join("same.rs")).unwrap();
+        assert_eq!((same.mtime, same.size), (mtime, size));
+
+        let differs = &files[&PathBuf::from("differs.rs")];
+        assert_eq!(
+            (differs.mtime, differs.size),
+            (0, 0),
+            "differing file must not satisfy the stat fast path"
+        );
+        assert_eq!(differs.content_hash, 0xDEAD_BEEF, "sibling hash preserved");
+
+        let missing = &files[&PathBuf::from("missing.rs")];
+        assert_eq!((missing.mtime, missing.size), (0, 0));
     }
 
     /// A missing state.json must not be mistaken for an incompatible index format.

--- a/colgrep/src/index/paths.rs
+++ b/colgrep/src/index/paths.rs
@@ -317,6 +317,29 @@ mod tests {
         assert_ne!(name1, name2);
     }
 
+    /// While one handle holds the index lock (e.g. a worktree mid-update), a
+    /// non-blocking attempt from another handle must report contention rather
+    /// than succeed. Worktree seeding relies on this to skip a busy sibling
+    /// instead of copying a store that is being rewritten under it.
+    #[test]
+    fn test_try_acquire_index_lock_reports_contention() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let held = try_acquire_index_lock(dir.path())
+            .unwrap()
+            .expect("uncontended lock must be acquired");
+        assert!(
+            try_acquire_index_lock(dir.path()).unwrap().is_none(),
+            "held lock must not be acquired a second time"
+        );
+
+        drop(held);
+        assert!(
+            try_acquire_index_lock(dir.path()).unwrap().is_some(),
+            "released lock must be acquirable again"
+        );
+    }
+
     #[test]
     fn test_different_models_different_hashes() {
         // Same project path, different models → different index directories.


### PR DESCRIPTION
## Summary

Two bugs in the git-worktree index seeding path (`try_seed_from_sibling_worktree`).

### 1. Stale sibling embeddings served for files that differ between branches

After copying a sibling worktree's index, the refresh loop stamped the **current** worktree's mtime and size onto every seeded file record while keeping the **sibling branch's** content hash:

```rust
info.mtime = mtime;   // current worktree
info.size  = size;    // current worktree
// info.content_hash stays = sibling's
```

On the first post-seed run, `compute_update_plan`'s mtime+size fast path therefore matched every file and the content-hash comparison never ran. Files whose content differs between the two branches were marked `unchanged` and kept serving the sibling branch's embeddings: indefinitely, until the user happened to edit them (the saved state then recorded current mtime/size with the sibling hash, so every subsequent run kept fast-path matching too). This contradicts the module's own contract that change detection keys on `content_hash`.

**Fix:** hash each seeded file once during seeding. Local content matching the sibling's hash keeps the fast path (mtime/size stamped as before). Differing or unreadable files get zeroed stats (`size == 0` is the codebase's established force-a-hash sentinel, see `FileInfo::size`), so the first update re-hashes them, sees the mismatch, and re-embeds. The one-time cost is an xxh3 pass over the tree, not re-embedding; identical files are still never re-embedded.

### 2. Unlocked cross-worktree copy (TOCTOU)

The seeding copy read and copied the sibling's store while holding only the **destination** index's lock. The `.building`/dirty checks only see the state at read time, so a sibling update starting mid-copy could rewrite chunks under the copy and leave the new worktree seeded with a torn store.

**Fix:** hold the sibling's lock across validation and copy. Acquisition is deliberately **non-blocking** (`try_acquire_index_lock`): a busy sibling is mid-update and would be rejected as dirty anyway, and never waiting on a foreign lock while holding our own rules out lock-order deadlocks. Two fresh worktrees seeding from each other both skip and fall back to a normal build instead of waiting on each other. Missing index dirs are skipped before locking so the lock file doesn't create them as a side effect.

## Test plan

- [x] New unit test `test_rebase_seeded_stats_keeps_differing_files_stale`: matching file adopts local stats, differing file keeps the sibling hash with zeroed stats, sibling-only file gets zeroed stats
- [x] New unit test `test_try_acquire_index_lock_reports_contention` (the lock primitive had no coverage): a held lock is not re-acquirable, a released lock is
- [x] Full colgrep suite: 621 tests pass
- [x] `cargo fmt` and `cargo clippy -p colgrep --all-targets` clean