### PR TITLE
feat(colgrep): add bounded CUDA indexing controls

### DIFF
--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -70,6 +70,7 @@ colgrep init              # current directory
 colgrep init /path/to/project  # or a specific project
 colgrep init -y  # auto-confirm for large codebases (>10K code units)
 colgrep init --codec-gpu-memory-mb 256  # per-run CUDA codec working-memory budget
+colgrep init --pooling-threads 4  # per-run bound on dedicated document-pooling workers
 ```
 
 **Search:**
@@ -163,6 +164,7 @@ colgrep settings --no-hybrid-search
 |      | `--no-pool`         | Disable embedding pooling                |
 |      | `--pool-factor`     | Set pool factor (default: 2)             |
 |      | `--codec-gpu-memory-mb` | `init` only: per-run CUDA codec working-memory budget (MiB) |
+|      | `--pooling-threads` | `init` only: per-run bound on dedicated document-pooling workers |
 
 ### Filtering
 
@@ -321,6 +323,31 @@ compression; it is **not** a process-wide VRAM cap, is not persisted in index id
 does not affect query encoding. Omit it to preserve the existing 4 GiB CUDA default.
 The 256 MiB value was validated experimentally, but is not made the default. The value must
 be a positive integer and is converted to bytes with checked arithmetic.
+
+#### Dedicated pooling workers
+
+Use `colgrep init --pooling-threads <N>` to bound the dedicated Rayon workers that run
+hierarchical document-embedding pooling for that indexing run. The bound applies **only** to
+pooling: ONNX sessions, the tokenizer, the index codec, and the global Rayon pool are
+unaffected. The setting is per-run, is not persisted in index identity, and does not affect
+query encoding. Omit it to preserve the existing global-Rayon pooling behavior exactly.
+The value must be a positive integer no greater than the host's available parallelism.
+With pooling disabled (`--no-pool` / pool factor 1) no dedicated pool is built and the
+option is a harmless no-op.
+
+Measured in isolation on a full-corpus source-only index build with the validated
+256 MiB CUDA codec budget (default pooling vs. bounded pooling workers):
+
+| Run | Wall time | Host HWM |
+| --- | --- | --- |
+| default pooling | 60.89 s | 1,765.8 MiB |
+| `--pooling-threads 4` | 62.19 s | 1,643.9 MiB |
+| `--pooling-threads 2` | 67.87 s | 1,598.1 MiB |
+
+Both bounded runs retained the identical ordered top-10 results on 20/20 benchmark
+queries. `--pooling-threads 4` is the best balance between the small time cost and the
+memory saving, but the evidence comes from one machine and workload so far, so the
+control remains opt-in and is not the default.
 
 ### Binary Embedding Storage
 

--- a/colgrep/README.md
+++ b/colgrep/README.md
@@ -69,6 +69,7 @@ powershell -c "irm https://github.com/lightonai/next-plaid/releases/latest/downl
 colgrep init              # current directory
 colgrep init /path/to/project  # or a specific project
 colgrep init -y  # auto-confirm for large codebases (>10K code units)
+colgrep init --codec-gpu-memory-mb 256  # per-run CUDA codec working-memory budget
 ```
 
 **Search:**
@@ -161,6 +162,7 @@ colgrep settings --no-hybrid-search
 |      | `--model`           | Override ColBERT model                   |
 |      | `--no-pool`         | Disable embedding pooling                |
 |      | `--pool-factor`     | Set pool factor (default: 2)             |
+|      | `--codec-gpu-memory-mb` | `init` only: per-run CUDA codec working-memory budget (MiB) |
 
 ### Filtering
 
@@ -310,6 +312,15 @@ Default when unset (`--parallel 0`):
 On a CPU build, raising sessions speeds up cold indexing roughly linearly with cores at only
 a modest, bounded memory increase. On accelerator builds the trade-off is steeper, so the
 default stays at 1 — raise it explicitly with `--parallel` if you have the device memory.
+
+#### CUDA codec memory budget
+
+Use `colgrep init --codec-gpu-memory-mb <MIB>` to bound the CUDA codec's working-memory
+budget for that indexing run. This controls batch sizes for centroid-code and residual
+compression; it is **not** a process-wide VRAM cap, is not persisted in index identity, and
+does not affect query encoding. Omit it to preserve the existing 4 GiB CUDA default.
+The 256 MiB value was validated experimentally, but is not made the default. The value must
+be a positive integer and is converted to bytes with checked arithmetic.
 
 ### Binary Embedding Storage
 

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -159,6 +159,16 @@ fn parse_positive_codec_gpu_memory_mb(raw: &str) -> Result<u64, String> {
     Ok(mib)
 }
 
+fn parse_positive_pooling_threads(raw: &str) -> Result<usize, String> {
+    let threads = raw
+        .parse::<usize>()
+        .map_err(|_| "must be a positive integer number of threads".to_string())?;
+    if threads == 0 {
+        return Err("must be greater than zero threads".to_string());
+    }
+    Ok(threads)
+}
+
 pub const INIT_HELP: &str = "\
 EXAMPLES:
     # Build or update index for the current directory
@@ -182,6 +192,9 @@ EXAMPLES:
     # Bound CUDA codec working memory for this indexing run (not a VRAM cap)
     colgrep init --codec-gpu-memory-mb 256
 
+    # Bound dedicated document-pooling workers for this run (not ONNX/tokenizer/codec threads)
+    colgrep init --pooling-threads 4
+
     # Override outer index chunk size for benchmarking/tuning
     colgrep init --index-chunk-size 4096
 
@@ -195,6 +208,9 @@ NOTES:
     • --codec-gpu-memory-mb is a per-run CUDA codec working-memory budget, not a process-wide VRAM cap
     • Omit --codec-gpu-memory-mb to preserve the 4 GiB CUDA codec default
     • 256 MiB was validated experimentally, but is not the default
+    • --pooling-threads bounds only hierarchical document-embedding pooling workers for this run;
+      ONNX sessions, the tokenizer, the index codec, and the global Rayon pool are unaffected
+    • Omit --pooling-threads to preserve the default global-Rayon pooling behavior exactly
     • Useful for pre-warming the index before searching
     • Subsequent searches will be fast since the index is already built";
 
@@ -666,6 +682,14 @@ pub enum Commands {
         )]
         codec_gpu_memory_mb: Option<u64>,
 
+        /// Bound dedicated document-pooling workers for this indexing run (not ONNX/tokenizer/codec threads)
+        #[arg(
+            long = "pooling-threads",
+            value_name = "N",
+            value_parser = parse_positive_pooling_threads
+        )]
+        pooling_threads: Option<usize>,
+
         /// Use strict batch-size batching instead of fixed dynamic GPU batching
         #[arg(long = "static-batch")]
         static_batch: bool,
