### PR TITLE
perf(binary): skip residual computation in encode_index_chunk for binary indexes

### DIFF
--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -312,9 +312,6 @@ pub fn encode_index_chunk(
     let doclens: Vec<i64> = embeddings.iter().map(|d| d.nrows() as i64).collect();
     let total_tokens: usize = doclens.iter().sum::<i64>() as usize;
 
-    #[cfg(not(feature = "_cuda"))]
-    let _ = force_cpu;
-
     let mut batch_embeddings = Array2::<f32>::zeros((total_tokens, embedding_dim));
     let mut offset = 0;
     for doc in embeddings {
@@ -325,7 +322,17 @@ pub fn encode_index_chunk(
         offset += n;
     }
 
-    let (batch_codes, batch_residuals) = {
+    let (batch_codes, batch_residuals) = if binary {
+        // Binary storage needs only centroid codes (for IVF); the packed store
+        // is the embeddings' sign bits, so computing residuals here would be
+        // O(tokens × dim) work thrown away (mirrors create_index_files).
+        let codes = if force_cpu {
+            codec.compress_into_codes_cpu(&batch_embeddings)
+        } else {
+            codec.compress_into_codes(&batch_embeddings)
+        };
+        (codes, Array2::<f32>::zeros((0, embedding_dim)))
+    } else {
         #[cfg(feature = "_cuda")]
         {
             let force_gpu = crate::is_force_gpu();

--- a/next-plaid/tests/binary_integration.rs
+++ b/next-plaid/tests/binary_integration.rs
@@ -203,3 +203,54 @@ fn binary_index_rejects_incremental_update() {
     let reloaded = MmapIndex::load(path).unwrap();
     assert!(reloaded.metadata.binary);
 }
+
+#[test]
+fn encode_index_chunk_binary_packs_signs_with_ivf_codes() {
+    // encode_index_chunk with `binary: true` must produce the same artifact as
+    // create_index_files' binary path: rows of packed sign bits (not residual
+    // codes) plus one centroid code per token for IVF. Guards the fast path
+    // that skips residual computation entirely in binary mode.
+    let dim = 64usize;
+    let docs = random_docs(10, 8, dim);
+    let centroids = next_plaid::compute_kmeans(
+        &docs,
+        &next_plaid::kmeans::ComputeKmeansConfig {
+            seed: 42,
+            num_partitions: Some(16),
+            force_cpu: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let artifacts = next_plaid::prepare_codec_artifacts(&docs, centroids, &config(true)).unwrap();
+
+    let chunk = next_plaid::encode_index_chunk(&docs, &artifacts.codec, true, true).unwrap();
+
+    let total_tokens: usize = docs.iter().map(|d| d.nrows()).sum();
+    assert_eq!(chunk.codes.len(), total_tokens);
+    assert_eq!(chunk.residuals.ncols(), binary::packed_dim(dim));
+    assert_eq!(chunk.residuals.nrows(), total_tokens);
+    assert_eq!(
+        chunk.doclens,
+        docs.iter().map(|d| d.nrows() as i64).collect::<Vec<_>>()
+    );
+
+    // The packed rows must be the embeddings' sign bits...
+    let mut flat = Array2::<f32>::zeros((total_tokens, dim));
+    let mut offset = 0;
+    for doc in &docs {
+        flat.slice_mut(ndarray::s![offset..offset + doc.nrows(), ..])
+            .assign(doc);
+        offset += doc.nrows();
+    }
+    assert_eq!(chunk.residuals, binary::binarize(&flat.view()));
+
+    // ...and the codes the nearest-centroid assignment the IVF is built from.
+    let want_codes: Vec<i64> = artifacts
+        .codec
+        .compress_into_codes_cpu(&flat)
+        .iter()
+        .map(|&c| c as i64)
+        .collect();
+    assert_eq!(chunk.codes.to_vec(), want_codes);
+}


### PR DESCRIPTION
## What

Follow-up from the #155 review: `encode_index_chunk` with `binary: true` still ran `compress_and_residuals_cpu` — a full `f32` clone of the batch plus a per-token centroid subtraction — and then discarded the residuals, since binary indexes store the embeddings' sign bits and never read residuals. `create_index_files` already had the right pattern; this mirrors it: in binary mode only the nearest-centroid codes (needed for the IVF) are computed.

This is colgrep's main indexing path for binary indexes, so every `colgrep settings --binary` build paid the cost.

## Measurements

2,000 docs × 32 tokens, dim 128 (64k tokens), release build, Apple silicon:

| | encode_index_chunk (binary) |
|---|---:|
| before | ~42.2 ms/chunk |
| after | ~38.7 ms/chunk (**~9% faster**) |

Also removes an O(tokens × dim) f32 allocation per chunk (~32 MB at this shape).

## Testing

- New regression test `encode_index_chunk_binary_packs_signs_with_ivf_codes`: the binary chunk must be exactly the embeddings' packed sign bits plus the nearest-centroid code per token — i.e. bit-identical to `create_index_files`' binary artifact.
- `cargo test -p next-plaid` (140 lib + 7 binary integration) and `cargo test -p colgrep` (672) pass; `cargo fmt --check` and `clippy --all-targets -- -D warnings` clean.

## Notes

No behavior change: output is bit-identical (`binarize` reads the raw embeddings, not the residuals). The CUDA fused compress+residuals path is untouched for residual indexes; in binary mode `compress_into_codes` handles GPU/CPU dispatch as it already does in `create_index_files`.