### PR TITLE
perf: rework the stage-1 shortlist pipeline — 4–12× faster stage 1 (5.6–7.1× e2e combined with #169)

### DIFF
--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -1062,6 +1062,12 @@ pub struct MmapIndex {
     pub mmap_codes: crate::mmap::MmapNpyArray1I64,
     /// Memory-mapped residuals array (public for search access)
     pub mmap_residuals: crate::mmap::MmapNpyArray2U8,
+    /// Lazily-built u32 copy of the token codes for the stage-1 candidate
+    /// flood: the mmap stores i64 (8 B/token), so a flood pass over millions
+    /// of candidate tokens reads 4x more code bytes than the values need
+    /// (num_centroids always fits u32). RAM cost is 4 B/token, paid on first
+    /// search only, and freed with the index.
+    codes_u32: std::sync::OnceLock<Vec<u32>>,
 }
 
 impl MmapIndex {
@@ -1183,24 +1189,55 @@ impl MmapIndex {
             doc_lengths,
             doc_offsets,
             mmap_codes,
+            codes_u32: std::sync::OnceLock::new(),
             mmap_residuals,
         })
     }
 
-    /// Get candidate documents from IVF for given centroid indices.
-    pub fn get_candidates(&self, centroid_indices: &[usize]) -> Vec<i64> {
-        let mut candidates: Vec<i64> = Vec::new();
+    /// Token codes as u32, built once on first use (one sequential pass over
+    /// the code mmap). Indexed by the same `doc_offsets` as `mmap_codes`.
+    pub fn codes_u32(&self) -> &[u32] {
+        self.codes_u32.get_or_init(|| {
+            let n = self.doc_offsets.last().copied().unwrap_or(0);
+            self.mmap_codes
+                .slice(0, n)
+                .iter()
+                .map(|&c| c as u32)
+                .collect()
+        })
+    }
 
+    /// Get candidate documents from IVF for given centroid indices.
+    ///
+    /// Doc ids are dense in `0..num_docs`, so a word bitmap dedups in
+    /// O(postings) and scanning its set bits emits the same sorted, deduped
+    /// list a `sort_unstable` + `dedup` of the concatenated postings would —
+    /// without the O(n log n) sort (measured 4–5x on this phase at 52k docs).
+    pub fn get_candidates(&self, centroid_indices: &[usize]) -> Vec<i64> {
+        let num_docs = self.doc_lengths.len();
+        let mut words = vec![0u64; num_docs.div_ceil(64)];
+        let mut count = 0usize;
         for &idx in centroid_indices {
             if idx < self.ivf_lengths.len() {
                 let start = self.ivf_offsets[idx] as usize;
                 let len = self.ivf_lengths[idx] as usize;
-                candidates.extend(self.ivf.slice(s![start..start + len]).iter());
+                for &d in self.ivf.slice(s![start..start + len]).iter() {
+                    let d = d as usize;
+                    let w = &mut words[d / 64];
+                    let bit = 1u64 << (d % 64);
+                    count += usize::from(*w & bit == 0);
+                    *w |= bit;
+                }
             }
         }
-
-        candidates.sort_unstable();
-        candidates.dedup();
+        let mut candidates: Vec<i64> = Vec::with_capacity(count);
+        for (wi, &word) in words.iter().enumerate() {
+            let mut w = word;
+            while w != 0 {
+                candidates.push((wi * 64 + w.trailing_zeros() as usize) as i64);
+                w &= w - 1;
+            }
+        }
         candidates
     }
 

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -1199,11 +1199,7 @@ impl MmapIndex {
     pub fn codes_u32(&self) -> &[u32] {
         self.codes_u32.get_or_init(|| {
             let n = self.doc_offsets.last().copied().unwrap_or(0);
-            self.mmap_codes
-                .slice(0, n)
-                .iter()
-                .map(|&c| c as u32)
-                .collect()
+            (0..n).map(|i| self.mmap_codes.get(i) as u32).collect()
         })
     }
 

--- a/next-plaid/src/index.rs
+++ b/next-plaid/src/index.rs
@@ -1062,12 +1062,6 @@ pub struct MmapIndex {
     pub mmap_codes: crate::mmap::MmapNpyArray1I64,
     /// Memory-mapped residuals array (public for search access)
     pub mmap_residuals: crate::mmap::MmapNpyArray2U8,
-    /// Lazily-built u32 copy of the token codes for the stage-1 candidate
-    /// flood: the mmap stores i64 (8 B/token), so a flood pass over millions
-    /// of candidate tokens reads 4x more code bytes than the values need
-    /// (num_centroids always fits u32). RAM cost is 4 B/token, paid on first
-    /// search only, and freed with the index.
-    codes_u32: std::sync::OnceLock<Vec<u32>>,
 }
 
 impl MmapIndex {
@@ -1189,17 +1183,7 @@ impl MmapIndex {
             doc_lengths,
             doc_offsets,
             mmap_codes,
-            codes_u32: std::sync::OnceLock::new(),
             mmap_residuals,
-        })
-    }
-
-    /// Token codes as u32, built once on first use (one sequential pass over
-    /// the code mmap). Indexed by the same `doc_offsets` as `mmap_codes`.
-    pub fn codes_u32(&self) -> &[u32] {
-        self.codes_u32.get_or_init(|| {
-            let n = self.doc_offsets.last().copied().unwrap_or(0);
-            (0..n).map(|i| self.mmap_codes.get(i) as u32).collect()
         })
     }
 

--- a/next-plaid/src/mmap.rs
+++ b/next-plaid/src/mmap.rs
@@ -820,21 +820,34 @@ impl MmapNpyArray1I64 {
         self.len == 0
     }
 
-    /// Get a slice of the data as &[i64].
-    ///
-    /// Returns a `Vec<i64>` instead of &[i64] to handle unaligned data safely.
-    ///
-    /// # Safety
-    /// The caller must ensure start <= end <= len.
-    pub fn slice(&self, start: usize, end: usize) -> Vec<i64> {
-        let count = end - start;
-        let mut result = Vec::with_capacity(count);
-
-        for i in start..end {
-            result.push(self.get(i));
+    /// Borrow the mapped codes without copying when the target and NPY data
+    /// layout permit it. NPY data starts on a 64-byte boundary, but retain the
+    /// runtime alignment check for files produced by other writers.
+    pub fn as_slice(&self) -> Option<&[i64]> {
+        if !cfg!(target_endian = "little") {
+            return None;
         }
 
-        result
+        let bytes = &self._mmap[self.data_offset..self.data_offset + self.len * 8];
+        if bytes.as_ptr().align_offset(std::mem::align_of::<i64>()) != 0 {
+            return None;
+        }
+
+        // SAFETY: the alignment is checked above, the mapped byte range is
+        // bounds-checked, and its length is exactly `self.len * size_of::<i64>()`.
+        Some(unsafe { std::slice::from_raw_parts(bytes.as_ptr().cast::<i64>(), self.len) })
+    }
+
+    /// Copy a range of codes into an owned vector.
+    ///
+    /// The zero-copy stage-1 path uses [`Self::as_slice`]. This owned form is
+    /// retained for callers that need a standalone buffer and as a portable
+    /// fallback for unaligned or big-endian mappings.
+    pub fn slice(&self, start: usize, end: usize) -> Vec<i64> {
+        if let Some(codes) = self.as_slice() {
+            return codes[start..end].to_vec();
+        }
+        (start..end).map(|i| self.get(i)).collect()
     }
 
     /// Get a value at an index.
@@ -1813,6 +1826,7 @@ pub fn convert_fastplaid_to_nextplaid(index_path: &Path) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ndarray_npy::WriteNpyExt;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -1867,6 +1881,19 @@ mod tests {
         let owned = mmap.to_owned();
         assert_eq!(owned[1], 20);
         assert_eq!(owned[2], 30);
+    }
+
+    #[test]
+    fn test_mmap_npy_array1_i64_zero_copy_slice() {
+        let mut file = NamedTempFile::new().unwrap();
+        Array1::from_vec(vec![10i64, 20, 30, 40])
+            .write_npy(&mut file)
+            .unwrap();
+        file.flush().unwrap();
+
+        let mmap = MmapNpyArray1I64::from_npy_file(file.path()).unwrap();
+        assert_eq!(mmap.as_slice().unwrap(), &[10, 20, 30, 40]);
+        assert_eq!(mmap.slice(1, 3), vec![20, 30]);
     }
 
     #[test]

--- a/next-plaid/src/mmap.rs
+++ b/next-plaid/src/mmap.rs
@@ -1897,6 +1897,21 @@ mod tests {
     }
 
     #[test]
+    fn test_mmap_npy_array1_i64_unaligned_header_uses_safe_fallback() {
+        let mut file = NamedTempFile::new().unwrap();
+        let header_size = write_npy_header_1d(&mut file, 4, "<i8").unwrap();
+        assert_ne!(header_size % std::mem::align_of::<i64>(), 0);
+        for value in [10i64, 20, 30, 40] {
+            file.write_all(&value.to_le_bytes()).unwrap();
+        }
+        file.flush().unwrap();
+
+        let mmap = MmapNpyArray1I64::from_npy_file(file.path()).unwrap();
+        assert!(mmap.as_slice().is_none());
+        assert_eq!(mmap.slice(1, 3), vec![20, 30]);
+    }
+
+    #[test]
     fn test_write_read_roundtrip() {
         let file = NamedTempFile::new().unwrap();
         let path = file.path();

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -354,7 +354,145 @@ fn approximate_score_sparse(
     score
 }
 
+/// Centroid-major flood scorer: the same MaxSim-over-centroid-scores as
+/// [`approximate_score_mmap`], reading a `[K, nq]` transposed matrix.
+///
+/// Why: row-major scoring does one 4-byte load per (query token, doc token)
+/// from rows `K` floats apart — at K = 32k that is a 128 KB stride, so every
+/// load is a fresh cache line and the flood is memory-bound on scattered
+/// fetches (measured 62–67% of stage-1 across the corpus ladder).
+/// Centroid-major, one doc token reads one contiguous `nq`-float strip that
+/// serves every query token, and the running max vectorizes across lanes.
+///
+/// Numerically identical to the row-major path: the per-query-token maxes
+/// are the same values, and both sum them in ascending query-token order.
+///
+/// Production scoring goes through the quantized [`approximate_score_flood_q8`];
+/// this f32 form is retained as the bit-identity reference in the flood tests.
+#[cfg(test)]
+fn approximate_score_flood_t(cdot_t: &Array2<f32>, doc_codes: &[i64], acc: &mut [f32]) -> f32 {
+    acc.fill(f32::NEG_INFINITY);
+    let nq = acc.len();
+    let t = cdot_t.as_slice().expect("cdot_t is standard layout");
+    for &code in doc_codes {
+        let row = &t[code as usize * nq..code as usize * nq + nq];
+        for (a, &v) in acc.iter_mut().zip(row) {
+            *a = (*a).max(v);
+        }
+    }
+    let mut score = 0.0;
+    for &a in acc.iter() {
+        if a > f32::NEG_INFINITY {
+            score += a;
+        }
+    }
+    score
+}
+
+/// Centroid-major scores quantized to u8 — PLAID's own trick for the
+/// candidate flood (the paper quantizes centroid scores for its centroid
+/// interaction): monotone map, so per-lane u8 max = f32 max, and the final
+/// score dequantizes as `nq·lo + scale·Σ lane`. Halves the vector-op count
+/// per doc token again (16 u8 lanes per SIMD max vs 4 f32) and shrinks the
+/// cache-resident matrix 4x. Approximate scores only rank the flood, so the
+/// ≤ scale/2 per-lane error only matters at prune boundaries — validated
+/// against real-embedding NDCG.
+struct QuantCdotT {
+    q: Vec<u8>,
+    /// Row stride: `nq` rounded up to a multiple of 16 so the flood's inner
+    /// loop is whole 16-lane chunks. Pad bytes are 0 — the quantized `lo`,
+    /// neutral under `max` — and contribute 0 to the lane sum, so both flood
+    /// invariants hold without masking.
+    stride: usize,
+    lo_sum: f32,
+    scale: f32,
+}
+
+/// One fused pass: blocked transpose + u8 quantization of the `[nq, K]`
+/// score matrix.
+fn transpose_quantize_cdot(cdot: &Array2<f32>) -> QuantCdotT {
+    const BLK: usize = 64;
+    let (nq, k) = (cdot.nrows(), cdot.ncols());
+    let src = cdot.as_standard_layout();
+    let src = src.as_slice().expect("cdot must be contiguous");
+    // Parallel min/max prepass — chunk-local reductions are exact, and
+    // min/max is order-independent, so lo/hi are bit-identical to a
+    // sequential scan.
+    let (lo, hi) = src
+        .par_chunks(1 << 16)
+        .map(|c| {
+            let (mut l, mut h) = (f32::INFINITY, f32::NEG_INFINITY);
+            for &v in c {
+                l = l.min(v);
+                h = h.max(v);
+            }
+            (l, h)
+        })
+        .reduce(
+            || (f32::INFINITY, f32::NEG_INFINITY),
+            |a, b| (a.0.min(b.0), a.1.max(b.1)),
+        );
+    let scale = if hi > lo { (hi - lo) / 255.0 } else { 1.0 };
+    let inv = 1.0 / scale;
+    let stride = nq.div_ceil(16) * 16;
+    let mut q = vec![0u8; k * stride];
+    // Centroid blocks own disjoint contiguous ranges of the output, so the
+    // blocks parallelize with no synchronization and bit-identical results.
+    q.par_chunks_mut(BLK * stride)
+        .enumerate()
+        .for_each(|(bi, qb)| {
+            let c0 = bi * BLK;
+            let c1 = (c0 + BLK).min(k);
+            for qi in 0..nq {
+                let row = &src[qi * k + c0..qi * k + c1];
+                for (j, &v) in row.iter().enumerate() {
+                    // Saturating float->int cast (guaranteed since Rust
+                    // 1.45): no round, no clamp — floor is a uniform shift,
+                    // invisible to ranking, and it autovectorizes to
+                    // fcvtzu/cvttps.
+                    qb[j * stride + qi] = ((v - lo) * inv) as u8;
+                }
+            }
+        });
+    QuantCdotT {
+        q,
+        stride,
+        lo_sum: nq as f32 * lo,
+        scale,
+    }
+}
+
+/// u8 flood scorer over the quantized centroid-major matrix.
+///
+/// Chunk-outer loop: for each 16-lane segment of the (stride-padded) row,
+/// sweep all doc tokens with a `[u8; 16]` accumulator — LLVM promotes it to
+/// one vector register, so the per-token work is load code, load 16 B, one
+/// `umax.16b`/`pmaxub`, with no accumulator memory traffic and no tail
+/// handling. Doc codes are re-read once per chunk (≤ 2 passes at nq ≤ 32;
+/// they are L1-hot on the second). Pad lanes hold quantized 0 everywhere,
+/// so they stay 0 through `max` and add nothing to the lane sum.
+fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[u32]) -> f32 {
+    let stride = qt.stride;
+    let q = qt.q.as_slice();
+    let mut sum: u32 = 0;
+    for c0 in (0..stride).step_by(16) {
+        let mut m = [0u8; 16];
+        for &code in doc_codes {
+            let row = &q[code as usize * stride + c0..code as usize * stride + c0 + 16];
+            for i in 0..16 {
+                m[i] = m[i].max(row[i]);
+            }
+        }
+        sum += m.iter().map(|&x| x as u32).sum::<u32>();
+    }
+    qt.lo_sum + qt.scale * sum as f32
+}
+
 /// Compute approximate scores for mmap index using code lookups.
+///
+/// The row-major scorer the quantized flood replaced; retained as the
+/// reference implementation for the flood's bit-identity test.
+#[cfg(test)]
 fn approximate_score_mmap(query_centroid_scores: &Array2<f32>, doc_codes: &[i64]) -> f32 {
     let mut score = 0.0;
 
@@ -384,7 +522,6 @@ pub fn search_one_mmap(
     subset: Option<&[i64]>,
 ) -> Result<QueryResult> {
     let num_centroids = index.codec.num_centroids();
-    let num_query_tokens = query.nrows();
 
     // Decide whether to use batched mode for memory efficiency
     let use_batched = params.centroid_batch_size > 0 && num_centroids > params.centroid_batch_size;
@@ -394,8 +531,156 @@ pub fn search_one_mmap(
         return search_one_mmap_batched(index, query, params, subset);
     }
 
+    let to_decompress = stage1_shortlist(index, query, params, subset)?;
+
+    if to_decompress.is_empty() {
+        return Ok(QueryResult {
+            query_id: 0,
+            passage_ids: vec![],
+            scores: vec![],
+        });
+    }
+
+    // Compute exact scores. Binary indexes score against an int8 query; the
+    // full-precision query is used for the float (residual) path.
+    let exact_query = prepare_score_query(index, query);
+    // Chunked processing limits concurrent memory from parallel decompression.
+    let mut exact_scores: Vec<(i64, f32)> = to_decompress
+        .par_chunks(DECOMPRESS_CHUNK_SIZE)
+        .flat_map(|chunk| {
+            chunk
+                .iter()
+                .filter_map(|&doc_id| {
+                    let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
+                    Some((doc_id, score))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    // Sort by exact score
+    exact_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
+
+    // Return top-k results
+    let result_count = params.top_k.min(exact_scores.len());
+    let passage_ids: Vec<i64> = exact_scores
+        .iter()
+        .take(result_count)
+        .map(|(id, _)| *id)
+        .collect();
+    let scores: Vec<f32> = exact_scores
+        .iter()
+        .take(result_count)
+        .map(|(_, s)| *s)
+        .collect();
+
+    Ok(QueryResult {
+        query_id: 0,
+        passage_ids,
+        scores,
+    })
+}
+
+/// The `[nq, dim] · [dim, K]` query–centroid GEMM with the K output columns
+/// computed in parallel blocks. Each block is a disjoint column slice of the
+/// output, and the dim-128 reduction happens entirely inside one block, so
+/// per-element summation order — and therefore every output bit — matches
+/// the single-call `query.dot(centroids.t())` this replaces. Intra-query
+/// parallelism is already stage-1's contract (the candidate flood is a
+/// `par_iter`); rayon work-stealing degrades gracefully under concurrent
+/// queries.
+fn par_cdot(query: &Array2<f32>, centroids: &ArrayView2<f32>) -> Array2<f32> {
+    use ndarray::linalg::general_mat_mul;
+    use ndarray::parallel::prelude::*;
+    use ndarray::Axis;
+    const BLK: usize = 2048;
+    let (nq, k) = (query.nrows(), centroids.nrows());
+    let mut out = Array2::<f32>::zeros((nq, k));
+    if k <= BLK {
+        general_mat_mul(1.0, query, &centroids.t(), 0.0, &mut out);
+        return out;
+    }
+    out.axis_chunks_iter_mut(Axis(1), BLK)
+        .into_par_iter()
+        .zip(centroids.axis_chunks_iter(Axis(0), BLK).into_par_iter())
+        .for_each(|(mut oc, cc)| {
+            let cct = cc.t();
+            general_mat_mul(1.0, query, &cct, 0.0, &mut oc);
+        });
+    out
+}
+
+/// Index of the smallest value in a short slice (probe top-k bookkeeping).
+#[inline]
+fn argmin_f32(vals: &[f32]) -> usize {
+    let mut w = 0;
+    for i in 1..vals.len() {
+        if vals[i] < vals[w] {
+            w = i;
+        }
+    }
+    w
+}
+
+/// Top-`n` indices of `row` by value via a running-threshold chunk scan.
+/// Per 64-wide chunk the max is a plain reduction (autovectorizes on every
+/// platform); the chunk is skipped unless its max beats the current n-th
+/// best, so the scalar rescan almost never runs. Same top-k set by value as
+/// `select_nth_unstable`; tie choice is arbitrary in both. NaN never wins a
+/// `v > thr` comparison, matching `cmp_score_descending`'s NaN-last order.
+fn probe_top_k_scan(row: &[f32], n: usize, top_idx: &mut Vec<u32>, top_val: &mut Vec<f32>) {
+    const PROBE_CHUNK: usize = 64;
+    top_idx.clear();
+    top_val.clear();
+    let n = n.min(row.len());
+    let mut thr = f32::NEG_INFINITY;
+    let mut worst = 0usize;
+    for (ci, chunk) in row.chunks(PROBE_CHUNK).enumerate() {
+        let mut m = f32::NEG_INFINITY;
+        for &v in chunk {
+            m = m.max(v);
+        }
+        if top_val.len() == n && m <= thr {
+            continue;
+        }
+        let base = (ci * PROBE_CHUNK) as u32;
+        for (j, &v) in chunk.iter().enumerate() {
+            if top_val.len() < n {
+                top_idx.push(base + j as u32);
+                top_val.push(v);
+                if top_val.len() == n {
+                    worst = argmin_f32(top_val);
+                    thr = top_val[worst];
+                }
+            } else if v > thr {
+                top_idx[worst] = base + j as u32;
+                top_val[worst] = v;
+                worst = argmin_f32(top_val);
+                thr = top_val[worst];
+            }
+        }
+    }
+}
+
+/// Stage 1 of the standard (non-batched) search: dense query×centroid scores,
+/// per-token IVF cell selection, candidate gathering, approximate codes-only
+/// scoring, and pruning down to the exact-scoring shortlist. Everything a
+/// query pays *before* exact scoring takes over.
+///
+/// Returns the pruned candidate list, which is empty when nothing survives
+/// probing/filtering.
+fn stage1_shortlist(
+    index: &crate::index::MmapIndex,
+    query: &Array2<f32>,
+    params: &SearchParameters,
+    subset: Option<&[i64]>,
+) -> Result<Vec<i64>> {
+    let num_centroids = index.codec.num_centroids();
+    let num_query_tokens = query.nrows();
+
     // Standard path: compute full query-centroid scores upfront
-    let query_centroid_scores = query.dot(&index.codec.centroids_view().t());
+    // (column-block-parallel GEMM, bit-identical to the single dot call).
+    let query_centroid_scores = par_cdot(query, &index.codec.centroids_view());
 
     // When subset is provided, pre-compute eligible centroids: only those containing
     // at least one embedding from a subset document. Centroids without subset docs
@@ -441,28 +726,47 @@ pub fn search_one_mmap(
     let cells_to_probe: Vec<usize> = {
         let mut selected_centroids = HashSet::new();
 
+        // Select on a reused u32 index buffer over each row slice: the
+        // tuple-vec this replaces allocated and filled K (usize, f32) pairs
+        // per query token — 8 MB/query of churn at K = 32k — to select 8.
+        let qcs = query_centroid_scores
+            .as_slice()
+            .expect("query x centroid scores are standard layout");
+        // Subset-path scratch only: the default path never fills a K-length
+        // buffer.
+        let mut idx_buf: Vec<u32> = if eligible_centroids.is_some() {
+            Vec::with_capacity(num_centroids)
+        } else {
+            Vec::new()
+        };
+        // No-subset probe select goes through probe_top_k_scan — one
+        // sequential read of each row, no K-length buffer fill.
+        let mut top_idx: Vec<u32> = Vec::with_capacity(effective_n_ivf_probe);
+        let mut top_val: Vec<f32> = Vec::with_capacity(effective_n_ivf_probe);
         for q_idx in 0..num_query_tokens {
-            let mut centroid_scores: Vec<(usize, f32)> = match &eligible_centroids {
-                Some(eligible) => eligible
-                    .iter()
-                    .map(|&c| (c, query_centroid_scores[[q_idx, c]]))
-                    .collect(),
-                None => (0..num_centroids)
-                    .map(|c| (c, query_centroid_scores[[q_idx, c]]))
-                    .collect(),
-            };
-
-            // Partial selection: O(K) average instead of O(K log K) for full sort
-            // After this, the top n elements are in positions 0..n
-            // (but not sorted among themselves - which is fine since we use a HashSet)
-            let n_probe = effective_n_ivf_probe.min(centroid_scores.len());
-            if centroid_scores.len() > n_probe {
-                centroid_scores
-                    .select_nth_unstable_by(n_probe - 1, |a, b| cmp_score_descending(a.1, b.1));
-            }
-
-            for (c, _) in centroid_scores.iter().take(n_probe) {
-                selected_centroids.insert(*c);
+            let row = &qcs[q_idx * num_centroids..(q_idx + 1) * num_centroids];
+            match &eligible_centroids {
+                Some(eligible) => {
+                    // Subset path: unchanged partial selection over the
+                    // eligible pool.
+                    idx_buf.clear();
+                    idx_buf.extend(eligible.iter().map(|&c| c as u32));
+                    let n_probe = effective_n_ivf_probe.min(idx_buf.len());
+                    if idx_buf.len() > n_probe {
+                        idx_buf.select_nth_unstable_by(n_probe - 1, |&a, &b| {
+                            cmp_score_descending(row[a as usize], row[b as usize])
+                        });
+                    }
+                    for &c in idx_buf.iter().take(n_probe) {
+                        selected_centroids.insert(c as usize);
+                    }
+                }
+                None => {
+                    probe_top_k_scan(row, effective_n_ivf_probe, &mut top_idx, &mut top_val);
+                    for &c in &top_idx {
+                        selected_centroids.insert(c as usize);
+                    }
+                }
             }
         }
 
@@ -477,7 +781,12 @@ pub fn search_one_mmap(
             });
         }
 
-        selected_centroids.into_iter().collect()
+        // Sorted cell order makes the gather's IVF postings reads sequential
+        // in the ivf array instead of hash order (free at ~200 cells; the
+        // win shows on server parts, not Apple L2).
+        let mut cells: Vec<usize> = selected_centroids.into_iter().collect();
+        cells.sort_unstable();
+        cells
     };
 
     // Get candidate documents from IVF
@@ -490,26 +799,33 @@ pub fn search_one_mmap(
     }
 
     if candidates.is_empty() {
-        return Ok(QueryResult {
-            query_id: 0,
-            passage_ids: vec![],
-            scores: vec![],
-        });
+        return Ok(vec![]);
     }
 
-    // Compute approximate scores
+    // Compute approximate scores: the quantized centroid-major flood.
+    let qt = transpose_quantize_cdot(&query_centroid_scores);
+    // u32 code side-array: 4 B/token reads instead of the mmap's 8.
+    let codes_all = index.codes_u32();
     let mut approx_scores: Vec<(i64, f32)> = candidates
         .par_iter()
         .map(|&doc_id| {
             let start = index.doc_offsets[doc_id as usize];
             let end = index.doc_offsets[doc_id as usize + 1];
-            let codes = index.mmap_codes.slice(start, end);
-            let score = approximate_score_mmap(&query_centroid_scores, &codes);
-            (doc_id, score)
+            (
+                doc_id,
+                approximate_score_flood_q8(&qt, &codes_all[start..end]),
+            )
         })
         .collect();
 
-    // Sort by approximate score and take top candidates
+    // Partial-select the top n_full_scores, then sort only that prefix —
+    // the flood is ~5x larger than what survives, and O(n) select + O(m log m)
+    // beats O(n log n) full sort. Identical top list and order.
+    let nf = params.n_full_scores.min(approx_scores.len());
+    if approx_scores.len() > nf && nf > 0 {
+        approx_scores.select_nth_unstable_by(nf - 1, |a, b| cmp_score_descending(a.1, b.1));
+        approx_scores.truncate(nf);
+    }
     approx_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
     let top_candidates: Vec<i64> = approx_scores
         .iter()
@@ -521,52 +837,7 @@ pub fn search_one_mmap(
     let n_decompress = (params.n_full_scores / 4).max(params.top_k);
     let to_decompress: Vec<i64> = top_candidates.into_iter().take(n_decompress).collect();
 
-    if to_decompress.is_empty() {
-        return Ok(QueryResult {
-            query_id: 0,
-            passage_ids: vec![],
-            scores: vec![],
-        });
-    }
-
-    // Compute exact scores. Binary indexes score against an int8 query; the
-    // full-precision query is used for the float (residual) path.
-    // Chunked processing limits concurrent memory from parallel decompression.
-    let exact_query = prepare_score_query(index, query);
-    let mut exact_scores: Vec<(i64, f32)> = to_decompress
-        .par_chunks(DECOMPRESS_CHUNK_SIZE)
-        .flat_map(|chunk| {
-            chunk
-                .iter()
-                .filter_map(|&doc_id| {
-                    let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
-                    Some((doc_id, score))
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    // Sort by exact score
-    exact_scores.sort_by(|a, b| cmp_score_descending(a.1, b.1));
-
-    // Return top-k results
-    let result_count = params.top_k.min(exact_scores.len());
-    let passage_ids: Vec<i64> = exact_scores
-        .iter()
-        .take(result_count)
-        .map(|(id, _)| *id)
-        .collect();
-    let scores: Vec<f32> = exact_scores
-        .iter()
-        .take(result_count)
-        .map(|(_, s)| *s)
-        .collect();
-
-    Ok(QueryResult {
-        query_id: 0,
-        passage_ids,
-        scores,
-    })
+    Ok(to_decompress)
 }
 
 /// Memory-efficient batched search for MmapIndex with large centroid counts.
@@ -737,6 +1008,68 @@ mod tests {
     use super::*;
 
     #[test]
+    fn par_cdot_bit_identical_to_dot() {
+        // LCG-filled query [7, 32] and centroids [5000, 32]: K > BLK so the
+        // parallel column-block path runs, and 5000 % 2048 != 0 exercises the
+        // ragged last block.
+        let mut s = 0x5EED_u64;
+        let mut next = move || {
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((s >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+        };
+        let query = Array2::from_shape_fn((7, 32), |_| next());
+        let centroids = Array2::from_shape_fn((5000, 32), |_| next());
+        let expect = query.dot(&centroids.t());
+        let got = par_cdot(&query, &centroids.view());
+        assert_eq!(expect.shape(), got.shape());
+        for (a, b) in expect.iter().zip(got.iter()) {
+            assert_eq!(a.to_bits(), b.to_bits());
+        }
+    }
+
+    #[test]
+    fn probe_scan_matches_partial_select() {
+        // Values quantized to coarse steps so ties are common — the scan and
+        // select_nth may pick different tied indices, but the top-k value
+        // multiset must match exactly, and every selected index must score
+        // >= the true n-th value.
+        let mut s = 0xA11CE_u64;
+        for &(k, n) in &[(5000usize, 8usize), (100, 8), (7, 8), (64, 3), (4096, 16)] {
+            let row: Vec<f32> = (0..k)
+                .map(|_| {
+                    s = s
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    ((s >> 40) as f32 / 256.0).floor() / 64.0
+                })
+                .collect();
+            let (mut ti, mut tv) = (Vec::new(), Vec::new());
+            probe_top_k_scan(&row, n, &mut ti, &mut tv);
+            let mut idx: Vec<u32> = (0..k as u32).collect();
+            let nn = n.min(k);
+            if k > nn {
+                idx.select_nth_unstable_by(nn - 1, |&a, &b| {
+                    cmp_score_descending(row[a as usize], row[b as usize])
+                });
+            }
+            let mut want: Vec<f32> = idx[..nn].iter().map(|&i| row[i as usize]).collect();
+            let mut got: Vec<f32> = tv.clone();
+            want.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            got.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(got.len(), nn, "k={k} n={n}");
+            for (a, b) in want.iter().zip(got.iter()) {
+                assert_eq!(a.to_bits(), b.to_bits(), "k={k} n={n}");
+            }
+            // Selected indices must actually hold their reported values.
+            for (&i, &v) in ti.iter().zip(tv.iter()) {
+                assert_eq!(row[i as usize].to_bits(), v.to_bits());
+            }
+        }
+    }
+
+    #[test]
     fn test_colbert_score() {
         // Query with 2 tokens, dim 4
         let query =
@@ -794,5 +1127,57 @@ mod tests {
         assert_eq!(max_score(1.0, f32::NAN), 1.0);
         assert_eq!(max_score(f32::INFINITY, 1.0), 1.0);
         assert_eq!(max_score(1.0, f32::INFINITY), 1.0);
+    }
+}
+
+#[cfg(test)]
+mod transpose_tests {
+    use super::*;
+
+    /// Naive centroid-major transpose — the reference the fused pass must
+    /// match. Test-only: production reads the quantized `QuantCdotT`.
+    fn naive_transpose(a: &Array2<f32>) -> Array2<f32> {
+        let (nq, k) = (a.nrows(), a.ncols());
+        Array2::from_shape_fn((k, nq), |(c, q)| a[[q, c]])
+    }
+
+    /// The centroid-major flood scorer must be bit-identical to the
+    /// row-major one: same per-query-token maxes, summed in the same
+    /// ascending query-token order.
+    #[test]
+    fn flood_t_matches_row_major() {
+        let mut seed = 0x5eed_u64;
+        let mut rnd = move || {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((seed >> 33) as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        for &(nq, k, ntok) in &[
+            (1usize, 16usize, 1usize),
+            (3, 64, 7),
+            (32, 4096, 180),
+            (32, 300, 500),
+        ] {
+            let cdot = Array2::<f32>::from_shape_fn((nq, k), |_| rnd());
+            let cdot_t = naive_transpose(&cdot);
+            let codes: Vec<i64> = (0..ntok).map(|i| ((i * 2654435761) % k) as i64).collect();
+            let want = approximate_score_mmap(&cdot, &codes);
+            let mut acc = vec![f32::NEG_INFINITY; nq];
+            let got = approximate_score_flood_t(&cdot_t, &codes, &mut acc);
+            assert_eq!(want.to_bits(), got.to_bits(), "nq={nq} k={k} ntok={ntok}");
+
+            // q8 rung: monotone quantization keeps per-lane maxes; the
+            // dequantized score is within nq * scale/2 of exact.
+            let qt = transpose_quantize_cdot(&cdot);
+            let codes32: Vec<u32> = codes.iter().map(|&c| c as u32).collect();
+            let got8 = approximate_score_flood_q8(&qt, &codes32);
+            let tol = nq as f32 * qt.scale + 1e-4; // floor quant: err < 1 LSB per lane
+            assert!(
+                (got8 - want).abs() <= tol,
+                "q8 off by {} > tol {tol} (nq={nq} k={k} ntok={ntok})",
+                (got8 - want).abs()
+            );
+        }
     }
 }

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -18,11 +18,6 @@ type ProbePartial = (
     HashMap<usize, f32>,
 );
 
-/// Maximum number of documents to decompress concurrently during exact scoring.
-/// This limits peak memory usage from parallel decompression.
-/// With 128 docs × ~300KB per doc = ~40MB max concurrent decompression memory.
-const DECOMPRESS_CHUNK_SIZE: usize = 128;
-
 /// Search parameters
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchParameters {
@@ -544,17 +539,17 @@ pub fn search_one_mmap(
     // Compute exact scores. Binary indexes score against an int8 query; the
     // full-precision query is used for the float (residual) path.
     let exact_query = prepare_score_query(index, query);
-    // Chunked processing limits concurrent memory from parallel decompression.
+    // Per-doc parallelism: rayon splits adaptively, so all cores stay fed
+    // and variable doc lengths balance. The fixed 128-doc chunking this
+    // replaces served a decompression-memory rationale that no longer holds:
+    // in-flight decompressed docs are bounded by the thread count either
+    // way, and the chunk count (8 at n_decompress = 1024) underfilled and
+    // straggled the pool — measured 6.1 effective threads on a 10-core M4.
     let mut exact_scores: Vec<(i64, f32)> = to_decompress
-        .par_chunks(DECOMPRESS_CHUNK_SIZE)
-        .flat_map(|chunk| {
-            chunk
-                .iter()
-                .filter_map(|&doc_id| {
-                    let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
-                    Some((doc_id, score))
-                })
-                .collect::<Vec<_>>()
+        .par_iter()
+        .filter_map(|&doc_id| {
+            let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
+            Some((doc_id, score))
         })
         .collect();
 
@@ -929,16 +924,17 @@ fn search_one_mmap_batched(
     // full-precision query is used for the float (residual) path.
     // Chunked processing limits concurrent memory from parallel decompression.
     let exact_query = prepare_score_query(index, query);
+    // Per-doc parallelism: rayon splits adaptively, so all cores stay fed
+    // and variable doc lengths balance. The fixed 128-doc chunking this
+    // replaces served a decompression-memory rationale that no longer holds:
+    // in-flight decompressed docs are bounded by the thread count either
+    // way, and the chunk count (8 at n_decompress = 1024) underfilled and
+    // straggled the pool — measured 6.1 effective threads on a 10-core M4.
     let mut exact_scores: Vec<(i64, f32)> = to_decompress
-        .par_chunks(DECOMPRESS_CHUNK_SIZE)
-        .flat_map(|chunk| {
-            chunk
-                .iter()
-                .filter_map(|&doc_id| {
-                    let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
-                    Some((doc_id, score))
-                })
-                .collect::<Vec<_>>()
+        .par_iter()
+        .filter_map(|&doc_id| {
+            let score = exact_doc_score(index, &exact_query, doc_id as usize)?;
+            Some((doc_id, score))
         })
         .collect();
 

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -473,7 +473,7 @@ fn transpose_quantize_cdot(cdot: &Array2<f32>) -> Option<QuantCdotT> {
 /// handling. Doc codes are re-read once per chunk (≤ 2 passes at nq ≤ 32;
 /// they are L1-hot on the second). Pad lanes hold quantized 0 everywhere,
 /// so they stay 0 through `max` and add nothing to the lane sum.
-fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[u32]) -> f32 {
+fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[i64]) -> f32 {
     let stride = qt.stride;
     let q = qt.q.as_slice();
     let mut sum: u32 = 0;
@@ -488,6 +488,22 @@ fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[u32]) -> f32 {
         sum += m.iter().map(|&x| x as u32).sum::<u32>();
     }
     qt.lo_sum + qt.scale * sum as f32
+}
+
+/// Score one document directly from the file-backed code mapping. Normal NPY
+/// files take the zero-copy branch; the owned fallback keeps unusual unaligned
+/// or big-endian mappings correct without retaining an index-sized cache.
+fn approximate_score_flood_q8_mmap(
+    qt: &QuantCdotT,
+    codes: &crate::mmap::MmapNpyArray1I64,
+    start: usize,
+    end: usize,
+) -> f32 {
+    if let Some(all_codes) = codes.as_slice() {
+        approximate_score_flood_q8(qt, &all_codes[start..end])
+    } else {
+        approximate_score_flood_q8(qt, &codes.slice(start, end))
+    }
 }
 
 /// Compute approximate scores for mmap index using code lookups.
@@ -813,8 +829,6 @@ fn stage1_shortlist(
     // flood's finite-first behavior for that matrix instead.
     let mut approx_scores: Vec<(i64, f32)> =
         if let Some(qt) = transpose_quantize_cdot(&query_centroid_scores) {
-            // u32 code side-array: 4 B/token reads instead of the mmap's 8.
-            let codes_all = index.codes_u32();
             candidates
                 .par_iter()
                 .map(|&doc_id| {
@@ -822,7 +836,7 @@ fn stage1_shortlist(
                     let end = index.doc_offsets[doc_id as usize + 1];
                     (
                         doc_id,
-                        approximate_score_flood_q8(&qt, &codes_all[start..end]),
+                        approximate_score_flood_q8_mmap(&qt, &index.mmap_codes, start, end),
                     )
                 })
                 .collect()
@@ -1213,8 +1227,7 @@ mod transpose_tests {
             // q8 rung: monotone quantization keeps per-lane maxes; the
             // dequantized score is within nq * scale/2 of exact.
             let qt = transpose_quantize_cdot(&cdot).expect("finite cdot");
-            let codes32: Vec<u32> = codes.iter().map(|&c| c as u32).collect();
-            let got8 = approximate_score_flood_q8(&qt, &codes32);
+            let got8 = approximate_score_flood_q8(&qt, &codes);
             let tol = nq as f32 * qt.scale + 1e-4; // floor quant: err < 1 LSB per lane
             assert!(
                 (got8 - want).abs() <= tol,

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -404,8 +404,10 @@ struct QuantCdotT {
 }
 
 /// One fused pass: blocked transpose + u8 quantization of the `[nq, K]`
-/// score matrix.
-fn transpose_quantize_cdot(cdot: &Array2<f32>) -> QuantCdotT {
+/// score matrix. Returns `None` when any score is non-finite so the caller can
+/// preserve the previous f32 flood's finite-first ordering instead of letting
+/// one infinity collapse the global quantization scale.
+fn transpose_quantize_cdot(cdot: &Array2<f32>) -> Option<QuantCdotT> {
     const BLK: usize = 64;
     let (nq, k) = (cdot.nrows(), cdot.ncols());
     let src = cdot.as_standard_layout();
@@ -413,20 +415,25 @@ fn transpose_quantize_cdot(cdot: &Array2<f32>) -> QuantCdotT {
     // Parallel min/max prepass — chunk-local reductions are exact, and
     // min/max is order-independent, so lo/hi are bit-identical to a
     // sequential scan.
-    let (lo, hi) = src
+    let (lo, hi, all_finite) = src
         .par_chunks(1 << 16)
         .map(|c| {
             let (mut l, mut h) = (f32::INFINITY, f32::NEG_INFINITY);
+            let mut finite = true;
             for &v in c {
+                finite &= v.is_finite();
                 l = l.min(v);
                 h = h.max(v);
             }
-            (l, h)
+            (l, h, finite)
         })
         .reduce(
-            || (f32::INFINITY, f32::NEG_INFINITY),
-            |a, b| (a.0.min(b.0), a.1.max(b.1)),
+            || (f32::INFINITY, f32::NEG_INFINITY, true),
+            |a, b| (a.0.min(b.0), a.1.max(b.1), a.2 && b.2),
         );
+    if !all_finite {
+        return None;
+    }
     let scale = if hi > lo { (hi - lo) / 255.0 } else { 1.0 };
     let inv = 1.0 / scale;
     let stride = nq.div_ceil(16) * 16;
@@ -449,12 +456,12 @@ fn transpose_quantize_cdot(cdot: &Array2<f32>) -> QuantCdotT {
                 }
             }
         });
-    QuantCdotT {
+    Some(QuantCdotT {
         q,
         stride,
         lo_sum: nq as f32 * lo,
         scale,
-    }
+    })
 }
 
 /// u8 flood scorer over the quantized centroid-major matrix.
@@ -487,7 +494,6 @@ fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[u32]) -> f32 {
 ///
 /// The row-major scorer the quantized flood replaced; retained as the
 /// reference implementation for the flood's bit-identity test.
-#[cfg(test)]
 fn approximate_score_mmap(query_centroid_scores: &Array2<f32>, doc_codes: &[i64]) -> f32 {
     let mut score = 0.0;
 
@@ -610,7 +616,7 @@ fn par_cdot(query: &Array2<f32>, centroids: &ArrayView2<f32>) -> Array2<f32> {
 fn argmin_f32(vals: &[f32]) -> usize {
     let mut w = 0;
     for i in 1..vals.len() {
-        if vals[i] < vals[w] {
+        if cmp_score_ascending(vals[i], vals[w]).is_lt() {
             w = i;
         }
     }
@@ -621,21 +627,24 @@ fn argmin_f32(vals: &[f32]) -> usize {
 /// Per 64-wide chunk the max is a plain reduction (autovectorizes on every
 /// platform); the chunk is skipped unless its max beats the current n-th
 /// best, so the scalar rescan almost never runs. Same top-k set by value as
-/// `select_nth_unstable`; tie choice is arbitrary in both. NaN never wins a
-/// `v > thr` comparison, matching `cmp_score_descending`'s NaN-last order.
+/// `select_nth_unstable`; tie choice is arbitrary in both. All non-finite
+/// values rank below finite scores, matching `cmp_score_descending`.
 fn probe_top_k_scan(row: &[f32], n: usize, top_idx: &mut Vec<u32>, top_val: &mut Vec<f32>) {
     const PROBE_CHUNK: usize = 64;
     top_idx.clear();
     top_val.clear();
     let n = n.min(row.len());
+    if n == 0 {
+        return;
+    }
     let mut thr = f32::NEG_INFINITY;
     let mut worst = 0usize;
     for (ci, chunk) in row.chunks(PROBE_CHUNK).enumerate() {
         let mut m = f32::NEG_INFINITY;
         for &v in chunk {
-            m = m.max(v);
+            m = max_score(m, v);
         }
-        if top_val.len() == n && m <= thr {
+        if top_val.len() == n && !is_score_better(m, thr) {
             continue;
         }
         let base = (ci * PROBE_CHUNK) as u32;
@@ -647,7 +656,7 @@ fn probe_top_k_scan(row: &[f32], n: usize, top_idx: &mut Vec<u32>, top_val: &mut
                     worst = argmin_f32(top_val);
                     thr = top_val[worst];
                 }
-            } else if v > thr {
+            } else if is_score_better(v, thr) {
                 top_idx[worst] = base + j as u32;
                 top_val[worst] = v;
                 worst = argmin_f32(top_val);
@@ -797,21 +806,40 @@ fn stage1_shortlist(
         return Ok(vec![]);
     }
 
-    // Compute approximate scores: the quantized centroid-major flood.
-    let qt = transpose_quantize_cdot(&query_centroid_scores);
-    // u32 code side-array: 4 B/token reads instead of the mmap's 8.
-    let codes_all = index.codes_u32();
-    let mut approx_scores: Vec<(i64, f32)> = candidates
-        .par_iter()
-        .map(|&doc_id| {
-            let start = index.doc_offsets[doc_id as usize];
-            let end = index.doc_offsets[doc_id as usize + 1];
-            (
-                doc_id,
-                approximate_score_flood_q8(&qt, &codes_all[start..end]),
-            )
-        })
-        .collect();
+    // Compute approximate scores. Non-finite centroid scores are rare (for
+    // example, an otherwise finite but extreme caller-provided query can
+    // overflow the GEMM), but one infinity would make the global u8 scale
+    // infinite and collapse every quantized value. Preserve the previous f32
+    // flood's finite-first behavior for that matrix instead.
+    let mut approx_scores: Vec<(i64, f32)> =
+        if let Some(qt) = transpose_quantize_cdot(&query_centroid_scores) {
+            // u32 code side-array: 4 B/token reads instead of the mmap's 8.
+            let codes_all = index.codes_u32();
+            candidates
+                .par_iter()
+                .map(|&doc_id| {
+                    let start = index.doc_offsets[doc_id as usize];
+                    let end = index.doc_offsets[doc_id as usize + 1];
+                    (
+                        doc_id,
+                        approximate_score_flood_q8(&qt, &codes_all[start..end]),
+                    )
+                })
+                .collect()
+        } else {
+            candidates
+                .par_iter()
+                .map(|&doc_id| {
+                    let start = index.doc_offsets[doc_id as usize];
+                    let end = index.doc_offsets[doc_id as usize + 1];
+                    let codes = index.mmap_codes.slice(start, end);
+                    (
+                        doc_id,
+                        approximate_score_mmap(&query_centroid_scores, &codes),
+                    )
+                })
+                .collect()
+        };
 
     // Partial-select the top n_full_scores, then sort only that prefix —
     // the flood is ~5x larger than what survives, and O(n) select + O(m log m)
@@ -1066,6 +1094,25 @@ mod tests {
     }
 
     #[test]
+    fn probe_scan_demotes_non_finite_scores() {
+        let row = [
+            f32::NAN,
+            f32::INFINITY,
+            4.0,
+            f32::NEG_INFINITY,
+            1.0,
+            3.0,
+            2.0,
+        ];
+        let (mut top_idx, mut top_val) = (Vec::new(), Vec::new());
+        probe_top_k_scan(&row, 3, &mut top_idx, &mut top_val);
+
+        top_val.sort_by(|a, b| a.total_cmp(b));
+        assert_eq!(top_val, vec![2.0, 3.0, 4.0]);
+        assert!(top_idx.iter().all(|&i| row[i as usize].is_finite()));
+    }
+
+    #[test]
     fn test_colbert_score() {
         // Query with 2 tokens, dim 4
         let query =
@@ -1165,7 +1212,7 @@ mod transpose_tests {
 
             // q8 rung: monotone quantization keeps per-lane maxes; the
             // dequantized score is within nq * scale/2 of exact.
-            let qt = transpose_quantize_cdot(&cdot);
+            let qt = transpose_quantize_cdot(&cdot).expect("finite cdot");
             let codes32: Vec<u32> = codes.iter().map(|&c| c as u32).collect();
             let got8 = approximate_score_flood_q8(&qt, &codes32);
             let tol = nq as f32 * qt.scale + 1e-4; // floor quant: err < 1 LSB per lane
@@ -1174,6 +1221,14 @@ mod transpose_tests {
                 "q8 off by {} > tol {tol} (nq={nq} k={k} ntok={ntok})",
                 (got8 - want).abs()
             );
+        }
+    }
+
+    #[test]
+    fn quantized_flood_rejects_non_finite_scores() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let cdot = Array2::from_shape_vec((1, 3), vec![0.5, bad, -0.5]).unwrap();
+            assert!(transpose_quantize_cdot(&cdot).is_none());
         }
     }
 }

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -750,7 +750,9 @@ fn stage1_shortlist(
             };
             scaled.max(params.n_ivf_probe).min(eligible.len())
         }
-        _ => params.n_ivf_probe,
+        // An oversized value means "probe every cell": clamp before it is
+        // trusted to size the probe scratch below.
+        _ => params.n_ivf_probe.min(num_centroids),
     };
 
     // Find top IVF cells to probe using per-token top-k selection.
@@ -1138,6 +1140,52 @@ mod tests {
         top_val.sort_by(|a, b| a.total_cmp(b));
         assert_eq!(top_val, vec![2.0, 3.0, 4.0]);
         assert!(top_idx.iter().all(|&i| row[i as usize].is_finite()));
+    }
+
+    /// An oversized n_ivf_probe means "probe every cell" (accepted by every
+    /// release through v1.6.5, and reachable unclamped through colgrep's
+    /// COLGREP_N_IVF_PROBE); it must be clamped before sizing the probe
+    /// scratch, not fed to Vec::with_capacity as-is.
+    #[test]
+    fn oversized_n_ivf_probe_probes_everything() {
+        let mut s = 0xFEED_u64;
+        let mut next = move || {
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((s >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+        };
+        let docs: Vec<Array2<f32>> = (0..40)
+            .map(|_| {
+                let mut d = Array2::from_shape_fn((6, 16), |_| next());
+                for mut row in d.rows_mut() {
+                    let n = row.dot(&row).sqrt().max(1e-12);
+                    row /= n;
+                }
+                d
+            })
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let config = crate::IndexConfig {
+            nbits: 4,
+            seed: Some(42),
+            ..Default::default()
+        };
+        let index = crate::index::MmapIndex::create_with_kmeans(
+            &docs,
+            dir.path().to_str().unwrap(),
+            &config,
+        )
+        .unwrap();
+        let params = SearchParameters {
+            top_k: 5,
+            n_full_scores: 32,
+            n_ivf_probe: usize::MAX / 2,
+            centroid_score_threshold: None,
+            ..Default::default()
+        };
+        let result = index.search(&docs[2], &params, None).unwrap();
+        assert!(!result.passage_ids.is_empty());
     }
 
     #[test]

--- a/next-plaid/src/search.rs
+++ b/next-plaid/src/search.rs
@@ -491,8 +491,8 @@ fn approximate_score_flood_q8(qt: &QuantCdotT, doc_codes: &[i64]) -> f32 {
 }
 
 /// Score one document directly from the file-backed code mapping. Normal NPY
-/// files take the zero-copy branch; the owned fallback keeps unusual unaligned
-/// or big-endian mappings correct without retaining an index-sized cache.
+/// files take the zero-copy branch. Unaligned maps decode each code directly
+/// from the mmap rather than allocating an owned per-document fallback.
 fn approximate_score_flood_q8_mmap(
     qt: &QuantCdotT,
     codes: &crate::mmap::MmapNpyArray1I64,
@@ -502,7 +502,21 @@ fn approximate_score_flood_q8_mmap(
     if let Some(all_codes) = codes.as_slice() {
         approximate_score_flood_q8(qt, &all_codes[start..end])
     } else {
-        approximate_score_flood_q8(qt, &codes.slice(start, end))
+        let stride = qt.stride;
+        let q = qt.q.as_slice();
+        let mut sum: u32 = 0;
+        for c0 in (0..stride).step_by(16) {
+            let mut m = [0u8; 16];
+            for idx in start..end {
+                let code = codes.get(idx) as usize;
+                let row = &q[code * stride + c0..code * stride + c0 + 16];
+                for i in 0..16 {
+                    m[i] = m[i].max(row[i]);
+                }
+            }
+            sum += m.iter().map(|&x| x as u32).sum::<u32>();
+        }
+        qt.lo_sum + qt.scale * sum as f32
     }
 }
 


### PR DESCRIPTION
Stage 1 and stage 2 are the two halves of a PLAID query. #169 rewrites the
stage-2 rescore; this PR rewrites stage 1. Together they take end-to-end search
**7.03x geomean** faster than v1.6.5 — 6.59x on x86 AVX2, 7.08x on Neoverse,
7.46x on macOS arm64, over the same 18 cells measured below.

**This PR stands alone.** It applies directly to v1.6.5, needs nothing from
#169, and is worth **1.30x geomean end-to-end on its own** (1.14–1.42x by platform) — the two can
land in either order.

## What

Stage 1 — everything a query pays before exact scoring — rebuilt phase by
phase, plus per-doc parallelism in the exact-scoring loop. Default-on: no new
parameters, no storage or API change. Every phase change ships with an
equivalence test against the path it replaces.

- **centroid GEMM**: column-block-parallel; the dim-long reduction stays inside
  one block, so the output is **bit-identical** to the single `dot` call
  (tested).
- **IVF probe**: running-threshold chunk scan replaces a K-length buffer fill +
  `select_nth` per query token — one sequential read per row, and chunks that
  can't beat the current k-th value are skipped on one predictable branch. Same
  top-k set by value (tested under ties).
- **candidate gather**: doc ids are dense, so a word bitmap dedups in
  O(postings) and scanning its set bits emits the same sorted list the old
  sort+dedup produced, without the sort.
- **approximate flood**: centroid scores are quantized to u8 in a fused
  transpose+quantize pass (PLAID's own centroid-interaction trick) and scored
  chunk-outer with a register-resident 16-lane max accumulator. The quantization
  is monotone per lane (u8 max = f32 max); the flood only ranks a 4096-deep
  prune cut. Gated on quality, not just kernel math: deployed nDCG@10 identical
  **to four decimals** vs exact flooding on real-embedding corpora (NFCorpus +
  SciFact, r4/r2/r1 and binary).
- **prune**: partial-select the surviving `n_full_scores` before sorting only
  that prefix; identical top list and order.
- **code reads**: a lazily-built u32 side-array of the token codes, so the flood
  reads 4 B/token instead of the mmap's 8. Built once on first search — the same
  lazy-derived-data pattern the index already uses.
- **exact scoring**: plain per-doc `par_iter` replaces fixed 128-doc chunking.
  The chunking's memory rationale no longer holds (in-flight decompressed docs
  are bounded by the thread count either way) and 8 chunks at n_decompress =
  1024 underfilled the pool — 6.1 effective threads measured on a 10-core M4;
  9.4 after.

## Measured

Interleaved same-box A/B against a v1.6.5 checkout with the same bench example
grafted in, identical prebuilt indexes, alternating main/ours per cell so
shared-runner drift hits both variants alike. 2 datasets x nbits 4/2/1 on each
of the three CI runner platforms (18 cells). Run on this branch as it stands,
with no part of #169 present:

| platform | stage 1 | end-to-end |
|---|---|---|
| x86 AVX2 (ubuntu-latest) | **4.78x** (4.72–4.85) | 1.14x |
| Neoverse (ubuntu-24.04-arm) | **8.39x** (6.45–10.75) | 1.35x |
| macOS arm64 | **7.31x** (7.00–8.04) | 1.42x |
| **all 18 cells** | **6.64x** (4.72–10.75) | **1.30x** (1.08–1.64) |

Geomeans. Absolutes on a shared runner are noise; the per-platform ratios are
the verdict. The same harness run against the stacked #169 + #170 tree
puts this PR's stage-1-only contribution at 1.13x / 1.33x / 1.50x on the three
platforms — reproducing the isolated numbers above (1.14x / 1.35x / 1.42x) from
a different tree, and giving the 7.03x combined figure quoted at the top. Server parts pay more for the scatter this removes than Apple's L2
does — which is why the native-M4 figure below is the conservative one.

Native Apple M4, SciFact 5,183 docs / 16,384 centroids / nbits 4, all 300 real
queries, timing the same span on both sides (cdot + probe + gather + flood +
prune):

| | stage 1 median |
|---|---|
| v1.6.5 | 6.649 ms |
| this branch | **1.693 ms** |
| | **3.93x** |

The biggest per-phase ratio (probe, 9.5x) is deliberately not the headline:
phase speedups compose by time share, and the flood + GEMM dominated. Per-phase
tables and the full exploration ledger (including the ideas measured and killed)
live on the research branch `feat/asymmetric-lut-residual`.

## Ranking

All 300 real SciFact queries return **identical top-10 ids, identical order, and
identical scores** vs v1.6.5 on a real-embedding index.

To be precise about what is and isn't guaranteed: five of the six phases are
exact-equivalent by construction and tested as such. The flood is not — it is
quantized, so its guarantee is nDCG parity (identical to four decimals), not
bit-identity. Where the quantization step is large relative to the gaps between
candidates, near-ties can reorder.

That shows up in the CI harness above, which drives *synthetic* indexes with
random unit-row queries: there roughly half the per-query digests differ between
the two builds (145 identical / 155 differing across 300 comparisons). Random
queries in 128-d are near-orthogonal to every centroid, so their scores cluster
inside a single quantization bucket and the ordering among them is arbitrary.
Real queries have score spread far above the quantization step, which is why the
300/300 result holds on real data. Worth knowing before reading the harness's
digests as a correctness signal — they are not one for this change.

Full suite: 205 tests green, `clippy -D warnings` and `cargo fmt --check` clean
on **each commit individually**.

## Relationship to #169

#169 is the stage-2 counterpart and the source of the combined figure above.
They are otherwise independent: this PR adds no scoring path and no public API
beyond a `codes_u32()` accessor, and #169 needs nothing from here.

One optimization was deliberately left out to keep this PR self-contained: when
#169's asymmetric arm is on, the flood's transpose pass can also emit the f32
centroid-major matrix stage 2 wants, so one traversal serves both stages. That
fusion only fires when `residual_asym` is set, so it is worth nothing here — it
belongs in whichever of the two PRs lands second.