@@ -834,6 +858,46 @@ mod tests {
     #[test]
     fn codec_gpu_memory_cli_rejects_non_integer() {
         let error = Cli::try_parse_from(["colgrep", "init", "--codec-gpu-memory-mb", "1.5"])
+            .err()
+            .expect("non-integer should be rejected");
+        assert!(error.to_string().contains("positive integer"));
+    }
+
+    #[test]
+    fn pooling_threads_cli_defaults_to_none() {
+        let cli = Cli::try_parse_from(["colgrep", "init"]).unwrap();
+        let Some(Commands::Init {
+            pooling_threads, ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(pooling_threads, None);
+    }
+
+    #[test]
+    fn pooling_threads_cli_parses_positive() {
+        let cli = Cli::try_parse_from(["colgrep", "init", "--pooling-threads", "4"]).unwrap();
+        let Some(Commands::Init {
+            pooling_threads, ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(pooling_threads, Some(4));
+    }
+
+    #[test]
+    fn pooling_threads_cli_rejects_zero() {
+        let error = Cli::try_parse_from(["colgrep", "init", "--pooling-threads", "0"])
+            .err()
+            .expect("zero should be rejected");
+        assert!(error.to_string().contains("greater than zero"));
+    }
+
+    #[test]
+    fn pooling_threads_cli_rejects_non_integer() {
+        let error = Cli::try_parse_from(["colgrep", "init", "--pooling-threads", "2.5"])
             .err()
             .expect("non-integer should be rejected");
         assert!(error.to_string().contains("positive integer"));

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -149,6 +149,16 @@ NOTES:
     • Model preference is stored in ~/.config/colgrep/config.json
     • Use 'colgrep settings' to view the current model";
 
+fn parse_positive_codec_gpu_memory_mb(raw: &str) -> Result<u64, String> {
+    let mib = raw
+        .parse::<u64>()
+        .map_err(|_| "must be a positive integer number of MiB".to_string())?;
+    if mib == 0 {
+        return Err("must be greater than zero MiB".to_string());
+    }
+    Ok(mib)
+}
+
 pub const INIT_HELP: &str = "\
 EXAMPLES:
     # Build or update index for the current directory
@@ -169,6 +179,9 @@ EXAMPLES:
     # Override outer encoding batch size for benchmarking/tuning
     colgrep init --encode-batch-size 1024
 
+    # Bound CUDA codec working memory for this indexing run (not a VRAM cap)
+    colgrep init --codec-gpu-memory-mb 256
+
     # Override outer index chunk size for benchmarking/tuning
     colgrep init --index-chunk-size 4096
 
@@ -179,6 +192,9 @@ EXAMPLES:
 NOTES:
     • Creates a new index if none exists
     • Incrementally updates the index if files changed
+    • --codec-gpu-memory-mb is a per-run CUDA codec working-memory budget, not a process-wide VRAM cap
+    • Omit --codec-gpu-memory-mb to preserve the 4 GiB CUDA codec default
+    • 256 MiB was validated experimentally, but is not the default
     • Useful for pre-warming the index before searching
     • Subsequent searches will be fast since the index is already built";
 
@@ -642,6 +658,14 @@ pub enum Commands {
         #[arg(long = "index-chunk-size", value_name = "SIZE")]
         index_chunk_size: Option<usize>,
 
+        /// Bound CUDA codec working memory for this indexing run (MiB; not a process-wide VRAM cap)
+        #[arg(
+            long = "codec-gpu-memory-mb",
+            value_name = "MIB",
+            value_parser = parse_positive_codec_gpu_memory_mb
+        )]
+        codec_gpu_memory_mb: Option<u64>,
+
         /// Use strict batch-size batching instead of fixed dynamic GPU batching
         #[arg(long = "static-batch")]
         static_batch: bool,
@@ -766,4 +790,52 @@ pub enum Commands {
         #[arg(long = "clear-force-include")]
         clear_force_include: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn codec_gpu_memory_cli_defaults_to_none() {
+        let cli = Cli::try_parse_from(["colgrep", "init"]).unwrap();
+        let Some(Commands::Init {
+            codec_gpu_memory_mb,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(codec_gpu_memory_mb, None);
+    }
+
+    #[test]
+    fn codec_gpu_memory_cli_parses_positive_mib() {
+        let cli = Cli::try_parse_from(["colgrep", "init", "--codec-gpu-memory-mb", "256"]).unwrap();
+        let Some(Commands::Init {
+            codec_gpu_memory_mb,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(codec_gpu_memory_mb, Some(256));
+    }
+
+    #[test]
+    fn codec_gpu_memory_cli_rejects_zero() {
+        let error = Cli::try_parse_from(["colgrep", "init", "--codec-gpu-memory-mb", "0"])
+            .err()
+            .expect("zero should be rejected");
+        assert!(error.to_string().contains("greater than zero"));
+    }
+
+    #[test]
+    fn codec_gpu_memory_cli_rejects_non_integer() {
+        let error = Cli::try_parse_from(["colgrep", "init", "--codec-gpu-memory-mb", "1.5"])
+            .err()
+            .expect("non-integer should be rejected");
+        assert!(error.to_string().contains("positive integer"));
+    }
 }

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -13,7 +13,33 @@ pub struct InitOptions<'a> {
     pub batch_size: Option<usize>,
     pub encode_batch_size: Option<usize>,
     pub index_chunk_size: Option<usize>,
+    pub codec_gpu_memory_mb: Option<u64>,
     pub static_batch: bool,
+}
+
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+
+fn codec_gpu_memory_budget_bytes(codec_gpu_memory_mb: Option<u64>) -> Result<Option<usize>> {
+    let Some(mib) = codec_gpu_memory_mb else {
+        return Ok(None);
+    };
+    if mib == 0 {
+        anyhow::bail!("--codec-gpu-memory-mb must be greater than zero MiB");
+    }
+    let bytes = mib.checked_mul(BYTES_PER_MIB).ok_or_else(|| {
+        anyhow::anyhow!(
+            "--codec-gpu-memory-mb={} is too large: MiB-to-byte conversion overflowed",
+            mib
+        )
+    })?;
+    let bytes = usize::try_from(bytes).map_err(|_| {
+        anyhow::anyhow!(
+            "--codec-gpu-memory-mb={} is too large: {} bytes cannot be represented on this platform",
+            mib,
+            bytes
+        )
+    })?;
+    Ok(Some(bytes))
 }
 
 fn resolve_index_runtime_overrides(
@@ -39,6 +65,7 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let config = Config::load().unwrap_or_default();
     let model = resolve_model(&config, options.cli_model);
     let pool_factor = resolve_pool_factor(&config, options.pool_factor, options.no_pool);
+    let codec_gpu_memory_budget_bytes = codec_gpu_memory_budget_bytes(options.codec_gpu_memory_mb)?;
 
     let quantized = !config.use_fp32();
     let (parallel_sessions, batch_size) =
@@ -68,6 +95,9 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     )?;
     builder.set_auto_confirm(options.auto_confirm);
     builder.set_dynamic_batch(!options.static_batch);
+    if let Some(codec_gpu_memory_budget_bytes) = codec_gpu_memory_budget_bytes {
+        builder.set_codec_gpu_memory_budget_bytes(codec_gpu_memory_budget_bytes)?;
+    }
     if let Some(encode_batch_size) = options.encode_batch_size {
         builder.set_encode_batch_size(encode_batch_size.max(1));
     }
@@ -112,6 +142,7 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn test_resolve_index_runtime_overrides_preserves_explicit_values() {
@@ -149,5 +180,50 @@ mod tests {
 
         assert_eq!(parallel_sessions, Some(1));
         assert_eq!(batch_size, Some(1));
+    }
+
+    #[test]
+    fn test_codec_gpu_memory_budget_bytes_defaults_to_none() {
+        assert_eq!(codec_gpu_memory_budget_bytes(None).unwrap(), None);
+    }
+
+    #[test]
+    fn test_codec_gpu_memory_budget_bytes_converts_checked_mib() {
+        assert_eq!(
+            codec_gpu_memory_budget_bytes(Some(256)).unwrap(),
+            Some(256 * 1024 * 1024)
+        );
+        let error = codec_gpu_memory_budget_bytes(Some(u64::MAX))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("conversion overflowed"));
+    }
+
+    #[test]
+    fn test_codec_gpu_memory_cli_max_u64_is_rejected_by_checked_conversion() {
+        let cli = crate::cli::Cli::try_parse_from([
+            "colgrep",
+            "init",
+            "--codec-gpu-memory-mb",
+            &u64::MAX.to_string(),
+        ])
+        .unwrap();
+        let Some(crate::cli::Commands::Init {
+            codec_gpu_memory_mb,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(codec_gpu_memory_mb, Some(u64::MAX));
+        assert!(codec_gpu_memory_budget_bytes(codec_gpu_memory_mb).is_err());
+    }
+
+    #[test]
+    fn test_codec_gpu_memory_budget_bytes_rejects_zero() {
+        let error = codec_gpu_memory_budget_bytes(Some(0))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("greater than zero"));
     }
 }

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -14,6 +14,7 @@ pub struct InitOptions<'a> {
     pub encode_batch_size: Option<usize>,
     pub index_chunk_size: Option<usize>,
     pub codec_gpu_memory_mb: Option<u64>,
+    pub pooling_threads: Option<usize>,
     pub static_batch: bool,
 }
 
@@ -97,6 +98,9 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     builder.set_dynamic_batch(!options.static_batch);
     if let Some(codec_gpu_memory_budget_bytes) = codec_gpu_memory_budget_bytes {
         builder.set_codec_gpu_memory_budget_bytes(codec_gpu_memory_budget_bytes)?;
+    }
+    if let Some(pooling_threads) = options.pooling_threads {
+        builder.set_pooling_threads(pooling_threads)?;
     }
     if let Some(encode_batch_size) = options.encode_batch_size {
         builder.set_encode_batch_size(encode_batch_size.max(1));

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -456,6 +456,9 @@ struct ChunkPipelineConfig<'a> {
     update_config: UpdateConfig,
     /// Transient CUDA codec budget; deliberately kept outside next-plaid's public configs.
     codec_gpu_memory_budget_bytes: Option<usize>,
+    /// Dedicated Rayon workers for the pooling stage only; `None` keeps the
+    /// existing global-Rayon behavior exactly.
+    pooling_threads: Option<usize>,
     pb: Option<&'a ProgressBar>,
 }
 
@@ -600,16 +603,82 @@ fn run_tokenize_stage(
     Ok(())
 }
 
+/// Host upper bound for dedicated pooling workers: the available parallelism.
+/// Values above this would oversubscribe the machine.
+fn max_pooling_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(1)
+}
+
+/// Validate a dedicated pooling worker count. Zero and values above the
+/// host's available parallelism are rejected with a clear error.
+fn validate_pooling_threads(threads: usize) -> Result<usize> {
+    let max = max_pooling_threads();
+    if threads == 0 {
+        anyhow::bail!("pooling threads must be greater than zero");
+    }
+    if threads > max {
+        anyhow::bail!("pooling threads ({threads}) exceeds available parallelism ({max})");
+    }
+    Ok(threads)
+}
+
+/// Dedicated pooling only helps when pooling actually runs in parallel:
+/// pool factor `None`/`1` (`--no-pool`) is a passthrough, so it selects no
+/// dedicated pool and an explicit `pooling_threads` is a harmless no-op there.
+fn dedicated_pooling_threads(
+    pool_factor: Option<usize>,
+    pooling_threads: Option<usize>,
+) -> Option<usize> {
+    match (pool_factor, pooling_threads) {
+        (Some(factor), Some(threads)) if factor > 1 => Some(threads),
+        _ => None,
+    }
+}
+
+/// Build the dedicated Rayon pool for one pooling-stage run.
+///
+/// Only hierarchical document-embedding pooling (`pool_document_embeddings`)
+/// runs on these workers: ONNX sessions, the tokenizer, the index codec, and
+/// the global Rayon pool keep their existing threading. Construction errors
+/// propagate so the pipeline reports a genuine stage failure.
+fn build_pooling_thread_pool(threads: usize) -> Result<rayon::ThreadPool> {
+    // Defensive re-validation: callers normally go through the setter, but an
+    // invalid count must never reach the Rayon builder.
+    let threads = validate_pooling_threads(threads)?;
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .thread_name(|idx| format!("colgrep-pooling-{idx}"))
+        .build()
+        .context("Failed to build dedicated pooling thread pool")
+}
+
 /// Pool raw token-level embeddings into document-level vectors, then expand
 /// deduplicated embeddings back to the full set. After this stage every
 /// original code unit has its own embedding copy ready for index insertion.
+///
+/// When `pooling_threads` is set and pooling actually runs (pool factor > 1),
+/// one dedicated pool is built before the receive loop and each chunk's
+/// pooling is scoped to it via `pool.install`; otherwise pooling runs on the
+/// global Rayon pool exactly as before and no pooling workers are spawned.
 fn run_pool_stage(
     receiver: mpsc::Receiver<RawEncodedChunk>,
     sender: mpsc::SyncSender<PooledChunkForIndex>,
     pool_factor: Option<usize>,
+    pooling_threads: Option<usize>,
 ) -> Result<()> {
+    let pooling_pool = match dedicated_pooling_threads(pool_factor, pooling_threads) {
+        Some(threads) => Some(build_pooling_thread_pool(threads)?),
+        None => None,
+    };
     while let Ok(chunk) = receiver.recv() {
-        let pooled_unique = pool_document_embeddings(chunk.raw_embeddings, pool_factor);
+        let pooled_unique = match pooling_pool.as_ref() {
+            Some(pool) => {
+                pool.install(|| pool_document_embeddings(chunk.raw_embeddings, pool_factor))
+            }
+            None => pool_document_embeddings(chunk.raw_embeddings, pool_factor),
+        };
         // Expand: map each original unit back to its deduplicated embedding.
         let embeddings = chunk
             .original_to_unique
@@ -954,6 +1023,7 @@ fn run_chunk_pipeline(
         config,
         update_config,
         codec_gpu_memory_budget_bytes,
+        pooling_threads,
         pb,
     } = pipeline;
 
@@ -977,7 +1047,7 @@ fn run_chunk_pipeline(
         .context("Failed to spawn encode stage thread")?;
     let pool_handle = thread::Builder::new()
         .name("colgrep-pool".to_string())
-        .spawn(move || run_pool_stage(pool_rx, index_tx, pool_factor))
+        .spawn(move || run_pool_stage(pool_rx, index_tx, pool_factor, pooling_threads))
         .context("Failed to spawn pool stage thread")?;
     let index_path_for_index = index_path.to_string();
     let index_handle = thread::Builder::new()
@@ -1211,6 +1281,11 @@ pub struct IndexBuilder {
     /// Optional per-operation CUDA codec working-memory budget in bytes.
     /// This is not persisted and does not affect query encoding.
     codec_gpu_memory_budget_bytes: Option<usize>,
+    /// Optional dedicated Rayon worker count for the hierarchical
+    /// document-embedding pooling stage. This is not persisted, does not
+    /// affect index identity, and leaves ONNX sessions, the tokenizer, the
+    /// index codec, and the global Rayon pool untouched.
+    pooling_threads: Option<usize>,
 }
 
 impl IndexBuilder {
@@ -1266,6 +1341,7 @@ impl IndexBuilder {
                 .unwrap_or_default()
                 .use_binary(),
             codec_gpu_memory_budget_bytes: None,
+            pooling_threads: None,
         })
     }
 
@@ -1296,6 +1372,19 @@ impl IndexBuilder {
             anyhow::bail!("CUDA codec memory budget must be greater than zero");
         }
         self.codec_gpu_memory_budget_bytes = Some(budget_bytes);
+        Ok(())
+    }
+
+    /// Set a dedicated Rayon worker count for the hierarchical
+    /// document-embedding pooling stage during indexing.
+    ///
+    /// Only pooling workers are bounded: ONNX sessions, the tokenizer, the
+    /// index codec, and the global Rayon pool are unaffected. This is not
+    /// persisted in index identity and does not affect query encoding. Zero
+    /// and values above the host's available parallelism are rejected; leave
+    /// unset to preserve the default global-Rayon behavior exactly.
+    pub fn set_pooling_threads(&mut self, threads: usize) -> Result<()> {
+        self.pooling_threads = Some(validate_pooling_threads(threads)?);
         Ok(())
     }
 
@@ -1542,6 +1631,7 @@ impl IndexBuilder {
                 config,
                 update_config,
                 codec_gpu_memory_budget_bytes: self.codec_gpu_memory_budget_bytes,
+                pooling_threads: self.pooling_threads,
                 pb,
             },
         );
@@ -1594,6 +1684,7 @@ impl IndexBuilder {
                         config,
                         update_config,
                         codec_gpu_memory_budget_bytes: self.codec_gpu_memory_budget_bytes,
+                        pooling_threads: self.pooling_threads,
                         pb,
                     },
                 );
@@ -5766,6 +5857,7 @@ mod tests {
             model_id: "test-model".to_string(),
             binary: false,
             codec_gpu_memory_budget_bytes: None,
+            pooling_threads: None,
         }
     }
 
@@ -5789,6 +5881,161 @@ mod tests {
             builder.codec_gpu_memory_budget_bytes,
             Some(256 * 1024 * 1024)
         );
+    }
+
+    #[test]
+    fn test_pooling_threads_setter_is_per_builder_and_enforces_bounds() {
+        let project_dir = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        let mut builder = test_builder(project_dir.path(), index_dir.path());
+        let max = max_pooling_threads();
+
+        assert_eq!(builder.pooling_threads, None);
+        let in_range = 4.min(max);
+        builder.set_pooling_threads(in_range).unwrap();
+        assert_eq!(builder.pooling_threads, Some(in_range));
+
+        let error = builder.set_pooling_threads(0).unwrap_err();
+        assert!(error.to_string().contains("greater than zero"));
+        assert_eq!(builder.pooling_threads, Some(in_range));
+
+        let error = builder.set_pooling_threads(max + 1).unwrap_err();
+        assert!(error.to_string().contains("exceeds available parallelism"));
+        assert_eq!(builder.pooling_threads, Some(in_range));
+    }
+
+    /// Bounds are deterministic relative to the host: zero and
+    /// `available_parallelism + 1` are rejected while positive in-range
+    /// values are preserved, including through the defensive builder path.
+    #[test]
+    fn validate_pooling_threads_bounds() {
+        let max = max_pooling_threads();
+
+        let error = validate_pooling_threads(0).unwrap_err();
+        assert!(error.to_string().contains("greater than zero"));
+
+        let error = validate_pooling_threads(max + 1).unwrap_err();
+        assert!(error.to_string().contains("exceeds available parallelism"));
+        let error = build_pooling_thread_pool(max + 1).unwrap_err();
+        assert!(error.to_string().contains("exceeds available parallelism"));
+
+        assert_eq!(validate_pooling_threads(1).unwrap(), 1);
+        assert_eq!(validate_pooling_threads(max).unwrap(), max);
+    }
+
+    /// Pool factors None/1 are a passthrough: they select no dedicated pool,
+    /// so no pooling workers are spawned even when a bound was requested.
+    #[test]
+    fn dedicated_pool_selected_only_for_parallel_pool_factors() {
+        assert_eq!(dedicated_pooling_threads(None, Some(4)), None);
+        assert_eq!(dedicated_pooling_threads(Some(1), Some(4)), None);
+        assert_eq!(dedicated_pooling_threads(None, None), None);
+        assert_eq!(dedicated_pooling_threads(Some(2), None), None);
+        assert_eq!(dedicated_pooling_threads(Some(2), Some(4)), Some(4));
+    }
+
+    /// Deterministic raw chunk for pool-stage tests: fixed embeddings with a
+    /// 1:1 original-to-unique mapping (no dedup).
+    fn pool_stage_chunk(seed: usize, docs: usize, tokens: usize, dim: usize) -> RawEncodedChunk {
+        let units: Vec<Arc<CodeUnit>> = (0..docs)
+            .map(|i| {
+                Arc::new(CodeUnit::new(
+                    format!("unit-{seed}-{i}"),
+                    PathBuf::from(format!("file-{seed}.rs")),
+                    i + 1,
+                    i + 1,
+                    Language::Rust,
+                    crate::parser::UnitType::Function,
+                    None,
+                ))
+            })
+            .collect();
+        let raw_embeddings = (0..docs)
+            .map(|i| {
+                ndarray::Array2::from_shape_fn((tokens, dim), |(r, c)| {
+                    ((seed * 977 + i * 131 + r * 17 + c) % 89) as f32 / 89.0
+                })
+            })
+            .collect();
+        RawEncodedChunk {
+            units,
+            raw_embeddings,
+            original_to_unique: (0..docs).collect(),
+        }
+    }
+
+    /// Run the real pool stage over `chunks` and collect every output in order.
+    fn collect_pool_stage_outputs(
+        chunks: Vec<RawEncodedChunk>,
+        pool_factor: Option<usize>,
+        pooling_threads: Option<usize>,
+    ) -> Vec<PooledChunkForIndex> {
+        let capacity = chunks.len().max(1);
+        let (input_tx, input_rx) = mpsc::channel();
+        let (output_tx, output_rx) = mpsc::sync_channel(capacity);
+        for chunk in chunks {
+            input_tx.send(chunk).unwrap();
+        }
+        drop(input_tx);
+        run_pool_stage(input_rx, output_tx, pool_factor, pooling_threads).unwrap();
+        output_rx.into_iter().collect()
+    }
+
+    /// Bitwise embedding and ordering equality between two pool-stage runs.
+    fn assert_pool_outputs_identical(
+        expected: &[PooledChunkForIndex],
+        actual: &[PooledChunkForIndex],
+    ) {
+        assert_eq!(expected.len(), actual.len(), "chunk count differs");
+        for (expected_chunk, actual_chunk) in expected.iter().zip(actual.iter()) {
+            let expected_names: Vec<&str> = expected_chunk
+                .units
+                .iter()
+                .map(|unit| unit.name.as_str())
+                .collect();
+            let actual_names: Vec<&str> = actual_chunk
+                .units
+                .iter()
+                .map(|unit| unit.name.as_str())
+                .collect();
+            assert_eq!(expected_names, actual_names, "unit ordering differs");
+            assert_eq!(
+                expected_chunk.embeddings.len(),
+                actual_chunk.embeddings.len(),
+                "embedding count differs"
+            );
+            for (expected_emb, actual_emb) in expected_chunk
+                .embeddings
+                .iter()
+                .zip(actual_chunk.embeddings.iter())
+            {
+                assert_eq!(expected_emb.dim(), actual_emb.dim());
+                for (a, b) in expected_emb.iter().zip(actual_emb.iter()) {
+                    assert_eq!(a.to_bits(), b.to_bits(), "embedding values differ");
+                }
+            }
+        }
+    }
+
+    /// For pool factors None, 1, and 2, the dedicated-pool stage must produce
+    /// bitwise-identical embeddings in the same order as the default
+    /// global-Rayon stage.
+    #[test]
+    fn pool_stage_dedicated_pool_output_matches_default_for_all_pool_factors() {
+        let threads = 2.min(max_pooling_threads());
+        for pool_factor in [None, Some(1), Some(2)] {
+            let chunks = || {
+                vec![
+                    pool_stage_chunk(1, 6, 12, 8),
+                    pool_stage_chunk(2, 5, 9, 8),
+                    pool_stage_chunk(3, 7, 16, 8),
+                ]
+            };
+            let default_outputs = collect_pool_stage_outputs(chunks(), pool_factor, None);
+            let dedicated_outputs =
+                collect_pool_stage_outputs(chunks(), pool_factor, Some(threads));
+            assert_pool_outputs_identical(&default_outputs, &dedicated_outputs);
+        }
     }
 
     /// Build a small vector index + filtering DB at `index_path`, distributing `n` documents

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -13,7 +13,8 @@ use ignore::gitignore::GitignoreBuilder;
 use ignore::WalkBuilder;
 use indicatif::{ProgressBar, ProgressStyle};
 use next_plaid::{
-    delete_from_index, encode_index_chunk, filtering, prepare_codec_artifacts,
+    delete_from_index, encode_index_chunk_with_gpu_memory_budget, filtering,
+    preflight_codec_gpu_memory_budget, prepare_codec_artifacts_with_gpu_memory_budget,
     write_index_from_encoded_chunks, EncodedIndexChunk, IndexConfig, Metadata, MmapIndex,
     SearchParameters, UpdateConfig,
 };
@@ -245,6 +246,15 @@ const LARGE_BATCH_POOL_FACTOR: usize = 2;
 
 const DEFAULT_ENCODE_BATCH_SIZE: usize = 64;
 
+#[cfg(feature = "_cuda")]
+fn contains_codec_config_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<next_plaid::Error>()
+            .is_some_and(|error| matches!(error, next_plaid::Error::Config(_)))
+    })
+}
+
 /// Threshold for forcing CPU encoding even when CUDA is available.
 /// For small batches (< this many units), CPU is faster due to GPU initialization overhead.
 #[cfg(feature = "_cuda")]
