### PR TITLE
feat(colgrep): add first-class Dart support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "tree-sitter-cmake",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-graphql",
@@ -4706,6 +4707,16 @@ name = "tree-sitter-css"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/colgrep/Cargo.toml
+++ b/colgrep/Cargo.toml
@@ -32,6 +32,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-c-sharp = "0.23"
+tree-sitter-dart = "0.2"
 # Additional languages
 tree-sitter-kotlin-ng = "1.1"
 tree-sitter-swift = "0.7"

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -571,7 +571,7 @@ ColGREP automatically detects and repairs index/metadata desync from interrupted
 
 ## Supported Languages
 
-### Code (34 languages, tree-sitter AST parsing)
+### Code (35 languages, tree-sitter AST parsing)
 
 | Language         | Extensions                                              |
 | ---------------- | ------------------------------------------------------- |
@@ -584,6 +584,7 @@ ColGREP automatically detects and repairs index/metadata desync from interrupted
 | C                | `.c`, `.h`                                              |
 | C++              | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx`                   |
 | C#               | `.cs`                                                   |
+| Dart             | `.dart`                                                 |
 | Ruby             | `.rb`, `.rake`, `.gemspec`, `Rakefile`, `Gemfile`, `Vagrantfile` |
 | Kotlin           | `.kt`, `.kts`                                           |
 | Swift            | `.swift`                                                |

--- a/colgrep/python-sdk/Cargo.lock
+++ b/colgrep/python-sdk/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "tree-sitter-cmake",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-graphql",
@@ -3273,6 +3274,16 @@ name = "tree-sitter-css"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/colgrep/src/parser/analysis.rs
+++ b/colgrep/src/parser/analysis.rs
@@ -222,8 +222,8 @@ pub fn extract_docstring(node: Node, lines: &[&str], lang: Language) -> Option<S
             }
             None
         }
-        Language::Swift => {
-            // Swift uses /// doc comments (like Rust)
+        Language::Swift | Language::Dart => {
+            // Swift and Dart use /// doc comments (like Rust)
             let mut doc_lines = Vec::new();
             let start_row = node.start_position().row;
             if start_row > 0 {
@@ -399,8 +399,72 @@ pub fn extract_docstring(node: Node, lines: &[&str], lang: Language) -> Option<S
     }
 }
 
+/// Extract Dart parameter names from normal, named, optional, field-formal,
+/// and function-typed parameters.
+fn extract_dart_parameters(node: Node, bytes: &[u8]) -> Vec<String> {
+    fn parameter_name<'a>(node: Node<'a>, max_depth: usize) -> Option<Node<'a>> {
+        let mut stack = vec![(node, 0usize)];
+        while let Some((current, depth)) = stack.pop() {
+            if let Some(name) = current.child_by_field_name("name") {
+                return Some(name);
+            }
+            // Dart types use `type_identifier`, while parameter variables use
+            // `identifier`. Taking the first identifier avoids accidentally
+            // selecting an identifier from a default value or nested callback.
+            if current.kind() == "identifier" {
+                return Some(current);
+            }
+            if depth < max_depth && current.kind() != "annotation" {
+                let children: Vec<_> = current.children(&mut current.walk()).collect();
+                for child in children.into_iter().rev() {
+                    stack.push((child, depth + 1));
+                }
+            }
+        }
+        None
+    }
+
+    let Some(params) =
+        find_first_by_kind(node, "formal_parameter_list", super::max_recursion_depth())
+    else {
+        return Vec::new();
+    };
+
+    let mut result = Vec::new();
+    let mut stack: Vec<_> = params.children(&mut params.walk()).collect();
+    stack.reverse();
+    while let Some(current) = stack.pop() {
+        if current.kind() == "formal_parameter" {
+            if let Some(name) = parameter_name(current, super::max_recursion_depth()) {
+                if let Ok(text) = name.utf8_text(bytes) {
+                    let text = text.trim();
+                    if !text.is_empty()
+                        && text != "this"
+                        && text != "super"
+                        && !result.iter().any(|existing| existing == text)
+                    {
+                        result.push(text.to_string());
+                    }
+                }
+            }
+            continue;
+        }
+
+        let children: Vec<_> = current.children(&mut current.walk()).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+
+    result
+}
+
 /// Extract parameter names from a function node.
 pub fn extract_parameters(node: Node, bytes: &[u8], lang: Language) -> Vec<String> {
+    if lang == Language::Dart {
+        return extract_dart_parameters(node, bytes);
+    }
+
     let params_node = match lang {
         Language::Python | Language::Rust | Language::Go | Language::Java | Language::CSharp => {
             node.child_by_field_name("parameters")
@@ -578,14 +642,121 @@ pub fn extract_return_type(node: Node, bytes: &[u8], lang: Language) -> Option<S
         Language::Go => node.child_by_field_name("result"),
         Language::Java | Language::CSharp => node.child_by_field_name("type"),
         Language::Cpp | Language::C => node.child_by_field_name("type"),
+        Language::Dart => {
+            let signature = find_first_by_kinds(
+                node,
+                &[
+                    "function_signature",
+                    "getter_signature",
+                    "setter_signature",
+                    "operator_signature",
+                ],
+                super::max_recursion_depth(),
+            )?;
+            if signature.kind() == "setter_signature" {
+                return None;
+            }
+
+            let end_byte = if signature.kind() == "operator_signature" {
+                let source = signature.utf8_text(bytes).ok()?;
+                signature.start_byte() + source.find("operator")?
+            } else {
+                signature.child_by_field_name("name")?.start_byte()
+            };
+            let mut return_type = std::str::from_utf8(&bytes[signature.start_byte()..end_byte])
+                .ok()?
+                .trim();
+            if signature.kind() == "getter_signature" {
+                return_type = return_type
+                    .strip_suffix("get")
+                    .unwrap_or(return_type)
+                    .trim();
+            }
+            // Top-level setters parse as a function_signature whose `set`
+            // keyword is consumed as the type, since `set` is also a valid
+            // built-in identifier. Match class-level setters: no return type.
+            if return_type.is_empty() || return_type == "set" {
+                return None;
+            }
+            return Some(return_type.to_string());
+        }
         _ => None,
     };
 
     ret_node.and_then(|n| n.utf8_text(bytes).ok().map(|s| s.to_string()))
 }
 
+fn extract_dart_function_calls(node: Node, bytes: &[u8]) -> Vec<String> {
+    fn identifier_text(node: Node, bytes: &[u8]) -> Option<String> {
+        node.utf8_text(bytes)
+            .ok()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    fn callable_name(node: Node, bytes: &[u8]) -> Option<String> {
+        match node.kind() {
+            "identifier" | "type_identifier" => identifier_text(node, bytes),
+            "member_expression"
+            | "null_aware_member_expression"
+            | "cascade_member_expression"
+            | "cascade_null_aware_member_expression" => node
+                .child_by_field_name("property")
+                .and_then(|property| identifier_text(property, bytes)),
+            "call_expression" | "instantiation_expression" => node
+                .child_by_field_name("function")
+                .and_then(|function| callable_name(function, bytes)),
+            "cascade_call_expression" => node
+                .child_by_field_name("property")
+                .and_then(|property| identifier_text(property, bytes))
+                .or_else(|| {
+                    node.child_by_field_name("function")
+                        .and_then(|function| callable_name(function, bytes))
+                }),
+            "new_expression" | "const_object_expression" | "constructor_invocation" => node
+                .child_by_field_name("constructor")
+                .and_then(|constructor| identifier_text(constructor, bytes))
+                .or_else(|| {
+                    node.child_by_field_name("type")
+                        .and_then(|kind| identifier_text(kind, bytes))
+                }),
+            _ => None,
+        }
+    }
+
+    let mut calls = Vec::new();
+    walk_tree(node, |current| match current.kind() {
+        "call_expression" => {
+            if let Some(function) = current.child_by_field_name("function") {
+                if let Some(name) = callable_name(function, bytes) {
+                    calls.push(name);
+                }
+            }
+        }
+        "cascade_call_expression" => {
+            if let Some(name) = callable_name(current, bytes) {
+                calls.push(name);
+            }
+        }
+        "new_expression" | "const_object_expression" | "constructor_invocation" => {
+            if let Some(name) = callable_name(current, bytes) {
+                calls.push(name);
+            }
+        }
+        _ => {}
+    });
+    calls.sort();
+    calls.dedup();
+    calls
+}
+
 /// Extract function calls from a node.
 pub fn extract_function_calls(node: Node, bytes: &[u8], lang: Language) -> Vec<String> {
+    if lang == Language::Dart {
+        return extract_dart_function_calls(node, bytes);
+    }
+
     let mut calls = Vec::new();
     let call_types: &[&str] = match lang {
         Language::Python => &["call"],
@@ -641,7 +812,7 @@ pub fn extract_function_calls(node: Node, bytes: &[u8], lang: Language) -> Vec<S
 }
 
 /// Extract control flow information from a node.
-pub fn extract_control_flow(node: Node, _lang: Language) -> (usize, bool, bool, bool) {
+pub fn extract_control_flow(node: Node, lang: Language) -> (usize, bool, bool, bool) {
     let mut complexity = 1;
     let mut has_loops = false;
     let mut has_branches = false;
@@ -676,8 +847,10 @@ pub fn extract_control_flow(node: Node, _lang: Language) -> (usize, bool, bool, 
             | "try" => {
                 has_error_handling = true;
             }
-            // Rust-specific error handling patterns
-            "?" | "try_operator" => {
+            // Rust-specific error handling patterns. Other grammars emit a
+            // bare `?` token for unrelated syntax (Dart/Swift nullable types,
+            // TypeScript optional members), so gate on language.
+            "?" | "try_operator" if lang == Language::Rust => {
                 has_error_handling = true;
             }
             _ => {}
@@ -696,6 +869,12 @@ pub fn extract_variables(node: Node, bytes: &[u8], lang: Language) -> Vec<String
             &["variable_declarator", "lexical_declaration"]
         }
         Language::Go => &["short_var_declaration", "var_declaration"],
+        Language::Dart => &[
+            "initialized_identifier",
+            "initialized_variable_definition",
+            "static_final_declaration",
+            "declared_identifier",
+        ],
         Language::Java | Language::CSharp => &["variable_declarator", "local_variable_declaration"],
         Language::C | Language::Cpp => &["declaration", "init_declarator"],
         Language::Ruby => &["assignment"],
@@ -759,8 +938,80 @@ pub fn extract_variables(node: Node, bytes: &[u8], lang: Language) -> Vec<String
     vars
 }
 
+fn extract_dart_imports(node: Node, bytes: &[u8]) -> Vec<String> {
+    fn last_uri_component(uri: &str) -> Option<String> {
+        let trimmed = uri.trim_matches(|c: char| c == '\'' || c == '"');
+        let component = trimmed
+            .rsplit('/')
+            .next()
+            .unwrap_or(trimmed)
+            .rsplit(':')
+            .next()
+            .unwrap_or(trimmed)
+            .trim_end_matches(".dart");
+        (!component.is_empty()).then(|| component.to_string())
+    }
+
+    let mut imports = Vec::new();
+    walk_tree(node, |current| {
+        if current.kind() != "library_import" {
+            return;
+        }
+        let Some(specification) = find_first_by_kind(
+            current,
+            "import_specification",
+            super::max_recursion_depth(),
+        ) else {
+            return;
+        };
+
+        for child in specification.named_children(&mut specification.walk()) {
+            match child.kind() {
+                "identifier" => {
+                    if let Ok(alias) = child.utf8_text(bytes) {
+                        imports.push(alias.to_string());
+                    }
+                }
+                "combinator" => {
+                    // `hide` combinators exclude symbols from the import, so
+                    // only `show` combinators contribute imported names.
+                    if child.child(0).is_some_and(|kw| kw.kind() == "hide") {
+                        continue;
+                    }
+                    for identifier in child.named_children(&mut child.walk()) {
+                        if identifier.kind() == "identifier" {
+                            if let Ok(symbol) = identifier.utf8_text(bytes) {
+                                imports.push(symbol.to_string());
+                            }
+                        }
+                    }
+                }
+                "configurable_uri" | "uri" => {
+                    if let Some(literal) =
+                        find_first_by_kind(child, "string_literal", super::max_recursion_depth())
+                    {
+                        if let Ok(uri) = literal.utf8_text(bytes) {
+                            if let Some(component) = last_uri_component(uri) {
+                                imports.push(component);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+    imports.sort();
+    imports.dedup();
+    imports
+}
+
 /// Extract import statements from a file.
 pub fn extract_file_imports(node: Node, bytes: &[u8], lang: Language) -> Vec<String> {
+    if lang == Language::Dart {
+        return extract_dart_imports(node, bytes);
+    }
+
     let mut imports = Vec::new();
     let import_types: &[&str] = match lang {
         Language::Python => &["import_statement", "import_from_statement"],
@@ -1009,9 +1260,50 @@ pub fn extract_file_imports(node: Node, bytes: &[u8], lang: Language) -> Vec<Str
     imports
 }
 
+fn extract_dart_used_modules(node: Node, bytes: &[u8]) -> Vec<String> {
+    fn receiver_name(node: Node, bytes: &[u8]) -> Option<String> {
+        match node.kind() {
+            "identifier" | "type_identifier" => node
+                .utf8_text(bytes)
+                .ok()
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && *value != "this" && *value != "super")
+                .map(ToOwned::to_owned),
+            "member_expression" | "null_aware_member_expression" => node
+                .child_by_field_name("object")
+                .and_then(|object| receiver_name(object, bytes)),
+            "call_expression" | "instantiation_expression" => node
+                .child_by_field_name("function")
+                .and_then(|function| receiver_name(function, bytes)),
+            _ => None,
+        }
+    }
+
+    let mut modules = Vec::new();
+    walk_tree(node, |current| {
+        if matches!(
+            current.kind(),
+            "member_expression" | "null_aware_member_expression"
+        ) {
+            if let Some(object) = current.child_by_field_name("object") {
+                if let Some(module) = receiver_name(object, bytes) {
+                    modules.push(module);
+                }
+            }
+        }
+    });
+    modules.sort();
+    modules.dedup();
+    modules
+}
+
 /// Extract module/receiver names from attribute access patterns (e.g., `json` from `json.loads()`).
 /// These are identifiers that are used as the base of attribute access or method calls.
 pub fn extract_used_modules(node: Node, bytes: &[u8], lang: Language) -> Vec<String> {
+    if lang == Language::Dart {
+        return extract_dart_used_modules(node, bytes);
+    }
+
     let mut modules = Vec::new();
     let attr_types: &[&str] = match lang {
         Language::Python => &["attribute"],
@@ -1243,6 +1535,13 @@ pub fn extract_parent_class(
                 }
             }
             None
+        }
+
+        // Dart: class Dog extends Animal -> superclass -> type_identifier
+        Language::Dart => {
+            let superclass = node.child_by_field_name("superclass")?;
+            find_first_by_kind(superclass, "type_identifier", max_depth)
+                .and_then(|n| n.utf8_text(bytes).ok().map(ToOwned::to_owned))
         }
 
         // Kotlin: class Dog : Animal() -> delegation_specifiers -> delegation_specifier -> constructor_invocation -> user_type -> identifier

--- a/colgrep/src/parser/ast.rs
+++ b/colgrep/src/parser/ast.rs
@@ -19,6 +19,14 @@ pub fn is_function_node(kind: &str, lang: Language) -> bool {
         Language::C | Language::Cpp => kind == "function_definition",
         Language::Ruby => kind == "method" || kind == "singleton_method",
         Language::CSharp => kind == "method_declaration" || kind == "constructor_declaration",
+        Language::Dart => matches!(
+            kind,
+            "function_signature"
+                | "getter_signature"
+                | "setter_signature"
+                | "method_signature"
+                | "declaration"
+        ),
         // Additional languages
         Language::Kotlin => matches!(kind, "function_declaration" | "anonymous_function"),
         Language::Swift => matches!(kind, "function_declaration" | "init_declaration"),
@@ -77,6 +85,16 @@ pub fn is_class_node(kind: &str, lang: Language) -> bool {
                 | "interface_declaration"
                 | "enum_declaration"
                 | "struct_declaration"
+        ),
+        Language::Dart => matches!(
+            kind,
+            "class_declaration"
+                | "class_definition"
+                | "mixin_declaration"
+                | "extension_declaration"
+                | "extension_type_declaration"
+                | "enum_declaration"
+                | "type_alias"
         ),
         // Additional languages
         Language::Kotlin => matches!(
@@ -176,6 +194,10 @@ pub fn is_constant_node(kind: &str, lang: Language) -> bool {
             matches!(kind, "lexical_declaration" | "variable_declaration")
         }
         Language::Go => matches!(kind, "const_declaration" | "var_declaration"),
+        Language::Dart => matches!(
+            kind,
+            "static_final_declaration_list" | "initialized_identifier_list" | "identifier_list"
+        ),
         Language::C | Language::Cpp => kind == "declaration",
         Language::Python => {
             // Python doesn't have const, but we capture module-level assignments
@@ -213,6 +235,14 @@ pub fn find_class_body(node: Node, lang: Language) -> Option<Node> {
             node.child_by_field_name("body")
         }
         Language::Java | Language::CSharp => node.child_by_field_name("body"),
+        Language::Dart => node.child_by_field_name("body").or_else(|| {
+            node.children(&mut node.walk()).find(|child| {
+                matches!(
+                    child.kind(),
+                    "class_body" | "mixin_body" | "extension_body" | "enum_body"
+                )
+            })
+        }),
         Language::Go => node.child_by_field_name("type"),
         Language::Cpp => {
             // Look for field_declaration_list in class_specifier
@@ -275,6 +305,112 @@ pub fn find_class_body(node: Node, lang: Language) -> Option<Node> {
     }
 }
 
+fn get_dart_node_name(node: Node, bytes: &[u8]) -> Option<String> {
+    fn text(node: Node, bytes: &[u8]) -> Option<String> {
+        node.utf8_text(bytes)
+            .ok()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    fn find_signature(node: Node, max_depth: usize) -> Option<Node> {
+        let signature_kinds = [
+            "function_signature",
+            "getter_signature",
+            "setter_signature",
+            "operator_signature",
+            "constructor_signature",
+            "constant_constructor_signature",
+            "factory_constructor_signature",
+            "redirecting_factory_constructor_signature",
+        ];
+        let mut stack = vec![(node, 0usize)];
+        while let Some((current, depth)) = stack.pop() {
+            if signature_kinds.contains(&current.kind()) {
+                return Some(current);
+            }
+            if depth < max_depth {
+                let children: Vec<_> = current.children(&mut current.walk()).collect();
+                for child in children.into_iter().rev() {
+                    stack.push((child, depth + 1));
+                }
+            }
+        }
+        None
+    }
+
+    match node.kind() {
+        "type_alias" => {
+            let has_equals = node
+                .children(&mut node.walk())
+                .any(|child| child.kind() == "=");
+            let names: Vec<_> = node
+                .children(&mut node.walk())
+                .filter(|child| child.kind() == "type_identifier")
+                .collect();
+            let name = if has_equals {
+                names.first()
+            } else {
+                names.last()
+            }?;
+            return text(*name, bytes);
+        }
+        "mixin_declaration" => {
+            let name = node
+                .children(&mut node.walk())
+                .find(|child| child.kind() == "identifier")?;
+            return text(name, bytes);
+        }
+        "extension_declaration" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                return text(name, bytes);
+            }
+            let target = node.child_by_field_name("class")?;
+            return text(target, bytes).map(|target| format!("extension on {target}"));
+        }
+        "class_declaration"
+        | "class_definition"
+        | "extension_type_declaration"
+        | "enum_declaration" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                return text(name, bytes);
+            }
+        }
+        _ => {}
+    }
+
+    let signature = find_signature(node, super::max_recursion_depth())?;
+    match signature.kind() {
+        "constructor_signature"
+        | "constant_constructor_signature"
+        | "factory_constructor_signature"
+        | "redirecting_factory_constructor_signature" => {
+            let source = text(signature, bytes)?;
+            let mut head = source.split('(').next().unwrap_or(&source).trim();
+            for prefix in ["external ", "const ", "factory "] {
+                if let Some(stripped) = head.strip_prefix(prefix) {
+                    head = stripped.trim();
+                }
+            }
+            (!head.is_empty()).then(|| head.to_string())
+        }
+        "operator_signature" => {
+            let source = text(signature, bytes)?;
+            let operator = source.find("operator")?;
+            let head = source[operator..]
+                .split('(')
+                .next()
+                .unwrap_or("operator")
+                .trim();
+            Some(head.to_string())
+        }
+        _ => signature
+            .child_by_field_name("name")
+            .and_then(|name| text(name, bytes)),
+    }
+}
+
 /// Get the name of a node (function, class, etc.).
 pub fn get_node_name(node: Node, bytes: &[u8], lang: Language) -> Option<String> {
     let name_node = match lang {
@@ -287,6 +423,7 @@ pub fn get_node_name(node: Node, bytes: &[u8], lang: Language) -> Option<String>
         Language::TypeScript | Language::JavaScript | Language::Vue | Language::Svelte => node
             .child_by_field_name("name")
             .or_else(|| node.child_by_field_name("property")),
+        Language::Dart => return get_dart_node_name(node, bytes),
         Language::C | Language::Cpp => {
             // For classes/structs/unions/enums, look for name field or type_identifier
             if matches!(
@@ -646,6 +783,8 @@ pub fn find_start_with_attributes(node_start_line: usize, lines: &[&str], lang: 
             Language::Python => line.starts_with('@'),
             // Java, Kotlin, Scala: @Annotation
             Language::Java | Language::Kotlin | Language::Scala => line.starts_with('@'),
+            // Dart: metadata annotations and /// documentation comments
+            Language::Dart => line.starts_with('@') || line.starts_with("///"),
             // C#: [Attribute]
             Language::CSharp => line.starts_with('[') && line.ends_with(']'),
             // TypeScript/JavaScript/Vue/Svelte: @decorator (when using decorators), or /** JSDoc */

--- a/colgrep/src/parser/extract.rs
+++ b/colgrep/src/parser/extract.rs
@@ -9,6 +9,29 @@ use super::types::{CodeUnit, Language, UnitType};
 use std::path::Path;
 use tree_sitter::Node;
 
+/// Dart's grammar represents a function declaration as a signature node
+/// followed by a sibling `function_body`. Other supported grammars usually
+/// wrap both pieces in one node, so normalize that shape here.
+fn dart_function_body(node: Node) -> Option<Node> {
+    if matches!(
+        node.kind(),
+        "function_signature" | "getter_signature" | "setter_signature" | "method_signature"
+    ) {
+        node.next_named_sibling()
+            .filter(|sibling| sibling.kind() == "function_body")
+    } else {
+        None
+    }
+}
+
+fn extend_unique(target: &mut Vec<String>, values: Vec<String>) {
+    for value in values {
+        if !target.contains(&value) {
+            target.push(value);
+        }
+    }
+}
+
 /// Extract a function or method from an AST node.
 pub fn extract_function(
     node: Node,
@@ -21,10 +44,17 @@ pub fn extract_function(
 ) -> Option<CodeUnit> {
     let name = get_node_name(node, bytes, lang)?;
     let ast_start_line = node.start_position().row;
+    let dart_body = (lang == Language::Dart)
+        .then(|| dart_function_body(node))
+        .flatten();
+    let content_node = dart_body.unwrap_or(node);
     // tree-sitter can report an end row one past EOF for a construct left
     // unterminated at end-of-file (e.g. a block missing its closing brace);
     // clamp so a unit's end_line never points outside the file.
-    let end_line = node.end_position().row.min(lines.len().saturating_sub(1));
+    let end_line = content_node
+        .end_position()
+        .row
+        .min(lines.len().saturating_sub(1));
 
     // Include preceding attributes/decorators in the line range
     let code_start = find_start_with_attributes(ast_start_line, lines, lang);
@@ -54,10 +84,13 @@ pub fn extract_function(
 
     // Layer 2: Call Graph
     unit.calls = extract_function_calls(node, bytes, lang);
+    if let Some(body) = dart_body {
+        extend_unique(&mut unit.calls, extract_function_calls(body, bytes, lang));
+    }
 
     // Layer 3: Control Flow
     let (complexity, has_loops, has_branches, has_error_handling) =
-        extract_control_flow(node, lang);
+        extract_control_flow(content_node, lang);
     unit.complexity = complexity;
     unit.has_loops = has_loops;
     unit.has_branches = has_branches;
@@ -65,10 +98,16 @@ pub fn extract_function(
 
     // Layer 4: Data Flow
     unit.variables = extract_variables(node, bytes, lang);
+    if let Some(body) = dart_body {
+        extend_unique(&mut unit.variables, extract_variables(body, bytes, lang));
+    }
 
     // Layer 5: Dependencies
     // Get modules used via attribute access (e.g., `json` from `json.loads()`)
-    let used_modules = extract_used_modules(node, bytes, lang);
+    let mut used_modules = extract_used_modules(node, bytes, lang);
+    if let Some(body) = dart_body {
+        extend_unique(&mut used_modules, extract_used_modules(body, bytes, lang));
+    }
     // Filter to only modules that are actually imported (case-insensitive for Ruby, etc.)
     unit.imports = file_imports
         .iter()
@@ -173,6 +212,10 @@ fn extract_class_type_parameters(node: Node, bytes: &[u8], lang: Language) -> Ve
         Language::Rust => node.child_by_field_name("type_parameters"),
         Language::CSharp => node.child_by_field_name("type_parameters"),
         Language::Kotlin => node.child_by_field_name("type_parameters"),
+        Language::Dart => node.child_by_field_name("type_parameters").or_else(|| {
+            node.children(&mut node.walk())
+                .find(|child| child.kind() == "type_parameters")
+        }),
         Language::Swift => {
             // Swift uses generic_parameter_clause
             node.children(&mut node.walk())
@@ -212,6 +255,7 @@ fn extract_type_param_names(node: Node, bytes: &[u8], lang: Language, result: &m
         Language::Rust => kind == "type_identifier" || kind == "identifier",
         Language::CSharp => kind == "identifier",
         Language::Kotlin => kind == "type_identifier" || kind == "simple_identifier",
+        Language::Dart => kind == "type_identifier" || kind == "identifier",
         Language::Swift => kind == "type_identifier" || kind == "simple_identifier",
         Language::Scala => kind == "identifier" || kind == "type_identifier",
         _ => false,
@@ -415,6 +459,45 @@ fn get_constant_name(node: Node, bytes: &[u8], lang: Language) -> Option<String>
                 if child.kind() == "identifier" {
                     if let Ok(text) = child.utf8_text(bytes) {
                         return Some(text.to_string());
+                    }
+                }
+            }
+            None
+        }
+        Language::Dart => {
+            let mut stack = vec![(node, 0usize)];
+            let max_depth = super::max_recursion_depth();
+            while let Some((current, depth)) = stack.pop() {
+                if matches!(
+                    current.kind(),
+                    "initialized_identifier"
+                        | "initialized_variable_definition"
+                        | "static_final_declaration"
+                ) {
+                    if let Some(name) = current.child_by_field_name("name").or_else(|| {
+                        current
+                            .children(&mut current.walk())
+                            .find(|child| child.kind() == "identifier")
+                    }) {
+                        if let Ok(text) = name.utf8_text(bytes) {
+                            return Some(text.to_string());
+                        }
+                    }
+                }
+                if current.kind() == "identifier_list" {
+                    if let Some(name) = current
+                        .children(&mut current.walk())
+                        .find(|child| child.kind() == "identifier")
+                    {
+                        if let Ok(text) = name.utf8_text(bytes) {
+                            return Some(text.to_string());
+                        }
+                    }
+                }
+                if depth < max_depth {
+                    let children: Vec<_> = current.children(&mut current.walk()).collect();
+                    for child in children.into_iter().rev() {
+                        stack.push((child, depth + 1));
                     }
                 }
             }

--- a/colgrep/src/parser/language.rs
+++ b/colgrep/src/parser/language.rs
@@ -35,6 +35,7 @@ pub fn detect_language(path: &Path) -> Option<Language> {
         "cpp" | "cc" | "cxx" | "hpp" | "hxx" => Some(Language::Cpp),
         "rb" | "rake" | "gemspec" => Some(Language::Ruby),
         "cs" => Some(Language::CSharp),
+        "dart" => Some(Language::Dart),
         // Additional languages
         "kt" | "kts" => Some(Language::Kotlin),
         "swift" => Some(Language::Swift),
@@ -111,6 +112,7 @@ pub fn get_tree_sitter_language(lang: Language) -> TsLanguage {
         Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
         Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
         Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
+        Language::Dart => tree_sitter_dart::LANGUAGE.into(),
         // Additional languages
         Language::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
         Language::Swift => tree_sitter_swift::LANGUAGE.into(),
@@ -211,6 +213,14 @@ mod tests {
     #[test]
     fn test_detect_language_go() {
         assert_eq!(detect_language(Path::new("main.go")), Some(Language::Go));
+    }
+
+    #[test]
+    fn test_detect_language_dart() {
+        assert_eq!(
+            detect_language(Path::new("lib/main.dart")),
+            Some(Language::Dart)
+        );
     }
 
     #[test]
@@ -508,6 +518,7 @@ mod tests {
         assert!(!is_text_format(Language::Ini));
 
         assert!(!is_text_format(Language::Python));
+        assert!(!is_text_format(Language::Dart));
         assert!(!is_text_format(Language::Rust));
         assert!(!is_text_format(Language::TypeScript));
         assert!(!is_text_format(Language::Go));

--- a/colgrep/src/parser/mod.rs
+++ b/colgrep/src/parser/mod.rs
@@ -66,6 +66,7 @@ fn is_abstract_type_container(kind: &str, lang: Language) -> bool {
             "interface_declaration" | "trait_declaration" | "enum_declaration"
         ),
         Language::Cpp => kind == "enum_specifier",
+        Language::Dart => kind == "type_alias",
         _ => false,
     }
 }
@@ -240,6 +241,12 @@ fn extract_from_node(
             extract_function(node, path, lines, bytes, lang, parent_class, file_imports)
         {
             units.push(unit);
+            // Dart method signatures contain nested function signatures. Once
+            // the outer declaration is extracted, recursing would emit a
+            // duplicate unit for the same method.
+            if lang == Language::Dart {
+                return;
+            }
         }
     }
     // Check if this is a class definition

--- a/colgrep/src/parser/tests/mod.rs
+++ b/colgrep/src/parser/tests/mod.rs
@@ -9,6 +9,7 @@ mod test_cmake;
 mod test_cpp;
 mod test_csharp;
 mod test_css;
+mod test_dart;
 mod test_elixir;
 mod test_go;
 mod test_graphql;

--- a/colgrep/src/parser/tests/test_dart.rs
+++ b/colgrep/src/parser/tests/test_dart.rs
@@ -1,0 +1,188 @@
+//! Dart parser tests.
+
+use super::common::{assert_extractor_invariants, get_unit_by_name};
+use crate::parser::{Language, UnitType};
+
+#[test]
+fn test_dart_functions_classes_and_metadata() {
+    let source = r#"import 'dart:convert' show jsonEncode;
+
+const defaultGreeting = 'Hello';
+
+/// Returns a JSON greeting.
+String greet(String name, {int times = 1, bool loud = false}) {
+  final message = List.filled(times, 'Hello $name').join(' ');
+  return jsonEncode({'message': message});
+}
+
+class Greeter extends Object {
+  final String prefix;
+
+  Greeter(this.prefix);
+
+  String greet(String name) => '$prefix $name';
+}
+"#;
+
+    let units = assert_extractor_invariants(source, Language::Dart, "lib/greeting.dart");
+
+    let constant = get_unit_by_name(&units, "defaultGreeting").expect("Dart constant");
+    assert_eq!(constant.unit_type, UnitType::Constant);
+
+    let top_level = units
+        .iter()
+        .find(|unit| unit.name == "greet" && unit.unit_type == UnitType::Function)
+        .expect("top-level greet function");
+    assert!(top_level.parameters.contains(&"name".to_string()));
+    assert!(top_level.parameters.contains(&"times".to_string()));
+    assert!(top_level.parameters.contains(&"loud".to_string()));
+    assert_eq!(top_level.return_type.as_deref(), Some("String"));
+    assert!(top_level.calls.iter().any(|call| call == "filled"));
+    assert!(top_level.calls.iter().any(|call| call == "join"));
+    assert!(top_level.calls.iter().any(|call| call == "jsonEncode"));
+    assert!(top_level.variables.contains(&"message".to_string()));
+    assert!(top_level.imports.contains(&"jsonEncode".to_string()));
+    assert!(top_level.code.contains("return jsonEncode"));
+    assert_eq!(
+        top_level.docstring.as_deref(),
+        Some("Returns a JSON greeting.")
+    );
+
+    let class = get_unit_by_name(&units, "Greeter").expect("Greeter class");
+    assert_eq!(class.unit_type, UnitType::Class);
+    assert_eq!(class.extends.as_deref(), Some("Object"));
+
+    let method = units
+        .iter()
+        .find(|unit| {
+            unit.name == "greet"
+                && unit.unit_type == UnitType::Method
+                && unit.parent_class.as_deref() == Some("Greeter")
+        })
+        .expect("Greeter.greet method");
+    assert!(method.code.contains("=> '$prefix $name';"));
+
+    assert_eq!(
+        units.iter().filter(|unit| unit.name == "greet").count(),
+        2,
+        "Dart method signatures must not create duplicate function units"
+    );
+}
+
+#[test]
+fn test_dart_modern_type_declarations() {
+    let source = r#"mixin Loggable {
+  void log(String message) => print(message);
+}
+
+enum Status { pending, complete }
+
+extension StringTools on String {
+  bool get isBlank => trim().isEmpty;
+}
+
+extension type UserId(int value) {
+  String show() => value.toString();
+}
+
+typedef Mapper<T, R> = R Function(T value);
+typedef int Comparator(String left, String right);
+"#;
+
+    let units = assert_extractor_invariants(source, Language::Dart, "lib/types.dart");
+    for name in [
+        "Loggable",
+        "Status",
+        "StringTools",
+        "UserId",
+        "Mapper",
+        "Comparator",
+    ] {
+        assert!(get_unit_by_name(&units, name).is_some(), "missing {name}");
+    }
+
+    assert!(units.iter().any(|unit| {
+        unit.name == "show"
+            && unit.unit_type == UnitType::Method
+            && unit.parent_class.as_deref() == Some("UserId")
+    }));
+}
+
+#[test]
+fn test_dart_nullable_types_are_not_error_handling() {
+    let source = r#"class Btn {
+  Btn({required this.onTap, String? tooltip});
+  final void Function() onTap;
+
+  Future<void> load() async {
+    try {
+      await fetch();
+    } catch (e) {
+      rethrow;
+    }
+  }
+}
+"#;
+
+    let units = assert_extractor_invariants(source, Language::Dart, "lib/btn.dart");
+
+    let ctor = units
+        .iter()
+        .find(|unit| unit.name == "Btn" && unit.unit_type == UnitType::Method)
+        .expect("Btn constructor");
+    assert!(
+        !ctor.has_error_handling,
+        "nullable-type `?` must not count as error handling"
+    );
+
+    let load = get_unit_by_name(&units, "load").expect("load method");
+    assert!(load.has_error_handling, "try/catch must still be detected");
+}
+
+#[test]
+fn test_dart_hide_combinator_is_not_an_import() {
+    let source = r#"import 'dart:convert' show jsonEncode;
+import 'package:flutter/material.dart' hide Colors;
+
+String render() {
+  Colors.red;
+  return jsonEncode({});
+}
+"#;
+
+    let units = assert_extractor_invariants(source, Language::Dart, "lib/render.dart");
+
+    let render = get_unit_by_name(&units, "render").expect("render function");
+    assert!(render.imports.contains(&"jsonEncode".to_string()));
+    assert!(
+        !render.imports.iter().any(|import| import == "Colors"),
+        "symbols excluded via `hide` must not be recorded as imports"
+    );
+}
+
+#[test]
+fn test_dart_top_level_getter_and_setter() {
+    let source = r#"int get answer => 42;
+
+set answer(int value) {
+  store(value);
+}
+"#;
+
+    let units = assert_extractor_invariants(source, Language::Dart, "lib/accessors.dart");
+
+    let getter = units
+        .iter()
+        .find(|unit| unit.name == "answer" && unit.return_type.is_some())
+        .expect("top-level getter");
+    assert_eq!(getter.return_type.as_deref(), Some("int"));
+
+    let setter = units
+        .iter()
+        .find(|unit| unit.name == "answer" && unit.parameters == ["value"])
+        .expect("top-level setter");
+    assert_eq!(
+        setter.return_type, None,
+        "the `set` keyword must not be reported as a return type"
+    );
+}

--- a/colgrep/src/parser/tests/test_rust.rs
+++ b/colgrep/src/parser/tests/test_rust.rs
@@ -400,3 +400,18 @@ fn read_config(path: &str) -> io::Result<String> {
 }"#;
     assert_eq!(text, expected);
 }
+
+#[test]
+fn test_try_operator_counts_as_error_handling() {
+    let source = r#"fn read_config(path: &str) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    std::io::read_to_string(file)
+}
+"#;
+    let units = parse(source, Language::Rust, "test.rs");
+    let func = get_unit_by_name(&units, "read_config").unwrap();
+    assert!(
+        func.has_error_handling,
+        "Rust `?` operator must still be detected as error handling"
+    );
+}

--- a/colgrep/src/parser/types.rs
+++ b/colgrep/src/parser/types.rs
@@ -16,6 +16,7 @@ pub enum Language {
     Cpp,
     Ruby,
     CSharp,
+    Dart,
     // Additional languages with tree-sitter
     Kotlin,
     Swift,
@@ -72,6 +73,7 @@ impl FromStr for Language {
             "cpp" | "c++" => Ok(Language::Cpp),
             "ruby" | "rb" => Ok(Language::Ruby),
             "csharp" | "c#" | "cs" => Ok(Language::CSharp),
+            "dart" => Ok(Language::Dart),
             // Additional languages
             "kotlin" | "kt" => Ok(Language::Kotlin),
             "swift" => Ok(Language::Swift),


### PR DESCRIPTION
## What

Adds Dart to ColGREP.
It uses https://github.com/nielsenko/tree-sitter-dart as the tree-sitter parser, which is not an official Tree-sitter parser.

Dart extraction covers:

- Top-level functions and methods
- Constructors, getters, setters, and operators
- Classes, mixins, extensions, extension types, and enums
- Modern and legacy typedefs
- Parameters, return types, `///` documentation, calls, variables, imports, and inheritance

The supported-language documentation and Cargo lockfile are updated as well.

## Implementation notes

- Uses `tree-sitter-dart 0.2.0` through the existing `LANGUAGE.into()` integration.
- Normalizes Dart's separate signature and function-body nodes so extracted units contain the complete implementation.
- Handles Dart's current `call_expression`, `member_expression`, and `class_declaration` grammar shapes.
- Prevents nested method signatures from producing duplicate code units.
- Preserves class and method relationships, including inheritance and qualified names.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p colgrep`
- `cargo test -p colgrep dart` 3 passed
- `cargo test -p colgrep` 722 passed, 1 pre-existing timing test ignored
- Doctests pass