@@ -444,6 +454,8 @@ struct ChunkPipelineConfig<'a> {
     index_path: &'a str,
     config: IndexConfig,
     update_config: UpdateConfig,
+    /// Transient CUDA codec budget; deliberately kept outside next-plaid's public configs.
+    codec_gpu_memory_budget_bytes: Option<usize>,
     pb: Option<&'a ProgressBar>,
 }
 
@@ -623,13 +635,14 @@ fn run_pool_stage(
 ///   While k-means runs, subsequent chunks are buffered in a coding channel. Once centroids
 ///   are ready, all chunks are compressed and written in one batch — producing a single
 ///   contiguous index file rather than incremental updates.
-/// - **Update**: Each chunk is appended to the existing index via `update_or_create`.
+/// - **Update**: Each chunk is appended to the existing index via `update_append`.
 fn run_index_stage(
     receiver: mpsc::Receiver<PooledChunkForIndex>,
     sender: mpsc::SyncSender<IndexedChunkForMetadata>,
     index_path: String,
     config: IndexConfig,
     update_config: UpdateConfig,
+    codec_gpu_memory_budget_bytes: Option<usize>,
     initial_kmeans_sample_docs: usize,
 ) -> Result<()> {
     let initial_create = !Path::new(&index_path).join("metadata.json").exists();
@@ -646,6 +659,14 @@ fn run_index_stage(
         if initial_create_config.n_samples_kmeans.is_none() {
             initial_create_config.n_samples_kmeans = Some(initial_kmeans_sample_docs.max(1));
         }
+
+        // Validate the codec shape before any index or metadata stage side effects.
+        preflight_codec_gpu_memory_budget(
+            &first_chunk.embeddings,
+            initial_create_config.force_cpu,
+            initial_create_config.binary,
+            codec_gpu_memory_budget_bytes,
+        )?;
 
         // Spawn k-means in a background thread so encoding can continue in parallel.
         // The coding thread blocks on the k-means result before compressing any chunks.
@@ -665,10 +686,11 @@ fn run_index_stage(
                         force_cpu: kmeans_config.force_cpu,
                     },
                 )?;
-                Ok(prepare_codec_artifacts(
+                Ok(prepare_codec_artifacts_with_gpu_memory_budget(
                     &sample_embeddings,
                     centroids,
                     &kmeans_config,
+                    codec_gpu_memory_budget_bytes,
                 )?)
             })
             .context("Failed to spawn kmeans stage thread")?;
@@ -689,11 +711,12 @@ fn run_index_stage(
                     .map_err(|_| anyhow::anyhow!("K-means stage thread panicked"))??;
                 let mut encoded_chunks: Vec<EncodedIndexChunk> = Vec::new();
                 while let Ok(chunk) = dedup_rx.recv() {
-                    let encoded = encode_index_chunk(
+                    let encoded = encode_index_chunk_with_gpu_memory_budget(
                         &chunk.embeddings,
                         &codec_artifacts.codec,
                         coding_force_cpu,
                         coding_config.binary,
+                        codec_gpu_memory_budget_bytes,
                     )?;
                     encoded_chunks.push(encoded);
                 }
@@ -758,8 +781,8 @@ fn run_index_stage(
                 &mut pending_embeddings,
                 &sender,
                 &index_path,
-                &config,
                 &update_config,
+                codec_gpu_memory_budget_bytes,
             )?;
         }
     }
@@ -769,8 +792,8 @@ fn run_index_stage(
         &mut pending_embeddings,
         &sender,
         &index_path,
-        &config,
         &update_config,
+        codec_gpu_memory_budget_bytes,
     )?;
 
     Ok(())
@@ -783,21 +806,23 @@ fn flush_update_batch(
     embeddings: &mut Vec<ndarray::Array2<f32>>,
     sender: &mpsc::SyncSender<IndexedChunkForMetadata>,
     index_path: &str,
-    config: &IndexConfig,
     update_config: &UpdateConfig,
+    codec_gpu_memory_budget_bytes: Option<usize>,
 ) -> Result<()> {
     if embeddings.is_empty() {
         return Ok(());
     }
 
     let _guard = CriticalSectionGuard::new();
-    let index_exists = Path::new(index_path).join("metadata.json").exists();
-    let doc_ids = if index_exists {
-        MmapIndex::update_append(embeddings, index_path, update_config)?
-    } else {
-        let (_, ids) = MmapIndex::update_or_create(embeddings, index_path, config, update_config)?;
-        ids
-    };
+    if !Path::new(index_path).join("metadata.json").exists() {
+        anyhow::bail!("Existing index metadata disappeared during update");
+    }
+    let doc_ids = MmapIndex::update_append_with_gpu_memory_budget(
+        embeddings,
+        index_path,
+        update_config,
+        codec_gpu_memory_budget_bytes,
+    )?;
     embeddings.clear();
 
     sender
@@ -928,6 +953,7 @@ fn run_chunk_pipeline(
         index_path,
         config,
         update_config,
+        codec_gpu_memory_budget_bytes,
         pb,
     } = pipeline;
 
@@ -963,6 +989,7 @@ fn run_chunk_pipeline(
                 index_path_for_index,
                 config,
                 update_config,
+                codec_gpu_memory_budget_bytes,
                 index_chunk_size,
             )
         })
@@ -974,6 +1001,7 @@ fn run_chunk_pipeline(
         .spawn(move || run_metadata_stage(metadata_rx, index_path_for_metadata, metadata_pb))
         .context("Failed to spawn metadata stage thread")?;
 
+    let mut producer_send: Result<()> = Ok(());
     for unit_chunk in sorted_units.chunks(index_chunk_size) {
         if is_interrupted_outside_critical() {
             was_interrupted = true;
@@ -982,9 +1010,16 @@ fn run_chunk_pipeline(
 
         let prepared = prepare_deduplicated_chunk(unit_chunk);
 
-        tokenize_tx
+        if let Err(error) = tokenize_tx
             .send(prepared)
-            .context("Failed to send prepared chunk to tokenize stage")?;
+            .context("Failed to send prepared chunk to tokenize stage")
+        {
+            // The tokenize stage is gone, so feeding must stop — but do not
+            // return early: every spawned stage is joined below so the genuine
+            // downstream failure is not masked by this closed-channel cascade.
+            producer_send = Err(error);
+            break;
+        }
     }
 
     // Signal pipeline shutdown: dropping the sender closes the channel,
@@ -992,23 +1027,83 @@ fn run_chunk_pipeline(
     // all downstream stages.
     drop(tokenize_tx);
 
-    tokenize_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Tokenize stage thread panicked"))??;
-    encode_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Encode stage thread panicked"))??;
-    pool_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Pool stage thread panicked"))??;
-    index_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Index stage thread panicked"))??;
-    metadata_handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("Metadata stage thread panicked"))??;
+    teardown_chunk_pipeline(
+        producer_send,
+        ChunkPipelineHandles {
+            tokenize: tokenize_handle,
+            encode: encode_handle,
+            pool: pool_handle,
+            index: index_handle,
+            metadata: metadata_handle,
+        },
+    )?;
 
     Ok(was_interrupted)
+}
+
+/// Handles for the five spawned chunk-pipeline stage threads.
+struct ChunkPipelineHandles {
+    tokenize: thread::JoinHandle<Result<()>>,
+    encode: thread::JoinHandle<Result<()>>,
+    pool: thread::JoinHandle<Result<()>>,
+    index: thread::JoinHandle<Result<()>>,
+    metadata: thread::JoinHandle<Result<()>>,
+}
+
+/// Join every pipeline stage exactly once, then resolve the outcome into a
+/// single result. Runs even when the producer send loop failed, so no stage
+/// thread is ever detached mid-pipeline.
+fn teardown_chunk_pipeline(producer_send: Result<()>, handles: ChunkPipelineHandles) -> Result<()> {
+    let stages = [
+        ("Tokenize", handles.tokenize),
+        ("Encode", handles.encode),
+        ("Pool", handles.pool),
+        ("Index", handles.index),
+        ("Metadata", handles.metadata),
+    ];
+    let joined: Vec<(&'static str, thread::Result<Result<()>>)> = stages
+        .into_iter()
+        .map(|(name, handle)| (name, handle.join()))
+        .collect();
+    resolve_pipeline_results(producer_send, joined)
+}
+
+/// Select which pipeline failure to return once every stage has been joined.
+///
+/// Stage failures cascade: when a stage returns, its input channel closes, so
+/// every upstream stage (and the producer send loop) typically fails with a
+/// generic closed-channel error. The genuine root cause is therefore the most
+/// downstream failing stage — an index-stage `next_plaid::Error::Config` must
+/// never be replaced by an upstream "failed to send" cascade. Panics are bugs
+/// rather than cascades, so they keep their dedicated diagnostics and are
+/// always reported first, in stage order.
+fn resolve_pipeline_results(
+    producer_send: Result<()>,
+    stages: Vec<(&'static str, thread::Result<Result<()>>)>,
+) -> Result<()> {
+    let mut first_panic: Option<anyhow::Error> = None;
+    let mut stage_results: Vec<Result<()>> = Vec::with_capacity(stages.len());
+    for (name, joined) in stages {
+        match joined {
+            Ok(result) => stage_results.push(result),
+            Err(_) => {
+                let panic = anyhow::anyhow!("{} stage thread panicked", name);
+                if first_panic.is_none() {
+                    first_panic = Some(panic);
+                }
+            }
+        }
+    }
+    if let Some(panic) = first_panic {
+        return Err(panic);
+    }
+
+    // Most-downstream failure wins: upstream stages and the producer only
+    // observe the closed-channel cascade from the stage that actually failed.
+    for result in stage_results.into_iter().rev() {
+        result?;
+    }
+    producer_send
 }
 
 fn parse_files_parallel(
@@ -1113,6 +1208,9 @@ pub struct IndexBuilder {
     /// codes (persisted `colgrep settings --binary`). Binary indexes cannot
     /// take incremental appends, so file changes trigger a full re-embed.
     binary: bool,
+    /// Optional per-operation CUDA codec working-memory budget in bytes.
+    /// This is not persisted and does not affect query encoding.
+    codec_gpu_memory_budget_bytes: Option<usize>,
 }
 
 impl IndexBuilder {
@@ -1167,6 +1265,7 @@ impl IndexBuilder {
             binary: crate::config::Config::load()
                 .unwrap_or_default()
                 .use_binary(),
+            codec_gpu_memory_budget_bytes: None,
         })
     }
 
@@ -1185,6 +1284,19 @@ impl IndexBuilder {
 
     pub fn set_dynamic_batch(&mut self, dynamic_batch: bool) {
         self.dynamic_batch = dynamic_batch;
+    }
+
+    /// Set an explicit per-operation CUDA codec working-memory budget in bytes.
+    ///
+    /// This budget controls indexing compression batch sizes only. It is not a
+    /// process-wide VRAM cap, is not persisted in index identity, and does not
+    /// affect query encoding. A value of zero is rejected.
+    pub fn set_codec_gpu_memory_budget_bytes(&mut self, budget_bytes: usize) -> Result<()> {
+        if budget_bytes == 0 {
+            anyhow::bail!("CUDA codec memory budget must be greater than zero");
+        }
+        self.codec_gpu_memory_budget_bytes = Some(budget_bytes);
+        Ok(())
     }
 
     /// Default session count for an encoding workload of `num_units` units.
@@ -1429,12 +1541,17 @@ impl IndexBuilder {
                 index_path,
                 config,
                 update_config,
+                codec_gpu_memory_budget_bytes: self.codec_gpu_memory_budget_bytes,
                 pb,
             },
         );
 
         #[cfg(feature = "_cuda")]
         if let Err(gpu_err) = result {
+            if contains_codec_config_error(&gpu_err) {
+                return Err(gpu_err);
+            }
+
             if self.is_using_gpu() {
                 let accel = env_acceleration_mode_lossy();
                 if accel == AccelerationMode::ForceGpu {
@@ -1476,6 +1593,7 @@ impl IndexBuilder {
                         index_path,
                         config,
                         update_config,
+                        codec_gpu_memory_budget_bytes: self.codec_gpu_memory_budget_bytes,
                         pb,
                     },
                 );
@@ -4597,6 +4715,213 @@ fn prompt_large_index_confirmation(num_units: usize) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "_cuda")]
+    #[test]
+    fn codec_config_errors_are_found_through_anyhow_chain() {
+        let error = anyhow::Error::new(next_plaid::Error::Config("invalid budget".into()))
+            .context("index pipeline failed");
+        assert!(contains_codec_config_error(&error));
+    }
+
+    #[cfg(feature = "_cuda")]
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn initial_codec_budget_fails_before_metadata_message() {
+        use ndarray::Array2;
+        use std::sync::mpsc::TryRecvError;
+
+        next_plaid::cuda::get_global_context().expect("requires an available CUDA device");
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let (input_tx, input_rx) = mpsc::channel();
+        let (metadata_tx, metadata_rx) = mpsc::sync_channel(1);
+        let unit = Arc::new(CodeUnit::new(
+            "unit".to_string(),
+            PathBuf::from("unit.rs"),
+            1,
+            1,
+            Language::Rust,
+            crate::parser::UnitType::Function,
+            None,
+        ));
+        input_tx
+            .send(PooledChunkForIndex {
+                units: vec![unit.clone(), unit],
+                embeddings: vec![Array2::zeros((4, 8)), Array2::zeros((4, 8))],
+            })
+            .unwrap();
+        drop(input_tx);
+
+        let config = IndexConfig {
+            force_cpu: false,
+            binary: false,
+            ..Default::default()
+        };
+        let error = run_index_stage(
+            input_rx,
+            metadata_tx,
+            temp_dir.path().to_str().unwrap().to_string(),
+            config,
+            UpdateConfig::default(),
+            Some(256),
+            2,
+        )
+        .unwrap_err();
+
+        assert!(contains_codec_config_error(&error));
+        assert!(error.to_string().contains("cannot hold one"));
+        assert!(matches!(
+            metadata_rx.try_recv(),
+            Err(TryRecvError::Empty | TryRecvError::Disconnected)
+        ));
+    }
+
+    /// Fabricated stage outcomes use the same stage order as
+    /// `teardown_chunk_pipeline`: tokenize → encode → pool → index → metadata.
+    fn stage_results(
+        tokenize: Result<()>,
+        encode: Result<()>,
+        pool: Result<()>,
+        index: Result<()>,
+        metadata: Result<()>,
+    ) -> Vec<(&'static str, thread::Result<Result<()>>)> {
+        vec![
+            ("Tokenize", Ok(tokenize)),
+            ("Encode", Ok(encode)),
+            ("Pool", Ok(pool)),
+            ("Index", Ok(index)),
+            ("Metadata", Ok(metadata)),
+        ]
+    }
+
+    fn closed_channel_cascade(context: &str) -> Result<()> {
+        Err(anyhow::anyhow!("sending on a closed channel").context(context.to_string()))
+    }
+
+    fn index_codec_config_error() -> Result<()> {
+        Err(anyhow::Error::new(next_plaid::Error::Config(
+            "CUDA codec memory budget cannot hold one compression row".to_string(),
+        ))
+        .context("index stage failed"))
+    }
+
+    fn assert_codec_config_selected(error: &anyhow::Error) {
+        assert!(
+            error.chain().any(|cause| cause
+                .downcast_ref::<next_plaid::Error>()
+                .is_some_and(|e| matches!(e, next_plaid::Error::Config(_)))),
+            "expected next_plaid::Error::Config in the error chain, got: {error:?}"
+        );
+    }
+
+    /// Regression: when the index stage rejects the codec budget with several
+    /// chunks in flight, upstream stages and the producer only see
+    /// closed-channel cascades. The returned error must be the index stage's
+    /// Config error so `contains_codec_config_error` can gate the CPU retry.
+    #[test]
+    fn index_config_error_wins_over_upstream_channel_cascades() {
+        let producer_send =
+            closed_channel_cascade("Failed to send prepared chunk to tokenize stage");
+        let stages = stage_results(
+            closed_channel_cascade("Failed to send tokenized chunk to encode stage"),
+            closed_channel_cascade("Failed to send raw embeddings to pooling stage"),
+            closed_channel_cascade("Failed to send pooled embeddings to index stage"),
+            index_codec_config_error(),
+            Ok(()),
+        );
+        let error = resolve_pipeline_results(producer_send, stages).unwrap_err();
+        assert_codec_config_selected(&error);
+    }
+
+    /// The most downstream failing stage is the root cause: when the metadata
+    /// stage fails, the index stage's send failure is only the cascade.
+    #[test]
+    fn most_downstream_stage_error_wins_over_cascades() {
+        let producer_send =
+            closed_channel_cascade("Failed to send prepared chunk to tokenize stage");
+        let stages = stage_results(
+            closed_channel_cascade("tokenize cascade"),
+            closed_channel_cascade("encode cascade"),
+            closed_channel_cascade("pool cascade"),
+            closed_channel_cascade("Failed to send indexed chunk to metadata stage"),
+            Err(anyhow::anyhow!("filtering database is read-only")),
+        );
+        let error = resolve_pipeline_results(producer_send, stages).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("filtering database is read-only"),
+            "expected the metadata stage error, got: {error:?}"
+        );
+    }
+
+    /// Panics are bugs, not cascades: they keep their per-stage diagnostics
+    /// and are reported before any stage error.
+    #[test]
+    fn stage_panic_diagnostics_are_preserved() {
+        let mut stages = stage_results(Ok(()), Ok(()), Ok(()), index_codec_config_error(), Ok(()));
+        stages[0] = ("Tokenize", Err(Box::new("boom")));
+        let error = resolve_pipeline_results(Ok(()), stages).unwrap_err();
+        assert_eq!(error.to_string(), "Tokenize stage thread panicked");
+
+        let mut stages = stage_results(Ok(()), Ok(()), Ok(()), Ok(()), Ok(()));
+        stages[3] = ("Index", Err(Box::new("boom")));
+        let error = resolve_pipeline_results(Ok(()), stages).unwrap_err();
+        assert_eq!(error.to_string(), "Index stage thread panicked");
+    }
+
+    #[test]
+    fn producer_send_error_is_returned_when_stages_succeed() {
+        let stages = stage_results(Ok(()), Ok(()), Ok(()), Ok(()), Ok(()));
+        let producer_send =
+            closed_channel_cascade("Failed to send prepared chunk to tokenize stage");
+        let error = resolve_pipeline_results(producer_send, stages).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to send prepared chunk to tokenize stage"),
+            "expected the producer send error, got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn successful_pipeline_results_resolve_to_ok() {
+        let stages = stage_results(Ok(()), Ok(()), Ok(()), Ok(()), Ok(()));
+        resolve_pipeline_results(Ok(()), stages).unwrap();
+    }
+
+    /// Teardown must join every spawned stage exactly once and consume every
+    /// result even when the producer send failed — no detached threads — and
+    /// the index stage's Config error still wins over the live cascades.
+    #[test]
+    fn teardown_joins_every_stage_and_consumes_all_results() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let completed = Arc::new(AtomicUsize::new(0));
+        let spawn_stage = |result: Result<()>| {
+            let completed = Arc::clone(&completed);
+            thread::spawn(move || {
+                completed.fetch_add(1, Ordering::SeqCst);
+                result
+            })
+        };
+
+        let handles = ChunkPipelineHandles {
+            tokenize: spawn_stage(closed_channel_cascade("tokenize cascade")),
+            encode: spawn_stage(closed_channel_cascade("encode cascade")),
+            pool: spawn_stage(closed_channel_cascade("pool cascade")),
+            index: spawn_stage(index_codec_config_error()),
+            metadata: spawn_stage(Ok(())),
+        };
+        let producer_send =
+            closed_channel_cascade("Failed to send prepared chunk to tokenize stage");
+
+        let error = teardown_chunk_pipeline(producer_send, handles).unwrap_err();
+
+        assert_eq!(completed.load(Ordering::SeqCst), 5);
+        assert_codec_config_selected(&error);
+    }
+
     /// The mtime fast path in `compute_update_plan` must skip content hashing
     /// for files whose stored mtime is unchanged. The stored hash is wrong on
     /// purpose: if the plan still reports the file as unchanged, hashing was
@@ -5440,7 +5765,30 @@ mod tests {
             auto_confirm: true,
             model_id: "test-model".to_string(),
             binary: false,
+            codec_gpu_memory_budget_bytes: None,
         }
+    }
+
+    #[test]
+    fn test_codec_gpu_memory_budget_setter_is_per_builder_and_rejects_zero() {
+        let project_dir = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        let mut builder = test_builder(project_dir.path(), index_dir.path());
+
+        assert_eq!(builder.codec_gpu_memory_budget_bytes, None);
+        builder
+            .set_codec_gpu_memory_budget_bytes(256 * 1024 * 1024)
+            .unwrap();
+        assert_eq!(
+            builder.codec_gpu_memory_budget_bytes,
+            Some(256 * 1024 * 1024)
+        );
+        let error = builder.set_codec_gpu_memory_budget_bytes(0).unwrap_err();
+        assert!(error.to_string().contains("greater than zero"));
+        assert_eq!(
+            builder.codec_gpu_memory_budget_bytes,
+            Some(256 * 1024 * 1024)
+        );
     }
 
     /// Build a small vector index + filtering DB at `index_path`, distributing `n` documents

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -276,6 +276,7 @@ fn main() -> Result<()> {
             encode_batch_size,
             index_chunk_size,
             codec_gpu_memory_mb,
+            pooling_threads,
             static_batch,
         }) => cmd_init(
             &path,
@@ -288,6 +289,7 @@ fn main() -> Result<()> {
                 encode_batch_size,
                 index_chunk_size,
                 codec_gpu_memory_mb,
+                pooling_threads,
                 static_batch,
             },
         ),

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -275,6 +275,7 @@ fn main() -> Result<()> {
             batch_size,
             encode_batch_size,
             index_chunk_size,
+            codec_gpu_memory_mb,
             static_batch,
         }) => cmd_init(
             &path,
@@ -286,6 +287,7 @@ fn main() -> Result<()> {
                 batch_size,
                 encode_batch_size,
                 index_chunk_size,
+                codec_gpu_memory_mb,
                 static_batch,
             },
         ),

--- a/next-plaid/README.md
+++ b/next-plaid/README.md
@@ -386,6 +386,15 @@ The CUDA module uses cuBLAS for matrix multiplication and custom PTX kernels for
 
 > **Tip:** First CUDA context creation can take 10-30s. Enable GPU persistence mode to reduce this: `sudo nvidia-smi -pm 1`
 
+### CUDA codec memory budget
+
+ColGREP can pass a transient per-run CUDA codec working-memory budget through
+`prepare_codec_artifacts_with_gpu_memory_budget`, `encode_index_chunk_with_gpu_memory_budget`,
+and `MmapIndex::update_append_with_gpu_memory_budget`. These APIs bound compression batch
+sizes; the budget is not a process-wide VRAM cap, is not persisted in index metadata, and is
+ignored when CPU execution is selected. The ordinary APIs retain the existing 4 GiB CUDA
+default.
+
 ---
 
 ## Index File Structure

--- a/next-plaid/src/codec.rs
+++ b/next-plaid/src/codec.rs
@@ -258,19 +258,52 @@ impl ResidualCodec {
     ///
     /// Centroid indices of shape `[N]`
     pub fn compress_into_codes(&self, embeddings: &Array2<f32>) -> Array1<usize> {
-        // Try CUDA acceleration if available
+        self.compress_into_codes_with_gpu_memory_budget(embeddings, None)
+            .expect("the default CUDA codec budget should not produce a configuration error")
+    }
+
+    /// Compress embeddings into centroid codes with an optional CUDA codec memory budget.
+    ///
+    /// `gpu_memory_budget_bytes` is a per-operation working-memory budget used only to
+    /// choose the CUDA compression batch size. It is not a process-wide VRAM limit and
+    /// does not affect query encoding. `None` preserves the existing 4 GiB CUDA default.
+    /// CPU compression ignores this value and keeps its existing behavior.
+    ///
+    /// Explicit CUDA budget/dimension validation errors are returned to the caller. Ordinary
+    /// CUDA operational failures keep the automatic CPU fallback, unless GPU execution is
+    /// forced, in which case the existing panic behavior is preserved.
+    pub(crate) fn compress_into_codes_with_gpu_memory_budget(
+        &self,
+        embeddings: &Array2<f32>,
+        gpu_memory_budget_bytes: Option<usize>,
+    ) -> Result<Array1<usize>> {
+        // Try CUDA acceleration if available.
         #[cfg(feature = "_cuda")]
-        {
+        if !crate::is_force_cpu() {
             let force_gpu = crate::is_force_gpu();
             if let Some(ctx) = crate::cuda::get_global_context() {
                 let centroids = self.centroids_view();
+                if let Some(budget) = gpu_memory_budget_bytes {
+                    crate::cuda::validate_compression_budget(
+                        &embeddings.view(),
+                        &centroids,
+                        budget,
+                        false,
+                    )?;
+                }
+
                 match crate::cuda::compress_into_codes_cuda_batched(
                     &ctx,
                     &embeddings.view(),
                     &centroids,
-                    None,
+                    gpu_memory_budget_bytes,
                 ) {
-                    Ok(codes) => return codes,
+                    Ok(codes) => return Ok(codes),
+                    Err(e)
+                        if gpu_memory_budget_bytes.is_some() && matches!(e, Error::Config(_)) =>
+                    {
+                        return Err(e);
+                    }
                     Err(e) => {
                         if force_gpu {
                             panic!(
@@ -289,7 +322,10 @@ impl ResidualCodec {
             }
         }
 
-        self.compress_into_codes_cpu(embeddings)
+        #[cfg(not(feature = "_cuda"))]
+        let _ = gpu_memory_budget_bytes;
+
+        Ok(self.compress_into_codes_cpu(embeddings))
     }
 
     /// CPU implementation of compress_into_codes.
@@ -660,6 +696,23 @@ mod tests {
         let codes = codec.compress_into_codes(&embeddings);
         assert_eq!(codes[0], 0);
         assert_eq!(codes[1], 2);
+    }
+
+    #[cfg(feature = "_cuda")]
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn test_explicit_cuda_budget_validation_is_returned() {
+        crate::cuda::get_global_context().expect("requires an available CUDA device");
+        let centroids = Array2::zeros((4, 8));
+        let codec = ResidualCodec::new(2, centroids, Array1::zeros(8), None, None).unwrap();
+        let embeddings = Array2::zeros((1, 8));
+        let centroid_bytes = 4 * 8 * std::mem::size_of::<f32>();
+
+        let error = codec
+            .compress_into_codes_with_gpu_memory_budget(&embeddings, Some(centroid_bytes))
+            .unwrap_err();
+        assert!(matches!(error, Error::Config(_)));
+        assert!(error.to_string().contains("cannot hold one"));
     }
 
     #[test]

--- a/next-plaid/src/cuda.rs
+++ b/next-plaid/src/cuda.rs
@@ -339,13 +339,170 @@ fn load_kernels(device: &Arc<CudarcContext>) -> Result<(CudaFunction, CudaFuncti
     Ok((argmax_func, gather_subtract_func))
 }
 
-/// Compute optimal batch size to stay within GPU memory budget.
-fn compute_batch_size(n: usize, k: usize, dim: usize, max_gpu_memory: usize) -> usize {
-    // Memory per row: embedding (dim*4) + scores (k*4) + code (4)
-    let bytes_per_row = dim * 4 + k * 4 + 4;
-    let fixed_memory = k * dim * 4; // centroids
-    let available = max_gpu_memory.saturating_sub(fixed_memory);
-    (available / bytes_per_row).clamp(1, n)
+const CUDA_API_MAX_DIMENSION: usize = i32::MAX as usize;
+const ARGMAX_BLOCK_SIZE: usize = 256;
+const ARGMAX_BLOCK_SIZE_U32: u32 = 256;
+
+#[derive(Debug)]
+struct CudaBatchPlan {
+    batch_size: usize,
+    k: i32,
+    dim: i32,
+}
+
+fn configuration_error(message: impl Into<String>) -> Error {
+    Error::Config(message.into())
+}
+
+fn checked_cuda_dimension(value: usize, name: &str) -> Result<i32> {
+    if value == 0 {
+        return Err(configuration_error(format!(
+            "CUDA codec {} must be greater than zero",
+            name
+        )));
+    }
+    i32::try_from(value).map_err(|_| {
+        configuration_error(format!(
+            "CUDA codec {} ({}) exceeds the CUDA API i32 limit",
+            name, value
+        ))
+    })
+}
+
+fn checked_cuda_grid_size(batch_n: usize) -> Result<u32> {
+    let grid_size = batch_n.div_ceil(ARGMAX_BLOCK_SIZE);
+    u32::try_from(grid_size).map_err(|_| {
+        configuration_error(format!(
+            "CUDA codec argmax grid size ({}) exceeds the CUDA API u32 limit",
+            grid_size
+        ))
+    })
+}
+
+/// Compute one checked CUDA batch plan for either centroid-only or fused residual compression.
+///
+/// The budget includes the resident centroid matrix and all per-row buffers. The returned
+/// batch size is capped to the i32 range required by cuBLAS and the kernels, even when the
+/// budget itself is usize::MAX. All arithmetic and API conversions are checked so no launch
+/// can receive a truncated dimension.
+fn compute_batch_plan(
+    n: usize,
+    k: usize,
+    dim: usize,
+    max_gpu_memory: usize,
+    include_residuals: bool,
+) -> Result<CudaBatchPlan> {
+    if max_gpu_memory == 0 {
+        return Err(configuration_error(
+            "CUDA codec memory budget must be greater than zero",
+        ));
+    }
+
+    let f32_bytes = std::mem::size_of::<f32>();
+    let embedding_bytes = dim.checked_mul(f32_bytes).ok_or_else(|| {
+        configuration_error("CUDA batch-size calculation overflowed for embedding dimensions")
+    })?;
+    let score_bytes = k.checked_mul(f32_bytes).ok_or_else(|| {
+        configuration_error("CUDA batch-size calculation overflowed for centroid scores")
+    })?;
+    // Memory per row: embedding + scores + code, plus residual for fused compression.
+    let bytes_per_row = embedding_bytes
+        .checked_add(score_bytes)
+        .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u32>()))
+        .and_then(|bytes| {
+            if include_residuals {
+                bytes.checked_add(embedding_bytes)
+            } else {
+                Some(bytes)
+            }
+        })
+        .ok_or_else(|| {
+            configuration_error("CUDA batch-size calculation overflowed per-row memory")
+        })?;
+    let fixed_memory = k
+        .checked_mul(dim)
+        .and_then(|elements| elements.checked_mul(f32_bytes))
+        .ok_or_else(|| {
+            configuration_error("CUDA batch-size calculation overflowed centroid memory")
+        })?;
+    let available = max_gpu_memory.checked_sub(fixed_memory).ok_or_else(|| {
+        configuration_error(format!(
+            "CUDA codec memory budget ({} bytes) is smaller than the {}-byte centroid matrix",
+            max_gpu_memory, fixed_memory
+        ))
+    })?;
+    let max_batch_by_memory = available / bytes_per_row;
+    if max_batch_by_memory == 0 {
+        return Err(configuration_error(format!(
+            "CUDA codec memory budget ({} bytes) cannot hold one compression row after the {}-byte centroid matrix",
+            max_gpu_memory, fixed_memory
+        )));
+    }
+
+    let k_i32 = checked_cuda_dimension(k, "centroid count")?;
+    let dim_i32 = checked_cuda_dimension(dim, "embedding dimension")?;
+    let batch_size = max_batch_by_memory.min(n).clamp(1, CUDA_API_MAX_DIMENSION);
+    Ok(CudaBatchPlan {
+        batch_size,
+        k: k_i32,
+        dim: dim_i32,
+    })
+}
+
+/// Centroid-score compression requires the embedding and centroid matrices to
+/// agree on the token dimension; a mismatch is a configuration error, not a
+/// CUDA operational failure.
+fn validate_embedding_centroid_dimensions(
+    embeddings: &ArrayView2<f32>,
+    centroids: &ArrayView2<f32>,
+) -> Result<()> {
+    if embeddings.ncols() != centroids.ncols() {
+        return Err(configuration_error(format!(
+            "CUDA codec embedding dimension ({}) does not match centroid dimension ({})",
+            embeddings.ncols(),
+            centroids.ncols()
+        )));
+    }
+    Ok(())
+}
+
+/// Validate an explicit CUDA codec budget before attempting provider initialization.
+///
+/// This is crate-visible so the high-level codec API can return configuration errors rather
+/// than turning an invalid explicit budget into an automatic CPU fallback.
+pub(crate) fn validate_compression_budget(
+    embeddings: &ArrayView2<f32>,
+    centroids: &ArrayView2<f32>,
+    max_gpu_memory: usize,
+    include_residuals: bool,
+) -> Result<()> {
+    validate_embedding_centroid_dimensions(embeddings, centroids)?;
+    if embeddings.nrows() == 0 {
+        return Ok(());
+    }
+    validate_compression_budget_shape(
+        centroids.nrows(),
+        embeddings.ncols(),
+        max_gpu_memory,
+        include_residuals,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn validate_compression_budget_shape(
+    num_centroids: usize,
+    embedding_dim: usize,
+    max_gpu_memory: usize,
+    include_residuals: bool,
+) -> Result<()> {
+    compute_batch_plan(
+        1,
+        num_centroids,
+        embedding_dim,
+        max_gpu_memory,
+        include_residuals,
+    )?;
+    Ok(())
 }
 
 /// CUDA-accelerated compress_into_codes with memory-efficient batching.
@@ -365,7 +522,9 @@ pub fn compress_into_codes_cuda_batched(
         return Ok(Array1::zeros(0));
     }
 
-    let batch_size = compute_batch_size(n, k, dim, max_mem);
+    validate_embedding_centroid_dimensions(embeddings, centroids)?;
+    let batch_plan = compute_batch_plan(n, k, dim, max_mem, false)?;
+    let batch_size = batch_plan.batch_size;
 
     // Ensure centroids are contiguous
     let centroids_cont = if centroids.is_standard_layout() {
@@ -385,7 +544,7 @@ pub fn compress_into_codes_cuda_batched(
     let mut all_codes = Vec::with_capacity(n);
 
     for batch_start in (0..n).step_by(batch_size) {
-        let batch_end = (batch_start + batch_size).min(n);
+        let batch_end = batch_start.saturating_add(batch_size).min(n);
         let batch_n = batch_end - batch_start;
 
         let batch = embeddings.slice(ndarray::s![batch_start..batch_end, ..]);
@@ -400,23 +559,32 @@ pub fn compress_into_codes_cuda_batched(
             .clone_htod(batch_cont.as_slice().unwrap())
             .map_err(|e| Error::Codec(format!("Failed to copy batch to GPU: {:?}", e)))?;
 
+        let score_elements = batch_n
+            .checked_mul(k)
+            .ok_or_else(|| configuration_error("CUDA score allocation size overflowed"))?;
         let mut scores_gpu: CudaSlice<f32> = ctx
             .stream
-            .alloc_zeros(batch_n * k)
+            .alloc_zeros(score_elements)
             .map_err(|e| Error::Codec(format!("Failed to allocate scores: {:?}", e)))?;
 
         // GEMM: scores = batch @ centroids.T
+        let batch_n_i32 = i32::try_from(batch_n).map_err(|_| {
+            configuration_error(format!(
+                "CUDA codec batch size ({}) exceeds i32 limit",
+                batch_n
+            ))
+        })?;
         let cfg = GemmConfig {
             transa: cublasOperation_t::CUBLAS_OP_T,
             transb: cublasOperation_t::CUBLAS_OP_N,
-            m: k as i32,
-            n: batch_n as i32,
-            k: dim as i32,
+            m: batch_plan.k,
+            n: batch_n_i32,
+            k: batch_plan.dim,
             alpha: 1.0f32,
-            lda: dim as i32,
-            ldb: dim as i32,
+            lda: batch_plan.dim,
+            ldb: batch_plan.dim,
             beta: 0.0f32,
-            ldc: k as i32,
+            ldc: batch_plan.k,
         };
 
         unsafe {
@@ -430,15 +598,12 @@ pub fn compress_into_codes_cuda_batched(
             .alloc_zeros(batch_n)
             .map_err(|e| Error::Codec(format!("Failed to allocate codes: {:?}", e)))?;
 
-        let block_size = 256;
-        let grid_size = batch_n.div_ceil(block_size);
+        let grid_size = checked_cuda_grid_size(batch_n)?;
         let launch_cfg = LaunchConfig {
-            block_dim: (block_size as u32, 1, 1),
-            grid_dim: (grid_size as u32, 1, 1),
+            block_dim: (ARGMAX_BLOCK_SIZE_U32, 1, 1),
+            grid_dim: (grid_size, 1, 1),
             shared_mem_bytes: 0,
         };
-        let batch_n_i32 = batch_n as i32;
-        let k_i32 = k as i32;
 
         unsafe {
             ctx.stream
@@ -446,7 +611,7 @@ pub fn compress_into_codes_cuda_batched(
                 .arg(&scores_gpu)
                 .arg(&mut codes_gpu)
                 .arg(&batch_n_i32)
-                .arg(&k_i32)
+                .arg(&batch_plan.k)
                 .launch(launch_cfg)
                 .map_err(|e| Error::Codec(format!("Argmax kernel failed: {:?}", e)))?;
         }
@@ -460,20 +625,6 @@ pub fn compress_into_codes_cuda_batched(
     }
 
     Ok(Array1::from_vec(all_codes))
-}
-
-/// Compute optimal batch size for fused compress+residuals to stay within GPU memory.
-fn compute_batch_size_with_residuals(
-    n: usize,
-    k: usize,
-    dim: usize,
-    max_gpu_memory: usize,
-) -> usize {
-    // Memory per row: embedding (dim*4) + scores (k*4) + code (4) + residual (dim*4)
-    let bytes_per_row = dim * 4 + k * 4 + 4 + dim * 4;
-    let fixed_memory = k * dim * 4; // centroids
-    let available = max_gpu_memory.saturating_sub(fixed_memory);
-    (available / bytes_per_row).clamp(1, n)
 }
 
 /// CUDA-accelerated fused compress_into_codes + residual computation.
@@ -508,7 +659,9 @@ pub fn compress_and_residuals_cuda_batched(
         return Ok((Array1::zeros(0), ndarray::Array2::zeros((0, dim))));
     }
 
-    let batch_size = compute_batch_size_with_residuals(n, k, dim, max_mem);
+    validate_embedding_centroid_dimensions(embeddings, centroids)?;
+    let batch_plan = compute_batch_plan(n, k, dim, max_mem, true)?;
+    let batch_size = batch_plan.batch_size;
 
     // Ensure centroids are contiguous
     let centroids_cont = if centroids.is_standard_layout() {
@@ -529,7 +682,7 @@ pub fn compress_and_residuals_cuda_batched(
     let mut all_residuals = ndarray::Array2::<f32>::zeros((n, dim));
 
     for batch_start in (0..n).step_by(batch_size) {
-        let batch_end = (batch_start + batch_size).min(n);
+        let batch_end = batch_start.saturating_add(batch_size).min(n);
         let batch_n = batch_end - batch_start;
 
         let batch = embeddings.slice(ndarray::s![batch_start..batch_end, ..]);
@@ -545,23 +698,32 @@ pub fn compress_and_residuals_cuda_batched(
             .map_err(|e| Error::Codec(format!("Failed to copy batch to GPU: {:?}", e)))?;
 
         // Allocate GPU memory for scores and codes
+        let score_elements = batch_n
+            .checked_mul(k)
+            .ok_or_else(|| configuration_error("CUDA score allocation size overflowed"))?;
         let mut scores_gpu: CudaSlice<f32> = ctx
             .stream
-            .alloc_zeros(batch_n * k)
+            .alloc_zeros(score_elements)
             .map_err(|e| Error::Codec(format!("Failed to allocate scores: {:?}", e)))?;
 
         // GEMM: scores = batch @ centroids.T
+        let batch_n_i32 = i32::try_from(batch_n).map_err(|_| {
+            configuration_error(format!(
+                "CUDA codec batch size ({}) exceeds i32 limit",
+                batch_n
+            ))
+        })?;
         let cfg = GemmConfig {
             transa: cublasOperation_t::CUBLAS_OP_T,
             transb: cublasOperation_t::CUBLAS_OP_N,
-            m: k as i32,
-            n: batch_n as i32,
-            k: dim as i32,
+            m: batch_plan.k,
+            n: batch_n_i32,
+            k: batch_plan.dim,
             alpha: 1.0f32,
-            lda: dim as i32,
-            ldb: dim as i32,
+            lda: batch_plan.dim,
+            ldb: batch_plan.dim,
             beta: 0.0f32,
-            ldc: k as i32,
+            ldc: batch_plan.k,
         };
 
         unsafe {
@@ -576,15 +738,12 @@ pub fn compress_and_residuals_cuda_batched(
             .alloc_zeros(batch_n)
             .map_err(|e| Error::Codec(format!("Failed to allocate codes: {:?}", e)))?;
 
-        let block_size = 256;
-        let grid_size = batch_n.div_ceil(block_size);
+        let grid_size = checked_cuda_grid_size(batch_n)?;
         let argmax_cfg = LaunchConfig {
-            block_dim: (block_size as u32, 1, 1),
-            grid_dim: (grid_size as u32, 1, 1),
+            block_dim: (ARGMAX_BLOCK_SIZE_U32, 1, 1),
+            grid_dim: (grid_size, 1, 1),
             shared_mem_bytes: 0,
         };
-        let batch_n_i32 = batch_n as i32;
-        let k_i32 = k as i32;
 
         unsafe {
             ctx.stream
@@ -592,7 +751,7 @@ pub fn compress_and_residuals_cuda_batched(
                 .arg(&scores_gpu)
                 .arg(&mut codes_gpu)
                 .arg(&batch_n_i32)
-                .arg(&k_i32)
+                .arg(&batch_plan.k)
                 .launch(argmax_cfg)
                 .map_err(|e| Error::Codec(format!("Argmax kernel failed: {:?}", e)))?;
         }
@@ -601,19 +760,31 @@ pub fn compress_and_residuals_cuda_batched(
         drop(scores_gpu);
 
         // Compute residuals: residuals = embeddings - centroids[codes]
+        let residual_elements = batch_n
+            .checked_mul(dim)
+            .ok_or_else(|| configuration_error("CUDA residual allocation size overflowed"))?;
         let mut residuals_gpu: CudaSlice<f32> = ctx
             .stream
-            .alloc_zeros(batch_n * dim)
+            .alloc_zeros(residual_elements)
             .map_err(|e| Error::Codec(format!("Failed to allocate residuals: {:?}", e)))?;
 
         // For gather_subtract: one block per row, threads parallelize over dimensions
-        let threads_per_row = dim.min(256);
+        let threads_per_row = dim.min(ARGMAX_BLOCK_SIZE);
+        let threads_per_row = u32::try_from(threads_per_row).map_err(|_| {
+            configuration_error("CUDA gather-subtract block dimension exceeds u32 limit")
+        })?;
+        let batch_grid_size = u32::try_from(batch_n).map_err(|_| {
+            configuration_error(format!(
+                "CUDA gather-subtract grid size ({}) exceeds u32 limit",
+                batch_n
+            ))
+        })?;
         let gather_cfg = LaunchConfig {
-            block_dim: (threads_per_row as u32, 1, 1),
-            grid_dim: (batch_n as u32, 1, 1),
+            block_dim: (threads_per_row, 1, 1),
+            grid_dim: (batch_grid_size, 1, 1),
             shared_mem_bytes: 0,
         };
-        let dim_i32 = dim as i32;
+        let dim_i32 = batch_plan.dim;
 
         unsafe {
             ctx.stream
@@ -660,12 +831,70 @@ mod tests {
     use ndarray_rand::RandomExt;
 
     #[test]
+    #[ignore = "requires an available CUDA device"]
     fn test_cuda_context() {
         let ctx = CudaContext::new(0);
         assert!(ctx.is_ok(), "Failed to create CUDA context");
     }
 
     #[test]
+    fn test_compute_batch_plan_is_deterministic() {
+        let budget = 4 * 1024 * 1024 * 1024;
+        assert_eq!(
+            compute_batch_plan(100, 64, 128, budget, false)
+                .unwrap()
+                .batch_size,
+            100
+        );
+        assert_eq!(
+            compute_batch_plan(100, 64, 128, budget, true)
+                .unwrap()
+                .batch_size,
+            100
+        );
+
+        let fixed = 4 * 8 * std::mem::size_of::<f32>();
+        let per_row = 8 * std::mem::size_of::<f32>()
+            + 4 * std::mem::size_of::<f32>()
+            + std::mem::size_of::<u32>();
+        assert_eq!(
+            compute_batch_plan(100, 4, 8, fixed + per_row * 3, false)
+                .unwrap()
+                .batch_size,
+            3
+        );
+    }
+
+    #[test]
+    fn test_compute_batch_plan_rejects_configuration_errors() {
+        let overflow = compute_batch_plan(1, 1, usize::MAX, usize::MAX, false);
+        assert!(matches!(&overflow, Err(Error::Config(_))));
+        assert!(overflow.unwrap_err().to_string().contains("overflowed"));
+
+        let too_small = compute_batch_plan(1, 4, 8, 4 * 8 * std::mem::size_of::<f32>(), false);
+        assert!(matches!(&too_small, Err(Error::Config(_))));
+        assert!(too_small
+            .unwrap_err()
+            .to_string()
+            .contains("cannot hold one"));
+
+        let dimension_limit = compute_batch_plan(1, i32::MAX as usize + 1, 8, usize::MAX, false);
+        assert!(matches!(dimension_limit, Err(Error::Config(_))));
+    }
+
+    #[test]
+    fn test_compute_batch_plan_caps_batch_to_i32_limit() {
+        let plan = compute_batch_plan(usize::MAX, 1, 1, usize::MAX, false).unwrap();
+        assert_eq!(plan.batch_size, i32::MAX as usize);
+        assert_eq!(checked_cuda_grid_size(plan.batch_size).unwrap(), 8_388_608);
+        assert!(matches!(
+            checked_cuda_grid_size(usize::MAX),
+            Err(Error::Config(_))
+        ));
+    }
+
+    #[test]
+    #[ignore = "requires an available CUDA device"]
     fn test_compress_into_codes_cuda() {
         let ctx = CudaContext::new(0).expect("No CUDA");
         let embeddings = Array2::random((1000, 128), Uniform::new(-1.0f32, 1.0));
@@ -679,5 +908,45 @@ mod tests {
         for &code in codes.iter() {
             assert!(code < 64);
         }
+    }
+
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn test_cuda_multi_batch_matches_unbounded_output() {
+        let ctx = CudaContext::new(0).expect("No CUDA");
+        let embeddings = Array2::random((257, 128), Uniform::new(-1.0f32, 1.0));
+        let centroids = Array2::random((64, 128), Uniform::new(-1.0f32, 1.0));
+
+        let fixed = 64 * 128 * std::mem::size_of::<f32>();
+        let residual_row = 128 * std::mem::size_of::<f32>()
+            + 64 * std::mem::size_of::<f32>()
+            + std::mem::size_of::<u32>()
+            + 128 * std::mem::size_of::<f32>();
+        let bounded_budget = fixed + residual_row * 7;
+
+        let unbounded_codes =
+            compress_into_codes_cuda_batched(&ctx, &embeddings.view(), &centroids.view(), None)
+                .expect("CUDA failed");
+        let bounded_codes = compress_into_codes_cuda_batched(
+            &ctx,
+            &embeddings.view(),
+            &centroids.view(),
+            Some(bounded_budget),
+        )
+        .expect("CUDA failed");
+        assert_eq!(bounded_codes, unbounded_codes);
+
+        let (unbounded_codes, unbounded_residuals) =
+            compress_and_residuals_cuda_batched(&ctx, &embeddings.view(), &centroids.view(), None)
+                .expect("CUDA failed");
+        let (bounded_codes, bounded_residuals) = compress_and_residuals_cuda_batched(
+            &ctx,
+            &embeddings.view(),
+            &centroids.view(),
+            Some(bounded_budget),
+        )
+        .expect("CUDA failed");
+        assert_eq!(bounded_codes, unbounded_codes);
+        assert_eq!(bounded_residuals, unbounded_residuals);
     }
 }

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use crate::binary;
 use crate::codec::ResidualCodec;
 use crate::error::{Error, Result};
+#[cfg(feature = "_cuda")]
+use crate::kmeans::estimate_num_partitions;
 use crate::kmeans::{compute_kmeans, ComputeKmeansConfig};
 use crate::utils::{atomic_write_file, quantile, quantiles};
 
@@ -38,6 +40,60 @@ fn compress_and_residuals_cpu(
         });
 
     (codes, residuals)
+}
+
+fn compress_and_residuals_with_gpu_memory_budget(
+    embeddings: &Array2<f32>,
+    codec: &ResidualCodec,
+    force_cpu: bool,
+    gpu_memory_budget_bytes: Option<usize>,
+) -> Result<(Array1<usize>, Array2<f32>)> {
+    #[cfg(feature = "_cuda")]
+    if !force_cpu && !crate::is_force_cpu() {
+        let force_gpu = crate::is_force_gpu();
+        if let Some(ctx) = crate::cuda::get_global_context() {
+            let centroids = codec.centroids_view();
+            if let Some(budget) = gpu_memory_budget_bytes {
+                crate::cuda::validate_compression_budget(
+                    &embeddings.view(),
+                    &centroids,
+                    budget,
+                    true,
+                )?;
+            }
+
+            match crate::cuda::compress_and_residuals_cuda_batched(
+                &ctx,
+                &embeddings.view(),
+                &centroids,
+                gpu_memory_budget_bytes,
+            ) {
+                Ok(result) => return Ok(result),
+                Err(e) if gpu_memory_budget_bytes.is_some() && matches!(e, Error::Config(_)) => {
+                    return Err(e);
+                }
+                Err(e) => {
+                    if force_gpu {
+                        panic!(
+                            "FORCE_GPU is set but CUDA compress_and_residuals failed: {}",
+                            e
+                        );
+                    }
+                    eprintln!(
+                        "[next-plaid] CUDA compress_and_residuals failed: {}, falling back to CPU",
+                        e
+                    );
+                }
+            }
+        } else if force_gpu {
+            panic!("FORCE_GPU is set but CUDA context is unavailable");
+        }
+    }
+
+    #[cfg(not(feature = "_cuda"))]
+    let _ = (force_cpu, gpu_memory_budget_bytes);
+
+    Ok(compress_and_residuals_cpu(embeddings, codec))
 }
 
 /// Configuration for index creation
@@ -195,6 +251,19 @@ pub fn prepare_codec_artifacts(
     centroids: Array2<f32>,
     config: &IndexConfig,
 ) -> Result<PreparedCodecArtifacts> {
+    prepare_codec_artifacts_with_gpu_memory_budget(embeddings, centroids, config, None)
+}
+
+/// Prepare codec training artifacts with an optional per-operation CUDA memory budget.
+///
+/// The budget is transient: it controls only CUDA compression during this preparation call
+/// and is not part of [`IndexConfig`] or persisted index metadata.
+pub fn prepare_codec_artifacts_with_gpu_memory_budget(
+    embeddings: &[Array2<f32>],
+    centroids: Array2<f32>,
+    config: &IndexConfig,
+    gpu_memory_budget_bytes: Option<usize>,
+) -> Result<PreparedCodecArtifacts> {
     let embedding_dim = centroids.ncols();
     let total_embeddings: usize = embeddings.iter().map(|e| e.nrows()).sum();
     let num_documents = embeddings.len();
@@ -246,7 +315,8 @@ pub fn prepare_codec_artifacts(
     let heldout_codes = if config.force_cpu {
         initial_codec.compress_into_codes_cpu(&heldout)
     } else {
-        initial_codec.compress_into_codes(&heldout)
+        initial_codec
+            .compress_into_codes_with_gpu_memory_budget(&heldout, gpu_memory_budget_bytes)?
     };
 
     let mut residuals = heldout.clone();
@@ -303,6 +373,21 @@ pub fn encode_index_chunk(
     force_cpu: bool,
     binary: bool,
 ) -> Result<EncodedIndexChunk> {
+    encode_index_chunk_with_gpu_memory_budget(embeddings, codec, force_cpu, binary, None)
+}
+
+/// Encode one index chunk, optionally bounding CUDA codec working memory.
+///
+/// The budget is applied to both centroid-code compression (including binary document storage)
+/// and fused residual compression. `None` preserves the existing 4 GiB CUDA default. CPU
+/// behavior is unchanged.
+pub fn encode_index_chunk_with_gpu_memory_budget(
+    embeddings: &[Array2<f32>],
+    codec: &ResidualCodec,
+    force_cpu: bool,
+    binary: bool,
+    gpu_memory_budget_bytes: Option<usize>,
+) -> Result<EncodedIndexChunk> {
     let embedding_dim = codec.embedding_dim();
     let packed_dim = if binary {
         binary::packed_dim(embedding_dim)
@@ -329,49 +414,19 @@ pub fn encode_index_chunk(
         let codes = if force_cpu {
             codec.compress_into_codes_cpu(&batch_embeddings)
         } else {
-            codec.compress_into_codes(&batch_embeddings)
+            codec.compress_into_codes_with_gpu_memory_budget(
+                &batch_embeddings,
+                gpu_memory_budget_bytes,
+            )?
         };
         (codes, Array2::<f32>::zeros((0, embedding_dim)))
     } else {
-        #[cfg(feature = "_cuda")]
-        {
-            let force_gpu = crate::is_force_gpu();
-            if !force_cpu {
-                if let Some(ctx) = crate::cuda::get_global_context() {
-                    match crate::cuda::compress_and_residuals_cuda_batched(
-                        &ctx,
-                        &batch_embeddings.view(),
-                        &codec.centroids_view(),
-                        None,
-                    ) {
-                        Ok(result) => result,
-                        Err(e) => {
-                            if force_gpu {
-                                panic!(
-                                    "FORCE_GPU is set but CUDA compress_and_residuals failed: {}",
-                                    e
-                                );
-                            }
-                            println!(
-                                "[next-plaid] CUDA compress_and_residuals failed: {}, falling back to CPU",
-                                e
-                            );
-                            compress_and_residuals_cpu(&batch_embeddings, codec)
-                        }
-                    }
-                } else if force_gpu {
-                    panic!("FORCE_GPU is set but CUDA context is unavailable");
-                } else {
-                    compress_and_residuals_cpu(&batch_embeddings, codec)
-                }
-            } else {
-                compress_and_residuals_cpu(&batch_embeddings, codec)
-            }
-        }
-        #[cfg(not(feature = "_cuda"))]
-        {
-            compress_and_residuals_cpu(&batch_embeddings, codec)
-        }
+        compress_and_residuals_with_gpu_memory_budget(
+            &batch_embeddings,
+            codec,
+            force_cpu,
+            gpu_memory_budget_bytes,
+        )?
     };
 
     let batch_packed = if binary {
@@ -395,6 +450,47 @@ pub fn encode_index_chunk(
         residuals,
         doclens,
     })
+}
+
+/// Validate a transient CUDA codec budget for the first chunk of a new index.
+///
+/// This intentionally does nothing when CPU execution is selected or CUDA cannot be initialized.
+/// For a ColGREP initial create, the first chunk is the complete K-means sample, so the same
+/// partition heuristic and sample-token cap determine the codec shape used by the write.
+pub fn preflight_codec_gpu_memory_budget(
+    embeddings: &[Array2<f32>],
+    force_cpu: bool,
+    binary: bool,
+    gpu_memory_budget_bytes: Option<usize>,
+) -> Result<()> {
+    let Some(budget) = gpu_memory_budget_bytes else {
+        return Ok(());
+    };
+    if force_cpu || crate::is_force_cpu() {
+        return Ok(());
+    }
+
+    #[cfg(feature = "_cuda")]
+    {
+        if crate::cuda::get_global_context().is_none() {
+            return Ok(());
+        }
+
+        let sample_tokens: usize = embeddings.iter().map(Array2::nrows).sum();
+        let num_centroids = estimate_num_partitions(embeddings).min(sample_tokens);
+        let embedding_dim = embeddings.first().map_or(0, Array2::ncols);
+        crate::cuda::validate_compression_budget_shape(
+            num_centroids,
+            embedding_dim,
+            budget,
+            !binary,
+        )?;
+    }
+
+    #[cfg(not(feature = "_cuda"))]
+    let _ = (embeddings, binary, budget);
+
+    Ok(())
 }
 
 pub fn write_index_from_encoded_chunks(
@@ -1753,8 +1849,21 @@ impl MmapIndex {
         index_path: &str,
         update_config: &crate::update::UpdateConfig,
     ) -> Result<Vec<i64>> {
+        Self::update_append_with_gpu_memory_budget(embeddings, index_path, update_config, None)
+    }
+
+    /// Append embeddings to an existing index with an optional transient CUDA codec budget.
+    ///
+    /// Unlike the generic update-or-create APIs, this method requires the index metadata to
+    /// exist and never creates or rebuilds an index.
+    pub fn update_append_with_gpu_memory_budget(
+        embeddings: &[Array2<f32>],
+        index_path: &str,
+        update_config: &crate::update::UpdateConfig,
+        gpu_memory_budget_bytes: Option<usize>,
+    ) -> Result<Vec<i64>> {
         use crate::codec::ResidualCodec;
-        use crate::update::update_index;
+        use crate::update::update_index_with_gpu_memory_budget;
 
         let index_dir = std::path::Path::new(index_path);
         let metadata = Metadata::load_from_path(index_dir)?;
@@ -1762,13 +1871,14 @@ impl MmapIndex {
         let start_doc_id = metadata.num_documents as i64;
         let num_new_docs = embeddings.len();
 
-        update_index(
+        update_index_with_gpu_memory_budget(
             embeddings,
             index_path,
             &codec,
             Some(update_config.batch_size),
             false,
             update_config.force_cpu,
+            gpu_memory_budget_bytes,
         )?;
 
         Ok((start_doc_id..start_doc_id + num_new_docs as i64).collect())

--- a/next-plaid/src/lib.rs
+++ b/next-plaid/src/lib.rs
@@ -34,7 +34,9 @@ pub use delete::delete_from_index;
 pub use error::{Error, Result};
 pub use index::MmapIndex;
 pub use index::{
-    encode_index_chunk, prepare_codec_artifacts, write_index_from_encoded_chunks,
+    encode_index_chunk, encode_index_chunk_with_gpu_memory_budget,
+    preflight_codec_gpu_memory_budget, prepare_codec_artifacts,
+    prepare_codec_artifacts_with_gpu_memory_budget, write_index_from_encoded_chunks,
     EncodedIndexChunk, IndexConfig, Metadata, PreparedCodecArtifacts,
 };
 pub use kmeans::{

--- a/next-plaid/src/update.rs
+++ b/next-plaid/src/update.rs
@@ -776,6 +776,30 @@ pub fn update_index(
     update_threshold: bool,
     force_cpu: bool,
 ) -> Result<usize> {
+    update_index_with_gpu_memory_budget(
+        embeddings,
+        index_path,
+        codec,
+        batch_size,
+        update_threshold,
+        force_cpu,
+        None,
+    )
+}
+
+/// Update an existing index with an optional CUDA codec working-memory budget.
+///
+/// The budget is applied to centroid-code compression during incremental updates.
+/// `None` preserves the existing 4 GiB CUDA default; CPU behavior is unchanged.
+pub(crate) fn update_index_with_gpu_memory_budget(
+    embeddings: &[Array2<f32>],
+    index_path: &str,
+    codec: &ResidualCodec,
+    batch_size: Option<usize>,
+    update_threshold: bool,
+    force_cpu: bool,
+    codec_gpu_memory_budget_bytes: Option<usize>,
+) -> Result<usize> {
     emit_update_progress("index_write", "writing index chunks");
     let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
     let index_dir = Path::new(index_path);
@@ -871,7 +895,10 @@ pub fn update_index(
         let batch_codes = if force_cpu {
             codec.compress_into_codes_cpu(&batch_embeddings)
         } else {
-            codec.compress_into_codes(&batch_embeddings)
+            codec.compress_into_codes_with_gpu_memory_budget(
+                &batch_embeddings,
+                codec_gpu_memory_budget_bytes,
+            )?
         };
 
         // BATCH: Compute residuals using parallel subtraction

--- a/next-plaid/tests/binary_integration.rs
+++ b/next-plaid/tests/binary_integration.rs
@@ -254,3 +254,277 @@ fn encode_index_chunk_binary_packs_signs_with_ivf_codes() {
         .collect();
     assert_eq!(chunk.codes.to_vec(), want_codes);
 }
+
+#[cfg(feature = "_cuda")]
+mod cuda_codec_budget_tests {
+    use super::*;
+
+    fn bounded_budget(dim: usize, num_centroids: usize) -> usize {
+        let fixed = num_centroids * dim * std::mem::size_of::<f32>();
+        let row = dim * std::mem::size_of::<f32>()
+            + num_centroids * std::mem::size_of::<f32>()
+            + std::mem::size_of::<u32>()
+            + dim * std::mem::size_of::<f32>();
+        fixed + row * 3
+    }
+
+    fn assert_cuda_available() {
+        next_plaid::cuda::get_global_context().expect("requires an available CUDA device");
+    }
+
+    /// Every file in an index directory, name-sorted, for byte-exact comparison
+    /// of two index artifacts or of one directory before and after an operation.
+    fn snapshot_index_dir(dir: &TempDir) -> Vec<(String, Vec<u8>)> {
+        let mut entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    std::fs::read(entry.path()).unwrap(),
+                )
+            })
+            .collect();
+        entries.sort();
+        entries
+    }
+
+    /// Bounded multi-batch append to a small residual index: the returned IDs
+    /// and document counts must be correct, and every persisted artifact must
+    /// byte-match an unbounded control append of the same documents.
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn update_append_with_gpu_memory_budget_matches_unbounded_multi_batch() {
+        use next_plaid::Metadata;
+
+        assert_cuda_available();
+        let all = random_docs(16, 8, 64);
+        let (docs, more) = all.split_at(10);
+
+        let bounded_dir = TempDir::new().unwrap();
+        let control_dir = TempDir::new().unwrap();
+        let bounded_path = bounded_dir.path().to_str().unwrap();
+        let control_path = control_dir.path().to_str().unwrap();
+        // CPU k-means keeps codec creation deterministic and identical across
+        // both dirs; the appended compression is the GPU path under test.
+        let create_config = IndexConfig {
+            force_cpu: true,
+            ..config(false)
+        };
+        MmapIndex::create_with_kmeans(docs, bounded_path, &create_config).unwrap();
+        MmapIndex::create_with_kmeans(docs, control_path, &create_config).unwrap();
+
+        // Budget for ~3 compression rows per batch: 48 appended tokens force
+        // well over a dozen CUDA batches (the unbounded control uses one).
+        let metadata = Metadata::load_from_path(bounded_dir.path()).unwrap();
+        let budget = bounded_budget(metadata.embedding_dim, metadata.num_partitions);
+
+        let update_config = next_plaid::update::UpdateConfig::default();
+        let bounded_ids = MmapIndex::update_append_with_gpu_memory_budget(
+            more,
+            bounded_path,
+            &update_config,
+            Some(budget),
+        )
+        .unwrap();
+        let control_ids = MmapIndex::update_append(more, control_path, &update_config).unwrap();
+
+        let want_ids: Vec<i64> = (10..16).collect();
+        assert_eq!(bounded_ids, want_ids);
+        assert_eq!(control_ids, want_ids);
+
+        assert_eq!(
+            snapshot_index_dir(&bounded_dir),
+            snapshot_index_dir(&control_dir),
+            "bounded append artifacts diverged from the unbounded control"
+        );
+
+        let reloaded = Metadata::load_from_path(bounded_dir.path()).unwrap();
+        assert_eq!(reloaded.num_documents, 16);
+        assert_eq!(reloaded.num_embeddings, 16 * 8);
+        assert_eq!(reloaded.avg_doclen, 8.0);
+    }
+
+    /// An undersized budget must propagate as `Error::Config` and leave the
+    /// index metadata and artifacts byte-identical.
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn update_append_with_gpu_memory_budget_config_error_leaves_index_unchanged() {
+        assert_cuda_available();
+        let all = random_docs(14, 8, 64);
+        let (docs, more) = all.split_at(10);
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap();
+        let create_config = IndexConfig {
+            force_cpu: true,
+            ..config(false)
+        };
+        MmapIndex::create_with_kmeans(docs, path, &create_config).unwrap();
+        let before = snapshot_index_dir(&dir);
+
+        // 1 byte is smaller than the resident centroid matrix: validation must
+        // fail before any chunk write.
+        let error = MmapIndex::update_append_with_gpu_memory_budget(
+            more,
+            path,
+            &next_plaid::update::UpdateConfig::default(),
+            Some(1),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, next_plaid::Error::Config(_)),
+            "expected the undersized budget to propagate as Error::Config, got: {error}"
+        );
+
+        assert_eq!(
+            snapshot_index_dir(&dir),
+            before,
+            "failed append mutated index metadata or artifacts"
+        );
+    }
+
+    /// Successful initial-create public path under a bounded multi-batch CUDA
+    /// budget: preflight → codec artifacts → encode chunk → write index files,
+    /// then validate the resulting metadata and artifacts against an unbounded
+    /// control run and through `MmapIndex::load`.
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn initial_index_public_path_with_gpu_memory_budget_matches_unbounded() {
+        use next_plaid::Metadata;
+
+        assert_cuda_available();
+        let docs = random_docs(12, 8, 64);
+        let total_tokens: usize = docs.iter().map(|d| d.nrows()).sum();
+
+        // Deterministic CPU k-means so the bounded and unbounded runs share
+        // the exact same codec inputs.
+        let centroids = next_plaid::compute_kmeans(
+            &docs,
+            &next_plaid::kmeans::ComputeKmeansConfig {
+                seed: 42,
+                num_partitions: Some(16),
+                force_cpu: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let cfg = config(false);
+
+        // Preflight validates the heuristic codec shape (which can exceed the
+        // explicit 16 centroids), so size the budget for the larger of the two
+        // while still forcing ~3 compression rows per CUDA batch.
+        let preflight_centroids =
+            next_plaid::kmeans::estimate_num_partitions(&docs).min(total_tokens);
+        let budget = bounded_budget(64, preflight_centroids.max(16));
+
+        let run_public_path = |budget: Option<usize>, dir: &TempDir| -> Metadata {
+            let path = dir.path().to_str().unwrap();
+            next_plaid::preflight_codec_gpu_memory_budget(&docs, false, false, budget).unwrap();
+            let artifacts = next_plaid::prepare_codec_artifacts_with_gpu_memory_budget(
+                &docs,
+                centroids.clone(),
+                &cfg,
+                budget,
+            )
+            .unwrap();
+            let chunk = next_plaid::encode_index_chunk_with_gpu_memory_budget(
+                &docs,
+                &artifacts.codec,
+                false,
+                false,
+                budget,
+            )
+            .unwrap();
+            next_plaid::write_index_from_encoded_chunks(&[chunk], &artifacts, path, &cfg).unwrap()
+        };
+
+        let bounded_dir = TempDir::new().unwrap();
+        let control_dir = TempDir::new().unwrap();
+        let bounded_metadata = run_public_path(Some(budget), &bounded_dir);
+        run_public_path(None, &control_dir);
+
+        assert_eq!(bounded_metadata.num_chunks, 1);
+        assert_eq!(bounded_metadata.num_documents, 12);
+        assert_eq!(bounded_metadata.num_embeddings, total_tokens);
+        assert_eq!(bounded_metadata.avg_doclen, 8.0);
+        assert!(!bounded_metadata.binary);
+
+        assert_eq!(
+            snapshot_index_dir(&bounded_dir),
+            snapshot_index_dir(&control_dir),
+            "bounded initial create artifacts diverged from the unbounded control"
+        );
+
+        let index = MmapIndex::load(bounded_dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(index.num_documents(), 12);
+    }
+
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn encode_index_chunk_with_gpu_memory_budget_binary_matches_legacy_multi_batch() {
+        assert_cuda_available();
+        let docs = random_docs(10, 8, 64);
+        let centroids = next_plaid::compute_kmeans(
+            &docs,
+            &next_plaid::kmeans::ComputeKmeansConfig {
+                seed: 42,
+                num_partitions: Some(16),
+                force_cpu: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let artifacts =
+            next_plaid::prepare_codec_artifacts(&docs, centroids, &config(true)).unwrap();
+        let budget = bounded_budget(64, artifacts.codec.num_centroids());
+
+        let legacy = next_plaid::encode_index_chunk(&docs, &artifacts.codec, false, true).unwrap();
+        let bounded = next_plaid::encode_index_chunk_with_gpu_memory_budget(
+            &docs,
+            &artifacts.codec,
+            false,
+            true,
+            Some(budget),
+        )
+        .unwrap();
+
+        assert_eq!(bounded.codes, legacy.codes);
+        assert_eq!(bounded.residuals, legacy.residuals);
+        assert_eq!(bounded.doclens, legacy.doclens);
+    }
+
+    #[test]
+    #[ignore = "requires an available CUDA device"]
+    fn encode_index_chunk_with_gpu_memory_budget_residual_matches_legacy_multi_batch() {
+        assert_cuda_available();
+        let docs = random_docs(10, 8, 64);
+        let centroids = next_plaid::compute_kmeans(
+            &docs,
+            &next_plaid::kmeans::ComputeKmeansConfig {
+                seed: 42,
+                num_partitions: Some(16),
+                force_cpu: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let artifacts =
+            next_plaid::prepare_codec_artifacts(&docs, centroids, &config(false)).unwrap();
+        let budget = bounded_budget(64, artifacts.codec.num_centroids());
+
+        let legacy = next_plaid::encode_index_chunk(&docs, &artifacts.codec, false, false).unwrap();
+        let bounded = next_plaid::encode_index_chunk_with_gpu_memory_budget(
+            &docs,
+            &artifacts.codec,
+            false,
+            false,
+            Some(budget),
+        )
+        .unwrap();
+
+        assert_eq!(bounded.codes, legacy.codes);
+        assert_eq!(bounded.residuals, legacy.residuals);
+        assert_eq!(bounded.doclens, legacy.doclens);
+    }
+}


### PR DESCRIPTION
## Summary

Add two opt-in, per-run controls for high-memory CUDA indexing without changing defaults:

```text
colgrep init --codec-gpu-memory-mb 256 --pooling-threads 4
```

- `--codec-gpu-memory-mb` bounds the working-memory budget used to choose CUDA centroid-code/residual compression batches. It is not a process-wide VRAM cap.
- `--pooling-threads` creates one dedicated Rayon pool for hierarchical document pooling only. ONNX sessions, tokenization, parsing, codec work, and global Rayon behavior remain unchanged.

Both controls are transient and are not persisted in index identity or metadata.

## Codec budget

- checked MiB-to-byte and CUDA allocation/launch arithmetic
- checked/capped cuBLAS/kernel dimensions rather than lossy casts
- applies to initial codec preparation, residual and binary encoding, and incremental append
- existing public signatures remain source-compatible; budget-aware entry points are additive
- explicit configuration errors propagate instead of being hidden by CPU retry
- CPU/no-GPU paths ignore the CUDA-only budget as before
- multi-stage pipeline teardown joins every stage and preserves the downstream root error

## Pooling bound

- rejects zero or values above available host parallelism
- constructs one named pool per indexing stage, never per chunk
- only constructs it when hierarchical pooling is active (`pool_factor > 1`)
- absent option keeps the prior global-Rayon path exactly
- normal and CPU-retry pipelines carry the same option

## Validation

Workspace tests/check and strict clippy pass, including CUDA 13 builds. Device tests on a GTX 1660 Ti cover bounded versus unbounded CUDA codes/residuals, public binary and residual chunk encoding, initial artifact publication, append parity, and unchanged artifacts after an undersized-budget error. Pooling tests cover output bits/order for passthrough and hierarchical factors, option bounds, and pipeline propagation.

An initial tuning pass reduced raw device peak from about 4,828 MiB with the existing 4 GiB codec budget to 3,091 MiB with 256 MiB, for about 1.9s additional indexing time.

A later same-corpus comparison used 883 files, 37,402 documents, 1,544,520 vectors, FP32 CUDA batch 8, pool factor 2, and a 256 MiB codec budget:

| Dedicated pooling workers | Wall time | Host HWM |
|---|---:|---:|
| Unset | 60.89s | 1,765.8 MiB |
| 4 | 62.19s | 1,643.9 MiB |
| 2 | 67.87s | 1,598.1 MiB |

Four workers saved 121.9 MiB host HWM (6.9%) for 1.30s (2.1%) additional time and were the best observed balance. Both bounded indexes retained identical ordered top-10 results on all 20 configured queries versus the unset control. The flags remain opt-in pending broader hardware and corpus evidence.

## Related work

PR #162 also changes the indexing pipeline for larger cold-index gains on CPU. This PR is narrower: explicit CUDA codec workspace and pooling-allocation controls, with defaults unchanged. `colgrep/src/index/mod.rs` will likely need a rebase if #162 lands first.
