### PR TITLE
fix(init): cover excluded subdirectories in the parent index when explicitly initialized

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -250,6 +250,16 @@ EXAMPLES:
     # Clear all force-include patterns
     colgrep settings --clear-force-include
 
+    # Index a directory the project's ignore rules exclude (e.g. a gitignored
+    # corpus); equivalent to running `colgrep init ./corpus`
+    colgrep settings --cover ./corpus
+
+    # Stop indexing a covered subdirectory
+    colgrep settings --no-cover ./corpus
+
+    # Clear all covered-subdirectory registrations (all projects)
+    colgrep settings --clear-cover
+
     # Show absolute paths in search output
     colgrep settings --no-relative-paths
 
@@ -765,5 +775,22 @@ pub enum Commands {
         /// Clear all force-include patterns
         #[arg(long = "clear-force-include")]
         clear_force_include: bool,
+
+        /// Register a covered subdirectory: index it as part of its enclosing
+        /// indexed project even though that project's ignore rules exclude it
+        /// (same effect as running `colgrep init` on the directory). Can be repeated.
+        #[arg(long = "cover", value_name = "PATH")]
+        add_cover: Vec<String>,
+
+        /// Stop indexing a covered subdirectory (registered with --cover or by
+        /// `colgrep init` on a directory the project's ignore rules exclude). Takes
+        /// the directory path; its files leave the parent index on its next update.
+        /// Can be repeated.
+        #[arg(long = "no-cover", value_name = "PATH")]
+        remove_cover: Vec<String>,
+
+        /// Clear all covered-subdirectory registrations (all projects)
+        #[arg(long = "clear-cover")]
+        clear_cover: bool,
     },
 }

--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -241,24 +241,20 @@ EXAMPLES:
     # Clear all extra ignore patterns (revert to defaults only)
     colgrep settings --clear-ignore
 
-    # Force-include files/dirs that are normally ignored
+    # Force-include a directory the project's ignore rules exclude (e.g. a
+    # gitignored corpus); equivalent to running `colgrep init ./corpus`
+    colgrep settings --force-include ./corpus
+
+    # Force-include by pattern (global, applies to every project's walk;
+    # patterns cannot override .gitignore — use a directory path for that)
     colgrep settings --force-include .vscode --force-include vendor/internal
 
-    # Remove a force-include pattern
+    # Remove a force-include (directory registration or pattern)
+    colgrep settings --no-force-include ./corpus
     colgrep settings --no-force-include .vscode
 
-    # Clear all force-include patterns
+    # Clear all force-include patterns and directory registrations
     colgrep settings --clear-force-include
-
-    # Index a directory the project's ignore rules exclude (e.g. a gitignored
-    # corpus); equivalent to running `colgrep init ./corpus`
-    colgrep settings --cover ./corpus
-
-    # Stop indexing a covered subdirectory
-    colgrep settings --no-cover ./corpus
-
-    # Clear all covered-subdirectory registrations (all projects)
-    colgrep settings --clear-cover
 
     # Show absolute paths in search output
     colgrep settings --no-relative-paths
@@ -758,39 +754,27 @@ pub enum Commands {
         #[arg(long = "no-ignore", value_name = "PATTERN")]
         remove_ignore: Vec<String>,
 
-        /// Add patterns to force-include even if normally ignored
-        /// Can be repeated. Examples: --force-include .vscode --force-include vendor/internal
-        #[arg(long = "force-include", value_name = "PATTERN")]
+        /// Force-include something the ignore rules exclude. An existing directory
+        /// inside an indexed project is registered for that project and indexed on
+        /// its next update — the only form that overrides .gitignore (`colgrep init
+        /// <dir>` does the same). Anything else is a global pattern applied to every
+        /// project's walk. Can be repeated.
+        /// Examples: --force-include ./corpus --force-include "*.gen.go"
+        #[arg(long = "force-include", value_name = "PATTERN_OR_DIR")]
         add_force_include: Vec<String>,
 
-        /// Remove patterns from the force-include list
-        /// Can be repeated. Examples: --no-force-include .vscode
-        #[arg(long = "no-force-include", value_name = "PATTERN")]
+        /// Remove a force-include registration: a directory path unregisters that
+        /// project's directory (its files leave the index on the next update),
+        /// anything else is removed from the global pattern list. Can be repeated.
+        #[arg(long = "no-force-include", value_name = "PATTERN_OR_DIR")]
         remove_force_include: Vec<String>,
 
         /// Clear all custom ignore patterns (revert to defaults only)
         #[arg(long = "clear-ignore")]
         clear_ignore: bool,
 
-        /// Clear all force-include patterns
+        /// Clear all force-include patterns and directory registrations
         #[arg(long = "clear-force-include")]
         clear_force_include: bool,
-
-        /// Register a covered subdirectory: index it as part of its enclosing
-        /// indexed project even though that project's ignore rules exclude it
-        /// (same effect as running `colgrep init` on the directory). Can be repeated.
-        #[arg(long = "cover", value_name = "PATH")]
-        add_cover: Vec<String>,
-
-        /// Stop indexing a covered subdirectory (registered with --cover or by
-        /// `colgrep init` on a directory the project's ignore rules exclude). Takes
-        /// the directory path; its files leave the parent index on its next update.
-        /// Can be repeated.
-        #[arg(long = "no-cover", value_name = "PATH")]
-        remove_cover: Vec<String>,
-
-        /// Clear all covered-subdirectory registrations (all projects)
-        #[arg(long = "clear-cover")]
-        clear_cover: bool,
     },
 }

--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 
 use colgrep::{
@@ -123,6 +125,9 @@ pub fn cmd_config(
     remove_force_include: Vec<String>,
     clear_ignore: bool,
     clear_force_include: bool,
+    add_cover: Vec<String>,
+    remove_cover: Vec<String>,
+    clear_cover: bool,
 ) -> Result<()> {
     let mut config = Config::load()?;
 
@@ -131,7 +136,10 @@ pub fn cmd_config(
         || !add_force_include.is_empty()
         || !remove_force_include.is_empty()
         || clear_ignore
-        || clear_force_include;
+        || clear_force_include
+        || !add_cover.is_empty()
+        || !remove_cover.is_empty()
+        || clear_cover;
 
     // If no options provided, show current config
     if default_k.is_none()
@@ -271,6 +279,18 @@ pub fn cmd_config(
             println!("  force-incl:  {}", fi.join(", "));
         }
 
+        // Covered subdirectories (registered by `colgrep init` on excluded dirs)
+        if config.covered_subdirs.is_empty() {
+            println!("  covered:     (none)");
+        } else {
+            println!("  covered:");
+            for (root, subs) in &config.covered_subdirs {
+                for sub in subs {
+                    println!("               {}", Path::new(root).join(sub).display());
+                }
+            }
+        }
+
         println!();
         println!("Use --k or --n to set values. Use 0 to reset to default.");
         println!("Use --fp32 or --int8 to change model precision.");
@@ -288,6 +308,7 @@ pub fn cmd_config(
         );
         println!("Use --ignore/--no-ignore to add/remove extra ignore patterns. --clear-ignore to reset.");
         println!("Use --force-include/--no-force-include to add/remove force-include patterns. --clear-force-include to reset.");
+        println!("Use --cover/--no-cover to add/remove covered subdirectories (indexed despite the project's ignore rules; `colgrep init <dir>` also registers). --clear-cover to reset.");
         return Ok(());
     }
 
@@ -503,11 +524,120 @@ pub fn cmd_config(
         changed = true;
     }
 
+    // Handle covered subdirectories
+    if clear_cover {
+        config.clear_covered_subdirs();
+        println!("✅ Cleared all covered-subdirectory registrations");
+        changed = true;
+    }
+    for raw in &add_cover {
+        let abs = resolve_cover_path(raw);
+        if !abs.is_dir() {
+            println!("⚠️  Not a directory: {}", abs.display());
+            continue;
+        }
+        match find_enclosing_project(&abs) {
+            Some((root, rel)) => {
+                if config.add_covered_subdir(&root, &rel) {
+                    println!(
+                        "✅ Covering {} under project {}",
+                        rel.display(),
+                        root.display()
+                    );
+                    println!(
+                        "   Its files are indexed on the project's next update (e.g. colgrep init {}).",
+                        root.display()
+                    );
+                } else {
+                    println!("✅ Already covered: {}", abs.display());
+                }
+                changed = true;
+            }
+            None => {
+                println!(
+                    "⚠️  No indexed project contains {}; index the project first with colgrep init",
+                    abs.display()
+                );
+            }
+        }
+    }
+    for raw in &remove_cover {
+        let abs = resolve_cover_path(raw);
+        if remove_covered_path(&mut config, &abs) {
+            println!("✅ Stopped covering: {}", abs.display());
+            println!("   Its files leave the parent index on its next update.");
+        } else {
+            println!(
+                "⚠️  No covered subdirectory registered for: {}",
+                abs.display()
+            );
+        }
+        changed = true;
+    }
+
     if changed {
         config.save()?;
     }
 
     Ok(())
+}
+
+/// Absolutize a `--no-cover` argument. Prefer canonicalization so the path
+/// matches the canonical roots coverage is keyed by; a directory that no
+/// longer exists falls back to a lexical join with the working directory.
+fn resolve_cover_path(raw: &str) -> PathBuf {
+    std::fs::canonicalize(raw).unwrap_or_else(|_| {
+        let path = Path::new(raw);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+    })
+}
+
+/// Resolve a `--cover` argument to (project root, root-relative subdir) against
+/// every indexed project, preferring the deepest containing root. Deliberately
+/// model-agnostic: coverage is a property of the project, not of one model's
+/// index, so every model's scan honors it.
+fn find_enclosing_project(abs: &Path) -> Option<(PathBuf, PathBuf)> {
+    let data_dir = colgrep::get_colgrep_data_dir().ok()?;
+    let mut best: Option<(PathBuf, PathBuf)> = None;
+    let mut best_depth = 0;
+    for entry in std::fs::read_dir(&data_dir).ok()?.filter_map(|e| e.ok()) {
+        let index_dir = entry.path();
+        if !index_dir.is_dir() {
+            continue;
+        }
+        if let Ok(meta) = colgrep::ProjectMetadata::load(&index_dir) {
+            if abs == meta.project_path {
+                continue; // the project root itself needs no coverage
+            }
+            if let Ok(rel) = abs.strip_prefix(&meta.project_path) {
+                let depth = meta.project_path.components().count();
+                if depth > best_depth {
+                    best_depth = depth;
+                    best = Some((meta.project_path, rel.to_path_buf()));
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Remove the coverage registration `abs` points into, matching it against
+/// every registered project root.
+fn remove_covered_path(config: &mut Config, abs: &Path) -> bool {
+    let roots: Vec<String> = config.covered_subdirs.keys().cloned().collect();
+    let mut removed = false;
+    for root in roots {
+        if let Ok(rel) = abs.strip_prefix(Path::new(&root)) {
+            removed |= config.remove_covered_subdir(Path::new(&root), rel);
+        }
+    }
+    removed
 }
 
 #[cfg(test)]

--- a/colgrep/src/commands/config.rs
+++ b/colgrep/src/commands/config.rs
@@ -125,9 +125,6 @@ pub fn cmd_config(
     remove_force_include: Vec<String>,
     clear_ignore: bool,
     clear_force_include: bool,
-    add_cover: Vec<String>,
-    remove_cover: Vec<String>,
-    clear_cover: bool,
 ) -> Result<()> {
     let mut config = Config::load()?;
 
@@ -136,10 +133,7 @@ pub fn cmd_config(
         || !add_force_include.is_empty()
         || !remove_force_include.is_empty()
         || clear_ignore
-        || clear_force_include
-        || !add_cover.is_empty()
-        || !remove_cover.is_empty()
-        || clear_cover;
+        || clear_force_include;
 
     // If no options provided, show current config
     if default_k.is_none()
@@ -273,20 +267,17 @@ pub fn cmd_config(
 
         // Force-include patterns
         let fi = config.get_force_include();
-        if fi.is_empty() {
+        if fi.is_empty() && config.force_include_dirs.is_empty() {
             println!("  force-incl:  (none)");
         } else {
-            println!("  force-incl:  {}", fi.join(", "));
-        }
-
-        // Covered subdirectories (registered by `colgrep init` on excluded dirs)
-        if config.covered_subdirs.is_empty() {
-            println!("  covered:     (none)");
-        } else {
-            println!("  covered:");
-            for (root, subs) in &config.covered_subdirs {
+            if !fi.is_empty() {
+                println!("  force-incl:  {}", fi.join(", "));
+            }
+            // Per-project directory registrations (`colgrep init` on an
+            // excluded dir, or `--force-include <dir>`)
+            for (root, subs) in &config.force_include_dirs {
                 for sub in subs {
-                    println!("               {}", Path::new(root).join(sub).display());
+                    println!("  force-incl:  {}", Path::new(root).join(sub).display());
                 }
             }
         }
@@ -307,8 +298,7 @@ pub fn cmd_config(
             "Use --alpha to set hybrid search balance (0=keyword, 1=semantic). Use 0 to reset."
         );
         println!("Use --ignore/--no-ignore to add/remove extra ignore patterns. --clear-ignore to reset.");
-        println!("Use --force-include/--no-force-include to add/remove force-include patterns. --clear-force-include to reset.");
-        println!("Use --cover/--no-cover to add/remove covered subdirectories (indexed despite the project's ignore rules; `colgrep init <dir>` also registers). --clear-cover to reset.");
+        println!("Use --force-include/--no-force-include to add/remove force-includes: an existing directory registers per-project (overrides .gitignore), anything else is a global pattern. --clear-force-include to reset.");
         return Ok(());
     }
 
@@ -504,73 +494,57 @@ pub fn cmd_config(
         changed = true;
     }
 
-    // Handle force-include patterns
+    // Handle force-includes. An argument that resolves to an existing directory
+    // inside an indexed project registers per-project (the only form that
+    // overrides .gitignore); anything else is a global walk pattern.
     if clear_force_include {
         config.clear_force_include();
-        println!("✅ Cleared all force-include patterns");
+        config.clear_force_include_dirs();
+        println!("✅ Cleared all force-include patterns and directory registrations");
         changed = true;
     }
-    for pattern in &add_force_include {
-        config.add_force_include(pattern);
-        println!("✅ Added force-include pattern: {}", pattern);
-        changed = true;
-    }
-    for pattern in &remove_force_include {
-        if config.remove_force_include(pattern) {
-            println!("✅ Removed force-include pattern: {}", pattern);
-        } else {
-            println!("⚠️  Force-include pattern not found: {}", pattern);
-        }
-        changed = true;
-    }
-
-    // Handle covered subdirectories
-    if clear_cover {
-        config.clear_covered_subdirs();
-        println!("✅ Cleared all covered-subdirectory registrations");
-        changed = true;
-    }
-    for raw in &add_cover {
-        let abs = resolve_cover_path(raw);
-        if !abs.is_dir() {
-            println!("⚠️  Not a directory: {}", abs.display());
-            continue;
-        }
-        match find_enclosing_project(&abs) {
-            Some((root, rel)) => {
-                if config.add_covered_subdir(&root, &rel) {
-                    println!(
-                        "✅ Covering {} under project {}",
-                        rel.display(),
-                        root.display()
-                    );
-                    println!(
-                        "   Its files are indexed on the project's next update (e.g. colgrep init {}).",
-                        root.display()
-                    );
-                } else {
-                    println!("✅ Already covered: {}", abs.display());
+    for raw in &add_force_include {
+        let abs = resolve_dir_argument(raw);
+        if abs.is_dir() {
+            match find_enclosing_project(&abs) {
+                Some((root, rel)) => {
+                    if config.add_force_include_dir(&root, &rel) {
+                        println!(
+                            "✅ Force-including directory {} (project: {})",
+                            rel.display(),
+                            root.display()
+                        );
+                        println!(
+                            "   Its files are indexed on the project's next update (e.g. colgrep init {}).",
+                            root.display()
+                        );
+                    } else {
+                        println!("✅ Directory already force-included: {}", abs.display());
+                    }
+                    changed = true;
+                    continue;
                 }
-                changed = true;
-            }
-            None => {
-                println!(
-                    "⚠️  No indexed project contains {}; index the project first with colgrep init",
-                    abs.display()
-                );
+                None => {
+                    println!(
+                        "⚠️  {} is a directory but no indexed project contains it; adding as a global pattern instead",
+                        abs.display()
+                    );
+                }
             }
         }
+        config.add_force_include(raw);
+        println!("✅ Added force-include pattern: {}", raw);
+        changed = true;
     }
-    for raw in &remove_cover {
-        let abs = resolve_cover_path(raw);
-        if remove_covered_path(&mut config, &abs) {
-            println!("✅ Stopped covering: {}", abs.display());
-            println!("   Its files leave the parent index on its next update.");
+    for raw in &remove_force_include {
+        let abs = resolve_dir_argument(raw);
+        if remove_force_included_dir(&mut config, &abs) {
+            println!("✅ Stopped force-including directory: {}", abs.display());
+            println!("   Its files leave the project's index on its next update.");
+        } else if config.remove_force_include(raw) {
+            println!("✅ Removed force-include pattern: {}", raw);
         } else {
-            println!(
-                "⚠️  No covered subdirectory registered for: {}",
-                abs.display()
-            );
+            println!("⚠️  Force-include not found: {}", raw);
         }
         changed = true;
     }
@@ -582,10 +556,11 @@ pub fn cmd_config(
     Ok(())
 }
 
-/// Absolutize a `--no-cover` argument. Prefer canonicalization so the path
-/// matches the canonical roots coverage is keyed by; a directory that no
-/// longer exists falls back to a lexical join with the working directory.
-fn resolve_cover_path(raw: &str) -> PathBuf {
+/// Absolutize a force-include argument for directory resolution. Prefer
+/// canonicalization so the path matches the canonical roots registrations are
+/// keyed by; a directory that no longer exists falls back to a lexical join
+/// with the working directory.
+fn resolve_dir_argument(raw: &str) -> PathBuf {
     std::fs::canonicalize(raw).unwrap_or_else(|_| {
         let path = Path::new(raw);
         if path.is_absolute() {
@@ -627,14 +602,14 @@ fn find_enclosing_project(abs: &Path) -> Option<(PathBuf, PathBuf)> {
     best
 }
 
-/// Remove the coverage registration `abs` points into, matching it against
-/// every registered project root.
-fn remove_covered_path(config: &mut Config, abs: &Path) -> bool {
-    let roots: Vec<String> = config.covered_subdirs.keys().cloned().collect();
+/// Remove the force-included directory registration `abs` points into,
+/// matching it against every registered project root.
+fn remove_force_included_dir(config: &mut Config, abs: &Path) -> bool {
+    let roots: Vec<String> = config.force_include_dirs.keys().cloned().collect();
     let mut removed = false;
     for root in roots {
         if let Ok(rel) = abs.strip_prefix(Path::new(&root)) {
-            removed |= config.remove_covered_subdir(Path::new(&root), rel);
+            removed |= config.remove_force_include_dir(Path::new(&root), rel);
         }
     }
     removed

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::commands::search::{resolve_model, resolve_pool_factor};
 use colgrep::{
-    ensure_model, find_parent_index, index_exists, Config, IndexBuilder, IndexState,
-    ParentIndexInfo,
+    ensure_model, find_parent_index, index_exists, scan_reaches_subdir, Config, IndexBuilder,
 };
 
 pub struct InitOptions<'a> {
@@ -31,20 +30,6 @@ fn resolve_index_runtime_overrides(
     )
 }
 
-/// Whether a parent index holds at least one file under the subdirectory being indexed.
-///
-/// Reads the parent's state rather than its vectors, so this costs a JSON load and no model.
-fn parent_covers_subdir(info: &ParentIndexInfo) -> bool {
-    match IndexState::load(&info.index_dir) {
-        Ok(state) => state
-            .files
-            .keys()
-            .any(|file| file.starts_with(&info.relative_subdir)),
-        // An unreadable parent state is not evidence of coverage: index `path` itself.
-        Err(_) => false,
-    }
-}
-
 pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let path = std::fs::canonicalize(path)
         .map_err(|_| anyhow::anyhow!("Path does not exist: {}", path.display()))?;
@@ -53,7 +38,7 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
         anyhow::bail!("Path is not a directory: {}", path.display());
     }
 
-    let config = Config::load().unwrap_or_default();
+    let mut config = Config::load().unwrap_or_default();
     let model = resolve_model(&config, options.cli_model);
     let pool_factor = resolve_pool_factor(&config, options.pool_factor, options.no_pool);
 
@@ -61,12 +46,41 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);
 
-    // Check if path is inside an already-indexed parent project, and reuse that index only
-    // if it actually holds files under `path`. A directory the parent's walk skips — most
-    // often one its .gitignore excludes — is a subdirectory of the parent without being
-    // covered by it, and reusing the parent there would report success having indexed none
-    // of the requested files.
-    let parent_info = find_parent_index(&path, &model)?.filter(parent_covers_subdir);
+    // An enclosing indexed project adopts this init. But if the project's walk
+    // rules exclude `path` — most often a .gitignore entry: dataset corpora,
+    // build outputs — updating the parent would report success having indexed
+    // none of the requested files. Running init on such a directory is an
+    // explicit ask, so register it as a covered subtree of the parent first.
+    // Registrations live in the config, which every scan consults: coverage
+    // survives incremental updates, full rebuilds (including index-format
+    // bumps on upgrade) and `colgrep clear`. A directory the walk simply
+    // hasn't seen yet (e.g. just created) is already reachable and needs no
+    // registration — the parent update below picks it up.
+    let parent_info = find_parent_index(&path, &model)?;
+    if let Some(info) = &parent_info {
+        let covered = config.covered_subdirs_for(&info.project_path);
+        if !scan_reaches_subdir(
+            &info.project_path,
+            &info.relative_subdir,
+            &config.extra_ignore,
+            &config.force_include,
+            &covered,
+        ) {
+            config.add_covered_subdir(&info.project_path, &info.relative_subdir);
+            config
+                .save()
+                .context("Failed to persist covered subdirectory registration")?;
+            eprintln!(
+                "📌 {} is excluded by {}'s ignore rules — registered it as covered so this and every future rebuild index it.",
+                info.relative_subdir.display(),
+                info.project_path.display(),
+            );
+            eprintln!(
+                "   Undo with: colgrep settings --no-cover {}",
+                path.display()
+            );
+        }
+    }
     let effective_root = match &parent_info {
         Some(info) => info.project_path.clone(),
         None => path.clone(),
@@ -172,55 +186,5 @@ mod tests {
 
         assert_eq!(parallel_sessions, Some(1));
         assert_eq!(batch_size, Some(1));
-    }
-
-    fn parent_with_files(files: &[&str]) -> (tempfile::TempDir, ParentIndexInfo) {
-        let dir = tempfile::tempdir().unwrap();
-        let mut state = IndexState::default();
-        for file in files {
-            state.files.insert(
-                PathBuf::from(file),
-                colgrep::FileInfo {
-                    content_hash: 0,
-                    mtime: 0,
-                    size: 0,
-                },
-            );
-        }
-        state.save(dir.path()).unwrap();
-        let info = ParentIndexInfo {
-            index_dir: dir.path().to_path_buf(),
-            project_path: PathBuf::from("/project"),
-            relative_subdir: PathBuf::from("corpus"),
-        };
-        (dir, info)
-    }
-
-    #[test]
-    fn test_parent_covers_subdir_when_it_holds_files_there() {
-        let (_dir, info) = parent_with_files(&["src/main.rs", "corpus/doc1.md"]);
-
-        assert!(parent_covers_subdir(&info));
-    }
-
-    #[test]
-    fn test_parent_does_not_cover_subdir_it_skipped() {
-        // The parent walk skipped `corpus/` — e.g. .gitignore excludes it — so an index of
-        // the parent holds none of the files `init corpus/` was asked to index.
-        let (_dir, info) = parent_with_files(&["src/main.rs", "README.md"]);
-
-        assert!(!parent_covers_subdir(&info));
-    }
-
-    #[test]
-    fn test_parent_does_not_cover_subdir_when_state_is_unreadable() {
-        let dir = tempfile::tempdir().unwrap();
-        let info = ParentIndexInfo {
-            index_dir: dir.path().join("missing"),
-            project_path: PathBuf::from("/project"),
-            relative_subdir: PathBuf::from("corpus"),
-        };
-
-        assert!(!parent_covers_subdir(&info));
     }
 }

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -46,17 +46,25 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);
 
-    // An enclosing indexed project adopts this init. But if the project's walk
-    // rules exclude `path` — most often a .gitignore entry: dataset corpora,
-    // build outputs — updating the parent would report success having indexed
-    // none of the requested files. Running init on such a directory is an
-    // explicit ask, so register it as a covered subtree of the parent first.
-    // Registrations live in the config, which every scan consults: coverage
-    // survives incremental updates, full rebuilds (including index-format
-    // bumps on upgrade) and `colgrep clear`. A directory the walk simply
-    // hasn't seen yet (e.g. just created) is already reachable and needs no
-    // registration — the parent update below picks it up.
-    let parent_info = find_parent_index(&path, &model)?;
+    // A path with its own index updates that index — the resolution search,
+    // clear and status already use. Only otherwise does an enclosing indexed
+    // project adopt this init; without the guard, `init` on a nested project's
+    // root would update the OUTER project instead, and coverage registered
+    // under the nested root would never apply.
+    let parent_info = if index_exists(&path, &model) {
+        None
+    } else {
+        find_parent_index(&path, &model)?
+    };
+    // If the adopting project's walk rules exclude `path` — most often a
+    // .gitignore entry: dataset corpora, build outputs — updating the parent
+    // would report success having indexed none of the requested files. Running
+    // init on such a directory is an explicit ask, so register it as a covered
+    // subtree of the parent first. Registrations live in the config, which
+    // every scan consults: coverage survives incremental updates, full rebuilds
+    // (including index-format bumps on upgrade) and `colgrep clear`. A
+    // directory the walk simply hasn't seen yet (e.g. just created) is already
+    // reachable and needs no registration — the parent update below picks it up.
     if let Some(info) = &parent_info {
         let covered = config.covered_subdirs_for(&info.project_path);
         if !scan_reaches_subdir(

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use anyhow::Result;
 
 use crate::commands::search::{resolve_model, resolve_pool_factor};
-use colgrep::{ensure_model, find_parent_index, index_exists, Config, IndexBuilder};
+use colgrep::{
+    ensure_model, find_parent_index, index_exists, Config, IndexBuilder, IndexState,
+    ParentIndexInfo,
+};
 
 pub struct InitOptions<'a> {
     pub cli_model: Option<&'a str>,
@@ -28,6 +31,20 @@ fn resolve_index_runtime_overrides(
     )
 }
 
+/// Whether a parent index holds at least one file under the subdirectory being indexed.
+///
+/// Reads the parent's state rather than its vectors, so this costs a JSON load and no model.
+fn parent_covers_subdir(info: &ParentIndexInfo) -> bool {
+    match IndexState::load(&info.index_dir) {
+        Ok(state) => state
+            .files
+            .keys()
+            .any(|file| file.starts_with(&info.relative_subdir)),
+        // An unreadable parent state is not evidence of coverage: index `path` itself.
+        Err(_) => false,
+    }
+}
+
 pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let path = std::fs::canonicalize(path)
         .map_err(|_| anyhow::anyhow!("Path does not exist: {}", path.display()))?;
@@ -44,8 +61,12 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     let (parallel_sessions, batch_size) =
         resolve_index_runtime_overrides(&config, options.batch_size);
 
-    // Check if path is inside an already-indexed parent project
-    let parent_info = find_parent_index(&path, &model)?;
+    // Check if path is inside an already-indexed parent project, and reuse that index only
+    // if it actually holds files under `path`. A directory the parent's walk skips — most
+    // often one its .gitignore excludes — is a subdirectory of the parent without being
+    // covered by it, and reusing the parent there would report success having indexed none
+    // of the requested files.
+    let parent_info = find_parent_index(&path, &model)?.filter(parent_covers_subdir);
     let effective_root = match &parent_info {
         Some(info) => info.project_path.clone(),
         None => path.clone(),
@@ -151,5 +172,55 @@ mod tests {
 
         assert_eq!(parallel_sessions, Some(1));
         assert_eq!(batch_size, Some(1));
+    }
+
+    fn parent_with_files(files: &[&str]) -> (tempfile::TempDir, ParentIndexInfo) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = IndexState::default();
+        for file in files {
+            state.files.insert(
+                PathBuf::from(file),
+                colgrep::FileInfo {
+                    content_hash: 0,
+                    mtime: 0,
+                    size: 0,
+                },
+            );
+        }
+        state.save(dir.path()).unwrap();
+        let info = ParentIndexInfo {
+            index_dir: dir.path().to_path_buf(),
+            project_path: PathBuf::from("/project"),
+            relative_subdir: PathBuf::from("corpus"),
+        };
+        (dir, info)
+    }
+
+    #[test]
+    fn test_parent_covers_subdir_when_it_holds_files_there() {
+        let (_dir, info) = parent_with_files(&["src/main.rs", "corpus/doc1.md"]);
+
+        assert!(parent_covers_subdir(&info));
+    }
+
+    #[test]
+    fn test_parent_does_not_cover_subdir_it_skipped() {
+        // The parent walk skipped `corpus/` — e.g. .gitignore excludes it — so an index of
+        // the parent holds none of the files `init corpus/` was asked to index.
+        let (_dir, info) = parent_with_files(&["src/main.rs", "README.md"]);
+
+        assert!(!parent_covers_subdir(&info));
+    }
+
+    #[test]
+    fn test_parent_does_not_cover_subdir_when_state_is_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = ParentIndexInfo {
+            index_dir: dir.path().join("missing"),
+            project_path: PathBuf::from("/project"),
+            relative_subdir: PathBuf::from("corpus"),
+        };
+
+        assert!(!parent_covers_subdir(&info));
     }
 }

--- a/colgrep/src/commands/init.rs
+++ b/colgrep/src/commands/init.rs
@@ -59,14 +59,14 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
     // If the adopting project's walk rules exclude `path` — most often a
     // .gitignore entry: dataset corpora, build outputs — updating the parent
     // would report success having indexed none of the requested files. Running
-    // init on such a directory is an explicit ask, so register it as a covered
-    // subtree of the parent first. Registrations live in the config, which
+    // init on such a directory is an explicit ask, so force-include it for the
+    // parent first. Registrations live in the config, which
     // every scan consults: coverage survives incremental updates, full rebuilds
     // (including index-format bumps on upgrade) and `colgrep clear`. A
     // directory the walk simply hasn't seen yet (e.g. just created) is already
     // reachable and needs no registration — the parent update below picks it up.
     if let Some(info) = &parent_info {
-        let covered = config.covered_subdirs_for(&info.project_path);
+        let covered = config.force_include_dirs_for(&info.project_path);
         if !scan_reaches_subdir(
             &info.project_path,
             &info.relative_subdir,
@@ -74,17 +74,17 @@ pub fn cmd_init(path: &PathBuf, options: InitOptions<'_>) -> Result<()> {
             &config.force_include,
             &covered,
         ) {
-            config.add_covered_subdir(&info.project_path, &info.relative_subdir);
+            config.add_force_include_dir(&info.project_path, &info.relative_subdir);
             config
                 .save()
-                .context("Failed to persist covered subdirectory registration")?;
+                .context("Failed to persist force-included directory registration")?;
             eprintln!(
-                "📌 {} is excluded by {}'s ignore rules — registered it as covered so this and every future rebuild index it.",
+                "📌 {} is excluded by {}'s ignore rules — force-included it so this and every future rebuild index it.",
                 info.relative_subdir.display(),
                 info.project_path.display(),
             );
             eprintln!(
-                "   Undo with: colgrep settings --no-cover {}",
+                "   Undo with: colgrep settings --no-force-include {}",
                 path.display()
             );
         }

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1331,7 +1331,7 @@ fn search_single_path(
                         subdir,
                         &config.extra_ignore,
                         &config.force_include,
-                        &config.covered_subdirs_for(&effective_root),
+                        &config.force_include_dirs_for(&effective_root),
                     ) {
                         eprintln!(
                             "This directory is excluded by the project's ignore rules; index it with: colgrep init {}",

--- a/colgrep/src/commands/search.rs
+++ b/colgrep/src/commands/search.rs
@@ -1323,6 +1323,21 @@ fn search_single_path(
                         "No indexed code units in subdirectory: {}",
                         subdir.display()
                     );
+                    // Empty because the project's walk rules exclude this directory
+                    // (e.g. a .gitignore entry), not because it holds no code: tell
+                    // the user how to bring it under coverage.
+                    if !colgrep::scan_reaches_subdir(
+                        &effective_root,
+                        subdir,
+                        &config.extra_ignore,
+                        &config.force_include,
+                        &config.covered_subdirs_for(&effective_root),
+                    ) {
+                        eprintln!(
+                            "This directory is excluded by the project's ignore rules; index it with: colgrep init {}",
+                            search_path.display()
+                        );
+                    }
                 }
                 return Ok(vec![]);
             }

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -2,8 +2,9 @@
 //!
 //! Stores user preferences (like default model) in the colgrep data directory.
 
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -189,6 +190,16 @@ pub struct Config {
     /// e.g., [".vscode", "build/generated", "vendor/internal"]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub force_include: Vec<String>,
+
+    /// Subdirectories indexed as part of a parent project even though the
+    /// project's walk rules exclude them (most often a .gitignore entry —
+    /// dataset corpora, build outputs). Keyed by the canonical project root;
+    /// values are root-relative directory paths. Registered by `colgrep init`
+    /// on an excluded directory and consulted on every scan, so coverage
+    /// survives incremental updates, full rebuilds (including index-format
+    /// bumps on upgrade) and `colgrep clear`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub covered_subdirs: BTreeMap<String, Vec<String>>,
 }
 
 impl Config {
@@ -524,6 +535,50 @@ impl Config {
     /// Clear all force-include patterns
     pub fn clear_force_include(&mut self) {
         self.force_include.clear();
+    }
+
+    /// Root-relative subdirectories registered as covered for `project_root`.
+    pub fn covered_subdirs_for(&self, project_root: &Path) -> Vec<PathBuf> {
+        self.covered_subdirs
+            .get(project_root.to_string_lossy().as_ref())
+            .map(|subs| subs.iter().map(PathBuf::from).collect())
+            .unwrap_or_default()
+    }
+
+    /// Register `subdir` (relative to `project_root`) as a covered subdirectory.
+    /// Returns false if an equal or ancestor entry already covers it; entries the
+    /// new one subsumes are pruned.
+    pub fn add_covered_subdir(&mut self, project_root: &Path, subdir: &Path) -> bool {
+        let key = project_root.to_string_lossy().into_owned();
+        let entry = self.covered_subdirs.entry(key).or_default();
+        if entry.iter().any(|c| subdir.starts_with(Path::new(c))) {
+            return false;
+        }
+        entry.retain(|c| !Path::new(c).starts_with(subdir));
+        entry.push(subdir.to_string_lossy().into_owned());
+        entry.sort();
+        true
+    }
+
+    /// Remove the covered-subdirectory registration for `subdir` under
+    /// `project_root`. Returns true if an entry was removed.
+    pub fn remove_covered_subdir(&mut self, project_root: &Path, subdir: &Path) -> bool {
+        let key = project_root.to_string_lossy().into_owned();
+        let Some(entry) = self.covered_subdirs.get_mut(&key) else {
+            return false;
+        };
+        let len = entry.len();
+        entry.retain(|c| Path::new(c) != subdir);
+        let removed = entry.len() < len;
+        if entry.is_empty() {
+            self.covered_subdirs.remove(&key);
+        }
+        removed
+    }
+
+    /// Clear all covered-subdirectory registrations, across all projects.
+    pub fn clear_covered_subdirs(&mut self) {
+        self.covered_subdirs.clear();
     }
 }
 
@@ -1013,6 +1068,94 @@ mod tests {
         assert_eq!(
             restored.coreml_cache_dir(),
             Some("/private/tmp/colgrep-coreml")
+        );
+    }
+
+    #[test]
+    fn test_add_covered_subdir() {
+        let mut config = Config::default();
+        let root = Path::new("/project");
+
+        assert!(config.add_covered_subdir(root, Path::new("corpus")));
+        assert_eq!(
+            config.covered_subdirs_for(root),
+            vec![PathBuf::from("corpus")]
+        );
+        // Other projects are unaffected.
+        assert!(config.covered_subdirs_for(Path::new("/other")).is_empty());
+    }
+
+    #[test]
+    fn test_add_covered_subdir_already_covered() {
+        let mut config = Config::default();
+        let root = Path::new("/project");
+        config.add_covered_subdir(root, Path::new("corpus"));
+
+        // An exact duplicate or a descendant of an existing entry adds nothing.
+        assert!(!config.add_covered_subdir(root, Path::new("corpus")));
+        assert!(!config.add_covered_subdir(root, Path::new("corpus/nested")));
+        assert_eq!(
+            config.covered_subdirs_for(root),
+            vec![PathBuf::from("corpus")]
+        );
+    }
+
+    #[test]
+    fn test_add_covered_subdir_prunes_subsumed_entries() {
+        let mut config = Config::default();
+        let root = Path::new("/project");
+        config.add_covered_subdir(root, Path::new("artifacts/traces"));
+
+        // Covering the ancestor subsumes the finer-grained entry.
+        assert!(config.add_covered_subdir(root, Path::new("artifacts")));
+        assert_eq!(
+            config.covered_subdirs_for(root),
+            vec![PathBuf::from("artifacts")]
+        );
+    }
+
+    #[test]
+    fn test_add_covered_subdir_component_boundary() {
+        let mut config = Config::default();
+        let root = Path::new("/project");
+        config.add_covered_subdir(root, Path::new("corpus"));
+
+        // `corpus-extra` shares a string prefix with `corpus` but is a distinct
+        // directory: it is neither covered by nor subsumed into that entry.
+        assert!(config.add_covered_subdir(root, Path::new("corpus-extra")));
+        assert_eq!(
+            config.covered_subdirs_for(root),
+            vec![PathBuf::from("corpus"), PathBuf::from("corpus-extra")]
+        );
+    }
+
+    #[test]
+    fn test_remove_covered_subdir() {
+        let mut config = Config::default();
+        let root = Path::new("/project");
+        config.add_covered_subdir(root, Path::new("corpus"));
+
+        assert!(config.remove_covered_subdir(root, Path::new("corpus")));
+        assert!(config.covered_subdirs_for(root).is_empty());
+        // The now-empty project key is dropped from the map entirely.
+        assert!(config.covered_subdirs.is_empty());
+        assert!(!config.remove_covered_subdir(root, Path::new("corpus")));
+    }
+
+    #[test]
+    fn test_covered_subdirs_serialization_roundtrip() {
+        let mut config = Config::default();
+        // Absent from JSON when empty, so existing configs stay untouched.
+        assert!(!serde_json::to_string(&config)
+            .unwrap()
+            .contains("covered_subdirs"));
+
+        config.add_covered_subdir(Path::new("/project"), Path::new("corpus"));
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.covered_subdirs_for(Path::new("/project")),
+            vec![PathBuf::from("corpus")]
         );
     }
 }

--- a/colgrep/src/config.rs
+++ b/colgrep/src/config.rs
@@ -191,15 +191,17 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub force_include: Vec<String>,
 
-    /// Subdirectories indexed as part of a parent project even though the
-    /// project's walk rules exclude them (most often a .gitignore entry —
-    /// dataset corpora, build outputs). Keyed by the canonical project root;
-    /// values are root-relative directory paths. Registered by `colgrep init`
-    /// on an excluded directory and consulted on every scan, so coverage
-    /// survives incremental updates, full rebuilds (including index-format
-    /// bumps on upgrade) and `colgrep clear`.
+    /// Per-project force-included directories: indexed as part of the project
+    /// even though its walk rules exclude them (most often a .gitignore entry —
+    /// dataset corpora, build outputs). The directory counterpart of the
+    /// `force_include` patterns above, and the only form that overrides
+    /// gitignore. Keyed by the canonical project root; values are root-relative
+    /// directory paths. Registered by `colgrep init` on an excluded directory
+    /// or `colgrep settings --force-include <dir>`, and consulted on every
+    /// scan, so registrations survive incremental updates, full rebuilds
+    /// (including index-format bumps on upgrade) and `colgrep clear`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub covered_subdirs: BTreeMap<String, Vec<String>>,
+    pub force_include_dirs: BTreeMap<String, Vec<String>>,
 }
 
 impl Config {
@@ -537,20 +539,20 @@ impl Config {
         self.force_include.clear();
     }
 
-    /// Root-relative subdirectories registered as covered for `project_root`.
-    pub fn covered_subdirs_for(&self, project_root: &Path) -> Vec<PathBuf> {
-        self.covered_subdirs
+    /// Root-relative force-included directories registered for `project_root`.
+    pub fn force_include_dirs_for(&self, project_root: &Path) -> Vec<PathBuf> {
+        self.force_include_dirs
             .get(project_root.to_string_lossy().as_ref())
             .map(|subs| subs.iter().map(PathBuf::from).collect())
             .unwrap_or_default()
     }
 
-    /// Register `subdir` (relative to `project_root`) as a covered subdirectory.
-    /// Returns false if an equal or ancestor entry already covers it; entries the
-    /// new one subsumes are pruned.
-    pub fn add_covered_subdir(&mut self, project_root: &Path, subdir: &Path) -> bool {
+    /// Register `subdir` (relative to `project_root`) as a force-included
+    /// directory. Returns false if an equal or ancestor entry already covers
+    /// it; entries the new one subsumes are pruned.
+    pub fn add_force_include_dir(&mut self, project_root: &Path, subdir: &Path) -> bool {
         let key = project_root.to_string_lossy().into_owned();
-        let entry = self.covered_subdirs.entry(key).or_default();
+        let entry = self.force_include_dirs.entry(key).or_default();
         if entry.iter().any(|c| subdir.starts_with(Path::new(c))) {
             return false;
         }
@@ -560,25 +562,25 @@ impl Config {
         true
     }
 
-    /// Remove the covered-subdirectory registration for `subdir` under
+    /// Remove the force-included directory registration for `subdir` under
     /// `project_root`. Returns true if an entry was removed.
-    pub fn remove_covered_subdir(&mut self, project_root: &Path, subdir: &Path) -> bool {
+    pub fn remove_force_include_dir(&mut self, project_root: &Path, subdir: &Path) -> bool {
         let key = project_root.to_string_lossy().into_owned();
-        let Some(entry) = self.covered_subdirs.get_mut(&key) else {
+        let Some(entry) = self.force_include_dirs.get_mut(&key) else {
             return false;
         };
         let len = entry.len();
         entry.retain(|c| Path::new(c) != subdir);
         let removed = entry.len() < len;
         if entry.is_empty() {
-            self.covered_subdirs.remove(&key);
+            self.force_include_dirs.remove(&key);
         }
         removed
     }
 
-    /// Clear all covered-subdirectory registrations, across all projects.
-    pub fn clear_covered_subdirs(&mut self) {
-        self.covered_subdirs.clear();
+    /// Clear all force-included directory registrations, across all projects.
+    pub fn clear_force_include_dirs(&mut self) {
+        self.force_include_dirs.clear();
     }
 }
 
@@ -1072,89 +1074,91 @@ mod tests {
     }
 
     #[test]
-    fn test_add_covered_subdir() {
+    fn test_add_force_include_dir() {
         let mut config = Config::default();
         let root = Path::new("/project");
 
-        assert!(config.add_covered_subdir(root, Path::new("corpus")));
+        assert!(config.add_force_include_dir(root, Path::new("corpus")));
         assert_eq!(
-            config.covered_subdirs_for(root),
+            config.force_include_dirs_for(root),
             vec![PathBuf::from("corpus")]
         );
         // Other projects are unaffected.
-        assert!(config.covered_subdirs_for(Path::new("/other")).is_empty());
+        assert!(config
+            .force_include_dirs_for(Path::new("/other"))
+            .is_empty());
     }
 
     #[test]
-    fn test_add_covered_subdir_already_covered() {
+    fn test_add_force_include_dir_already_covered() {
         let mut config = Config::default();
         let root = Path::new("/project");
-        config.add_covered_subdir(root, Path::new("corpus"));
+        config.add_force_include_dir(root, Path::new("corpus"));
 
         // An exact duplicate or a descendant of an existing entry adds nothing.
-        assert!(!config.add_covered_subdir(root, Path::new("corpus")));
-        assert!(!config.add_covered_subdir(root, Path::new("corpus/nested")));
+        assert!(!config.add_force_include_dir(root, Path::new("corpus")));
+        assert!(!config.add_force_include_dir(root, Path::new("corpus/nested")));
         assert_eq!(
-            config.covered_subdirs_for(root),
+            config.force_include_dirs_for(root),
             vec![PathBuf::from("corpus")]
         );
     }
 
     #[test]
-    fn test_add_covered_subdir_prunes_subsumed_entries() {
+    fn test_add_force_include_dir_prunes_subsumed_entries() {
         let mut config = Config::default();
         let root = Path::new("/project");
-        config.add_covered_subdir(root, Path::new("artifacts/traces"));
+        config.add_force_include_dir(root, Path::new("artifacts/traces"));
 
         // Covering the ancestor subsumes the finer-grained entry.
-        assert!(config.add_covered_subdir(root, Path::new("artifacts")));
+        assert!(config.add_force_include_dir(root, Path::new("artifacts")));
         assert_eq!(
-            config.covered_subdirs_for(root),
+            config.force_include_dirs_for(root),
             vec![PathBuf::from("artifacts")]
         );
     }
 
     #[test]
-    fn test_add_covered_subdir_component_boundary() {
+    fn test_add_force_include_dir_component_boundary() {
         let mut config = Config::default();
         let root = Path::new("/project");
-        config.add_covered_subdir(root, Path::new("corpus"));
+        config.add_force_include_dir(root, Path::new("corpus"));
 
         // `corpus-extra` shares a string prefix with `corpus` but is a distinct
         // directory: it is neither covered by nor subsumed into that entry.
-        assert!(config.add_covered_subdir(root, Path::new("corpus-extra")));
+        assert!(config.add_force_include_dir(root, Path::new("corpus-extra")));
         assert_eq!(
-            config.covered_subdirs_for(root),
+            config.force_include_dirs_for(root),
             vec![PathBuf::from("corpus"), PathBuf::from("corpus-extra")]
         );
     }
 
     #[test]
-    fn test_remove_covered_subdir() {
+    fn test_remove_force_include_dir() {
         let mut config = Config::default();
         let root = Path::new("/project");
-        config.add_covered_subdir(root, Path::new("corpus"));
+        config.add_force_include_dir(root, Path::new("corpus"));
 
-        assert!(config.remove_covered_subdir(root, Path::new("corpus")));
-        assert!(config.covered_subdirs_for(root).is_empty());
+        assert!(config.remove_force_include_dir(root, Path::new("corpus")));
+        assert!(config.force_include_dirs_for(root).is_empty());
         // The now-empty project key is dropped from the map entirely.
-        assert!(config.covered_subdirs.is_empty());
-        assert!(!config.remove_covered_subdir(root, Path::new("corpus")));
+        assert!(config.force_include_dirs.is_empty());
+        assert!(!config.remove_force_include_dir(root, Path::new("corpus")));
     }
 
     #[test]
-    fn test_covered_subdirs_serialization_roundtrip() {
+    fn test_force_include_dirs_serialization_roundtrip() {
         let mut config = Config::default();
         // Absent from JSON when empty, so existing configs stay untouched.
         assert!(!serde_json::to_string(&config)
             .unwrap()
-            .contains("covered_subdirs"));
+            .contains("force_include_dirs"));
 
-        config.add_covered_subdir(Path::new("/project"), Path::new("corpus"));
+        config.add_force_include_dir(Path::new("/project"), Path::new("corpus"));
         let json = serde_json::to_string(&config).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            restored.covered_subdirs_for(Path::new("/project")),
+            restored.force_include_dirs_for(Path::new("/project")),
             vec![PathBuf::from("corpus")]
         );
     }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2808,61 +2808,224 @@ impl IndexBuilder {
     fn scan_files(&self, languages: Option<&[Language]>) -> Result<(Vec<PathBuf>, usize)> {
         // Load user-configured ignore/include overrides from persistent config
         let config = crate::config::Config::load().unwrap_or_default();
-        let extra_ignore = config.extra_ignore.clone();
-        let force_include = config.force_include.clone();
 
-        let project_root = self.project_root.clone();
-        let walker = WalkBuilder::new(&self.project_root)
-            .hidden(false) // Handle hidden files manually in should_ignore (with .github exception)
-            .git_ignore(true)
-            .follow_links(false) // Explicitly prevent symlink traversal outside project
-            .filter_entry(move |entry| {
-                // Only apply ignore rules to path components relative to the project root.
-                // The project root itself is always trusted (the user explicitly chose it),
-                // so hidden-directory filtering must not reject ancestor path components.
-                match entry.path().strip_prefix(&project_root) {
-                    Ok(rel) if rel.as_os_str().is_empty() => true, // root entry itself
-                    Ok(rel) => !should_ignore(rel, &extra_ignore, &force_include),
-                    Err(_) => !should_ignore(entry.path(), &extra_ignore, &force_include), // fallback (shouldn't happen)
-                }
-            })
-            .build();
+        Ok(scan_project_files(
+            &self.project_root,
+            languages,
+            &config.extra_ignore,
+            &config.force_include,
+            &config.covered_subdirs_for(&self.project_root),
+        ))
+    }
+}
 
-        let mut files = Vec::new();
-        let mut skipped = 0;
+/// Scan `project_root` for indexable files, returning root-relative paths and
+/// the number of skipped files.
+///
+/// Covered subtrees (`colgrep init` on a directory the main walk's rules
+/// exclude) are scanned with their own walk and merged in. Because every scan
+/// consults the registrations, coverage survives incremental updates and full
+/// rebuilds alike — including the rebuilds an index-format bump or a
+/// `colgrep clear` forces.
+fn scan_project_files(
+    project_root: &Path,
+    languages: Option<&[Language]>,
+    extra_ignore: &[String],
+    force_include: &[String],
+    covered_subdirs: &[PathBuf],
+) -> (Vec<PathBuf>, usize) {
+    let mut files = Vec::new();
+    let mut skipped = 0;
 
-        for entry in walker.filter_map(|e| e.ok()) {
-            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
-                continue;
+    let root = project_root.to_path_buf();
+    let extra = extra_ignore.to_vec();
+    let force = force_include.to_vec();
+    let walker = WalkBuilder::new(project_root)
+        .hidden(false) // Handle hidden files manually in should_ignore (with .github exception)
+        .git_ignore(true)
+        .follow_links(false) // Explicitly prevent symlink traversal outside project
+        .filter_entry(move |entry| {
+            // Only apply ignore rules to path components relative to the project root.
+            // The project root itself is always trusted (the user explicitly chose it),
+            // so hidden-directory filtering must not reject ancestor path components.
+            match entry.path().strip_prefix(&root) {
+                Ok(rel) if rel.as_os_str().is_empty() => true, // root entry itself
+                Ok(rel) => !should_ignore(rel, &extra, &force),
+                Err(_) => !should_ignore(entry.path(), &extra, &force), // fallback (shouldn't happen)
             }
+        })
+        .build();
+    collect_scanned_files(project_root, walker, languages, &mut files, &mut skipped);
 
-            let path = entry.path();
+    for covered in covered_subdirs {
+        let sub_root = project_root.join(covered);
+        if !sub_root.is_dir() {
+            continue;
+        }
+        let root = sub_root.clone();
+        let extra = extra_ignore.to_vec();
+        let force = force_include.to_vec();
+        let mut builder = covered_subtree_walk_builder(&sub_root);
+        builder.filter_entry(move |entry| match entry.path().strip_prefix(&root) {
+            Ok(rel) if rel.as_os_str().is_empty() => true,
+            Ok(rel) => !should_ignore(rel, &extra, &force),
+            Err(_) => false,
+        });
+        collect_scanned_files(
+            project_root,
+            builder.build(),
+            languages,
+            &mut files,
+            &mut skipped,
+        );
+    }
 
-            // Skip files that are too large
-            if is_file_too_large(path) {
-                skipped += 1;
-                continue;
-            }
+    // A covered subtree the main walk later reaches again (e.g. its .gitignore
+    // entry was removed) would otherwise be collected twice.
+    let mut seen = HashSet::new();
+    files.retain(|f| seen.insert(f.clone()));
 
-            let lang = match detect_language(path) {
-                Some(l) => l,
-                None => continue,
-            };
+    (files, skipped)
+}
 
-            if languages.map(|ls| ls.contains(&lang)).unwrap_or(true) {
-                if let Ok(rel_path) = path.strip_prefix(&self.project_root) {
-                    // Verify the file is truly within the project root (handles symlink escapes)
-                    if is_within_project_root(&self.project_root, rel_path) {
-                        files.push(rel_path.to_path_buf());
-                    } else {
-                        skipped += 1;
-                    }
+/// Collect indexable files yielded by `walker` into `files` as paths relative
+/// to `project_root` (which for covered-subtree walks is an ancestor of the
+/// walker's own root).
+fn collect_scanned_files(
+    project_root: &Path,
+    walker: ignore::Walk,
+    languages: Option<&[Language]>,
+    files: &mut Vec<PathBuf>,
+    skipped: &mut usize,
+) {
+    for entry in walker.filter_map(|e| e.ok()) {
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+
+        let path = entry.path();
+
+        // Skip files that are too large
+        if is_file_too_large(path) {
+            *skipped += 1;
+            continue;
+        }
+
+        let lang = match detect_language(path) {
+            Some(l) => l,
+            None => continue,
+        };
+
+        if languages.map(|ls| ls.contains(&lang)).unwrap_or(true) {
+            if let Ok(rel_path) = path.strip_prefix(project_root) {
+                // Verify the file is truly within the project root (handles symlink escapes)
+                if is_within_project_root(project_root, rel_path) {
+                    files.push(rel_path.to_path_buf());
+                } else {
+                    *skipped += 1;
                 }
             }
         }
-
-        Ok((files, skipped))
     }
+}
+
+/// Walker over an explicitly covered subtree.
+///
+/// The subtree is covered precisely because the enclosing project's rules
+/// exclude it, so ancestor ignore files must not apply: `parents(false)`.
+/// Ignore files *inside* the subtree still do, even though any `.git` sits
+/// above the subtree root: `require_git(false)`.
+fn covered_subtree_walk_builder(sub_root: &Path) -> WalkBuilder {
+    let mut builder = WalkBuilder::new(sub_root);
+    builder
+        .hidden(false)
+        .git_ignore(true)
+        .parents(false)
+        .require_git(false)
+        .follow_links(false);
+    builder
+}
+
+/// Whether the project's file scan can reach `subdir` (relative to
+/// `project_root`): either the main walk's rules admit every step from the
+/// root, or a covered subtree contains it and the subtree walk admits the
+/// remaining steps.
+///
+/// This asks "would scanning index files under this directory?" — it
+/// deliberately ignores what any existing index currently holds, so a
+/// directory the walk simply hasn't seen yet (e.g. just created) counts as
+/// reachable.
+pub fn scan_reaches_subdir(
+    project_root: &Path,
+    subdir: &Path,
+    extra_ignore: &[String],
+    force_include: &[String],
+    covered_subdirs: &[PathBuf],
+) -> bool {
+    if subdir.as_os_str().is_empty() {
+        return true;
+    }
+
+    // Main walk, same settings as the real scan.
+    let mut builder = WalkBuilder::new(project_root);
+    builder.hidden(false).git_ignore(true).follow_links(false);
+    if walk_yields(builder, project_root, subdir, extra_ignore, force_include) {
+        return true;
+    }
+
+    for covered in covered_subdirs {
+        if subdir == covered.as_path() {
+            return true;
+        }
+        if let Ok(rest) = subdir.strip_prefix(covered) {
+            let sub_root = project_root.join(covered);
+            if walk_yields(
+                covered_subtree_walk_builder(&sub_root),
+                &sub_root,
+                rest,
+                extra_ignore,
+                force_include,
+            ) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Whether walking from `root` with `builder`'s rules yields `root/target`.
+/// Descends only along `target`'s ancestor chain, applying the same
+/// `should_ignore` filter as the real scan — cheap: it enumerates just the
+/// directories on that chain.
+fn walk_yields(
+    mut builder: WalkBuilder,
+    root: &Path,
+    target: &Path,
+    extra_ignore: &[String],
+    force_include: &[String],
+) -> bool {
+    let absolute_target = root.join(target);
+    let chain_target = absolute_target.clone();
+    let root = root.to_path_buf();
+    let extra = extra_ignore.to_vec();
+    let force = force_include.to_vec();
+    builder
+        .max_depth(Some(target.components().count()))
+        .filter_entry(move |entry| {
+            if !chain_target.starts_with(entry.path()) {
+                return false; // off the ancestor chain — don't descend
+            }
+            match entry.path().strip_prefix(&root) {
+                Ok(rel) if rel.as_os_str().is_empty() => true,
+                Ok(rel) => !should_ignore(rel, &extra, &force),
+                Err(_) => false,
+            }
+        });
+    builder
+        .build()
+        .filter_map(|e| e.ok())
+        .any(|entry| entry.path() == absolute_target)
 }
 
 /// Check if a file exceeds the maximum size limit
@@ -6006,5 +6169,209 @@ mod tests {
             "state must be reconstructed from the DB"
         );
         assert_eq!(state.index_format_version, INDEX_FORMAT_VERSION);
+    }
+
+    /// Run git isolated from host config/hooks and from any surrounding
+    /// `git commit` environment (same pattern as worktree.rs tests).
+    fn git(args: &[&str], cwd: &Path) {
+        let mut cmd = std::process::Command::new("git");
+        cmd.args(args)
+            .current_dir(cwd)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null");
+        for var in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_COMMON_DIR",
+            "GIT_PREFIX",
+        ] {
+            cmd.env_remove(var);
+        }
+        let out = cmd.output().expect("git available");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Git project with a tracked file and a gitignored `corpus/` holding docs.
+    fn project_with_gitignored_corpus() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        git(&["init", "-q"], &root);
+        std::fs::write(root.join(".gitignore"), "corpus/\n").unwrap();
+        std::fs::write(root.join("tracked.md"), "# tracked\n").unwrap();
+        std::fs::create_dir_all(root.join("corpus/nested")).unwrap();
+        std::fs::write(root.join("corpus/d1.md"), "# doc\n").unwrap();
+        std::fs::write(root.join("corpus/nested/n1.md"), "# nested doc\n").unwrap();
+        (dir, root)
+    }
+
+    #[test]
+    fn test_scan_reaches_subdir_not_yet_indexed() {
+        // A directory the walk rules admit is reachable even though no index has
+        // ever seen it — a freshly created folder must NOT be treated like an
+        // excluded one (that misclassification forked a separate index).
+        let (_dir, root) = project_with_gitignored_corpus();
+        std::fs::create_dir(root.join("newfeature")).unwrap();
+
+        assert!(scan_reaches_subdir(
+            &root,
+            Path::new("newfeature"),
+            &[],
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_scan_does_not_reach_gitignored_subdir() {
+        let (_dir, root) = project_with_gitignored_corpus();
+
+        assert!(!scan_reaches_subdir(
+            &root,
+            Path::new("corpus"),
+            &[],
+            &[],
+            &[]
+        ));
+        assert!(!scan_reaches_subdir(
+            &root,
+            Path::new("corpus/nested"),
+            &[],
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_scan_reaches_sibling_sharing_excluded_prefix() {
+        // `corpus-extra` shares a string prefix with the gitignored `corpus`
+        // but is a distinct, non-ignored directory.
+        let (_dir, root) = project_with_gitignored_corpus();
+        std::fs::create_dir(root.join("corpus-extra")).unwrap();
+
+        assert!(scan_reaches_subdir(
+            &root,
+            Path::new("corpus-extra"),
+            &[],
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_scan_reaches_covered_subdir_and_descendants() {
+        let (_dir, root) = project_with_gitignored_corpus();
+        let covered = [PathBuf::from("corpus")];
+
+        assert!(scan_reaches_subdir(
+            &root,
+            Path::new("corpus"),
+            &[],
+            &[],
+            &covered
+        ));
+        assert!(scan_reaches_subdir(
+            &root,
+            Path::new("corpus/nested"),
+            &[],
+            &[],
+            &covered
+        ));
+    }
+
+    #[test]
+    fn test_covered_subtree_still_applies_inner_rules() {
+        // Coverage overrides the PARENT's exclusion only: ignore rules inside
+        // the covered subtree (its own .gitignore, default ignored dirs) hold.
+        let (_dir, root) = project_with_gitignored_corpus();
+        std::fs::write(root.join("corpus/.gitignore"), "private/\n").unwrap();
+        std::fs::create_dir(root.join("corpus/private")).unwrap();
+        std::fs::create_dir(root.join("corpus/node_modules")).unwrap();
+        let covered = [PathBuf::from("corpus")];
+
+        assert!(!scan_reaches_subdir(
+            &root,
+            Path::new("corpus/private"),
+            &[],
+            &[],
+            &covered
+        ));
+        assert!(!scan_reaches_subdir(
+            &root,
+            Path::new("corpus/node_modules"),
+            &[],
+            &[],
+            &covered
+        ));
+    }
+
+    #[test]
+    fn test_scan_project_files_merges_covered_subtree() {
+        let (_dir, root) = project_with_gitignored_corpus();
+
+        let (without, _) = scan_project_files(&root, None, &[], &[], &[]);
+        assert_eq!(without, vec![PathBuf::from("tracked.md")]);
+
+        let (mut with, _) = scan_project_files(&root, None, &[], &[], &[PathBuf::from("corpus")]);
+        with.sort();
+        assert_eq!(
+            with,
+            vec![
+                PathBuf::from("corpus/d1.md"),
+                PathBuf::from("corpus/nested/n1.md"),
+                PathBuf::from("tracked.md"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_scan_project_files_covered_subtree_inner_gitignore() {
+        let (_dir, root) = project_with_gitignored_corpus();
+        std::fs::write(root.join("corpus/.gitignore"), "nested/\n").unwrap();
+
+        let (mut files, _) = scan_project_files(&root, None, &[], &[], &[PathBuf::from("corpus")]);
+        files.sort();
+        assert_eq!(
+            files,
+            vec![PathBuf::from("corpus/d1.md"), PathBuf::from("tracked.md")],
+            "the covered subtree's own .gitignore must still exclude nested/"
+        );
+    }
+
+    #[test]
+    fn test_scan_project_files_dedupes_reachable_covered_subtree() {
+        // Coverage outlives the exclusion that motivated it: once the
+        // .gitignore entry is dropped, both walks yield the corpus files and
+        // each must be indexed exactly once.
+        let (_dir, root) = project_with_gitignored_corpus();
+        std::fs::write(root.join(".gitignore"), "").unwrap();
+
+        let (files, _) = scan_project_files(&root, None, &[], &[], &[PathBuf::from("corpus")]);
+        let unique: HashSet<_> = files.iter().collect();
+        assert_eq!(files.len(), unique.len(), "no duplicate scan entries");
+        assert!(files.contains(&PathBuf::from("corpus/d1.md")));
+        assert!(files.contains(&PathBuf::from("tracked.md")));
+    }
+
+    #[test]
+    fn test_scan_reaches_missing_subdir_is_false() {
+        let (_dir, root) = project_with_gitignored_corpus();
+
+        assert!(!scan_reaches_subdir(
+            &root,
+            Path::new("does-not-exist"),
+            &[],
+            &[],
+            &[]
+        ));
     }
 }

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -4034,7 +4034,10 @@ impl Searcher {
         let prefix_str = prefix.to_string_lossy();
         // Match on a whole path component: a bare `{prefix}%` would also pull in
         // sibling directories sharing the string prefix (`corpus` ⊃ `corpus-extra/`).
-        let like_pattern = format!("{}/%", prefix_str.trim_end_matches('/'));
+        // Stored paths use native separators (serde serializes the unit's PathBuf),
+        // so the component boundary must too.
+        let sep = std::path::MAIN_SEPARATOR;
+        let like_pattern = format!("{}{}%", prefix_str.trim_end_matches(sep), sep);
         let subset = filtering::where_condition(
             &self.index_path,
             "file LIKE ?",

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -2814,7 +2814,7 @@ impl IndexBuilder {
             languages,
             &config.extra_ignore,
             &config.force_include,
-            &config.covered_subdirs_for(&self.project_root),
+            &config.force_include_dirs_for(&self.project_root),
         ))
     }
 }
@@ -2832,7 +2832,7 @@ fn scan_project_files(
     languages: Option<&[Language]>,
     extra_ignore: &[String],
     force_include: &[String],
-    covered_subdirs: &[PathBuf],
+    force_include_dirs: &[PathBuf],
 ) -> (Vec<PathBuf>, usize) {
     let mut files = Vec::new();
     let mut skipped = 0;
@@ -2857,7 +2857,7 @@ fn scan_project_files(
         .build();
     collect_scanned_files(project_root, walker, languages, &mut files, &mut skipped);
 
-    for covered in covered_subdirs {
+    for covered in force_include_dirs {
         let sub_root = project_root.join(covered);
         if !sub_root.is_dir() {
             continue;
@@ -2865,7 +2865,7 @@ fn scan_project_files(
         let root = sub_root.clone();
         let extra = extra_ignore.to_vec();
         let force = force_include.to_vec();
-        let mut builder = covered_subtree_walk_builder(&sub_root);
+        let mut builder = force_include_dir_walk_builder(&sub_root);
         builder.filter_entry(move |entry| match entry.path().strip_prefix(&root) {
             Ok(rel) if rel.as_os_str().is_empty() => true,
             Ok(rel) => !should_ignore(rel, &extra, &force),
@@ -2929,13 +2929,13 @@ fn collect_scanned_files(
     }
 }
 
-/// Walker over an explicitly covered subtree.
+/// Walker over a force-included directory's subtree.
 ///
-/// The subtree is covered precisely because the enclosing project's rules
+/// The directory is registered precisely because the enclosing project's rules
 /// exclude it, so ancestor ignore files must not apply: `parents(false)`.
 /// Ignore files *inside* the subtree still do, even though any `.git` sits
 /// above the subtree root: `require_git(false)`.
-fn covered_subtree_walk_builder(sub_root: &Path) -> WalkBuilder {
+fn force_include_dir_walk_builder(sub_root: &Path) -> WalkBuilder {
     let mut builder = WalkBuilder::new(sub_root);
     builder
         .hidden(false)
@@ -2960,7 +2960,7 @@ pub fn scan_reaches_subdir(
     subdir: &Path,
     extra_ignore: &[String],
     force_include: &[String],
-    covered_subdirs: &[PathBuf],
+    force_include_dirs: &[PathBuf],
 ) -> bool {
     if subdir.as_os_str().is_empty() {
         return true;
@@ -2973,14 +2973,14 @@ pub fn scan_reaches_subdir(
         return true;
     }
 
-    for covered in covered_subdirs {
+    for covered in force_include_dirs {
         if subdir == covered.as_path() {
             return true;
         }
         if let Ok(rest) = subdir.strip_prefix(covered) {
             let sub_root = project_root.join(covered);
             if walk_yields(
-                covered_subtree_walk_builder(&sub_root),
+                force_include_dir_walk_builder(&sub_root),
                 &sub_root,
                 rest,
                 extra_ignore,
@@ -6272,7 +6272,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_reaches_covered_subdir_and_descendants() {
+    fn test_scan_reaches_force_included_dir_and_descendants() {
         let (_dir, root) = project_with_gitignored_corpus();
         let covered = [PathBuf::from("corpus")];
 
@@ -6293,7 +6293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_covered_subtree_still_applies_inner_rules() {
+    fn test_force_included_dir_still_applies_inner_rules() {
         // Coverage overrides the PARENT's exclusion only: ignore rules inside
         // the covered subtree (its own .gitignore, default ignored dirs) hold.
         let (_dir, root) = project_with_gitignored_corpus();
@@ -6319,7 +6319,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_project_files_merges_covered_subtree() {
+    fn test_scan_project_files_merges_force_included_dir() {
         let (_dir, root) = project_with_gitignored_corpus();
 
         let (without, _) = scan_project_files(&root, None, &[], &[], &[]);
@@ -6338,7 +6338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_project_files_covered_subtree_inner_gitignore() {
+    fn test_scan_project_files_force_included_dir_inner_gitignore() {
         let (_dir, root) = project_with_gitignored_corpus();
         std::fs::write(root.join("corpus/.gitignore"), "nested/\n").unwrap();
 
@@ -6352,7 +6352,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_project_files_dedupes_reachable_covered_subtree() {
+    fn test_scan_project_files_dedupes_reachable_force_included_dir() {
         // Coverage outlives the exclusion that motivated it: once the
         // .gitignore entry is dropped, both walks yield the corpus files and
         // each must be indexed exactly once.

--- a/colgrep/src/index/mod.rs
+++ b/colgrep/src/index/mod.rs
@@ -4028,12 +4028,13 @@ impl Searcher {
         })
     }
 
-    /// Filter results to files within a subdirectory prefix.
-    /// Returns document IDs where file path starts with the given prefix.
+    /// Filter results to files within a subdirectory.
+    /// Returns document IDs where the file path has the given directory prefix.
     pub fn filter_by_path_prefix(&self, prefix: &Path) -> Result<Vec<i64>> {
         let prefix_str = prefix.to_string_lossy();
-        // Use SQL LIKE with the prefix followed by %
-        let like_pattern = format!("{}%", prefix_str);
+        // Match on a whole path component: a bare `{prefix}%` would also pull in
+        // sibling directories sharing the string prefix (`corpus` ⊃ `corpus-extra/`).
+        let like_pattern = format!("{}/%", prefix_str.trim_end_matches('/'));
         let subset = filtering::where_condition(
             &self.index_path,
             "file LIKE ?",

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -23,7 +23,7 @@ pub use index::paths::{
     acquire_index_lock, find_parent_index, get_colgrep_data_dir, get_index_dir_for_project,
     get_vector_index_path, ParentIndexInfo, ProjectMetadata,
 };
-pub use index::state::IndexState;
+pub use index::state::{FileInfo, IndexState};
 pub use index::{
     bre_to_ere, escape_literal_braces, index_exists, path_contains_ignored_dir, IndexBuilder,
     SearchResult, Searcher, UpdatePlan, UpdateStats, CONFIRMATION_THRESHOLD,

--- a/colgrep/src/lib.rs
+++ b/colgrep/src/lib.rs
@@ -23,10 +23,11 @@ pub use index::paths::{
     acquire_index_lock, find_parent_index, get_colgrep_data_dir, get_index_dir_for_project,
     get_vector_index_path, ParentIndexInfo, ProjectMetadata,
 };
-pub use index::state::{FileInfo, IndexState};
+pub use index::state::IndexState;
 pub use index::{
-    bre_to_ere, escape_literal_braces, index_exists, path_contains_ignored_dir, IndexBuilder,
-    SearchResult, Searcher, UpdatePlan, UpdateStats, CONFIRMATION_THRESHOLD,
+    bre_to_ere, escape_literal_braces, index_exists, path_contains_ignored_dir,
+    scan_reaches_subdir, IndexBuilder, SearchResult, Searcher, UpdatePlan, UpdateStats,
+    CONFIRMATION_THRESHOLD,
 };
 pub use model::{ensure_model, resolve_quantized, DEFAULT_MODEL};
 pub use onnx_runtime::{ensure_onnx_runtime, is_cudnn_available};

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -320,9 +320,6 @@ fn main() -> Result<()> {
             remove_force_include,
             clear_ignore,
             clear_force_include,
-            add_cover,
-            remove_cover,
-            clear_cover,
         }) => cmd_config(
             default_k,
             default_n,
@@ -350,9 +347,6 @@ fn main() -> Result<()> {
             remove_force_include,
             clear_ignore,
             clear_force_include,
-            add_cover,
-            remove_cover,
-            clear_cover,
         ),
         None => {
             // Default: run search if query is provided

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -320,6 +320,9 @@ fn main() -> Result<()> {
             remove_force_include,
             clear_ignore,
             clear_force_include,
+            add_cover,
+            remove_cover,
+            clear_cover,
         }) => cmd_config(
             default_k,
             default_n,
@@ -347,6 +350,9 @@ fn main() -> Result<()> {
             remove_force_include,
             clear_ignore,
             clear_force_include,
+            add_cover,
+            remove_cover,
+            clear_cover,
         ),
         None => {
             // Default: run search if query is provided


### PR DESCRIPTION
## The bug

`colgrep init <dir>` resolves `<dir>` up to an enclosing indexed project and updates that index instead. The reuse was conditioned only on a parent index existing for the same model — never on the parent's walk actually reaching `<dir>`. So a directory the parent's walk excludes (most often a `.gitignore` entry: dataset corpora, build outputs, vendored trees) was reported as already indexed:

```console
$ colgrep init repo/corpus
Index is up to date for /tmp/repo (1 files)     # ← indexed nothing under corpus/
```

`init` exits 0, nothing under `corpus/` is ever encoded, and the failure only surfaces later as searches that return nothing. This bit us on a 22,995-document gitignored corpus: one stray index of the repo root made every `init` a silent no-op.

## The fix: covered subdirectories

An earlier revision of this PR gated parent reuse on the parent index's *state* and forked a separate index when the state had no files under `<dir>`. Review found that approach conflates "the walk **excludes** this dir" with "the walk hasn't **seen** this dir yet" — a freshly created folder got a fragmented own-index instead of a parent update. Replaced (commit 2) with:

1. **Reachability is decided by walk rules, not index state.** `scan_reaches_subdir` replays the scan's own `WalkBuilder` + `should_ignore` semantics along the target's ancestor chain. A new, non-ignored folder is reachable → parent reuse and incremental update, exactly as before.
2. **An excluded directory the user explicitly inits is registered as a force-included directory** — persisted in `~/.config/colgrep/config.json` under `force_include_dirs`, keyed by project root — and indexed **into the parent index** via an extra walk rooted at the subtree. One project keeps one index: no duplicate embeddings, no worktree-seeding waste, no init/search divergence.
3. **Coverage is durable by construction.** Every scan consults the registrations, so covered dirs survive incremental updates, full rebuilds (including index-format bumps on colgrep upgrades) and `colgrep clear` + re-init. Verified empirically for all three.
4. **Inside a covered subtree, the parent's ignore rules no longer apply — but the subtree's own `.gitignore` and the default ignored dirs still do.**
5. **Configurable via the existing `--force-include` family** (no new flag — an argument that resolves to an existing directory inside an indexed project registers per-project, anything else stays a global pattern as before):
   ```console
   $ colgrep settings --force-include ./corpus     # register (same effect as colgrep init ./corpus)
   $ colgrep settings --no-force-include ./corpus  # unregister; files leave the index on next update
   $ colgrep settings --clear-force-include        # clears patterns AND directory registrations
   $ colgrep settings                              # lists both under "force-incl:"
   ```
6. **Search on an excluded, uncovered subdir now explains itself** instead of returning silent emptiness:
   ```
   No indexed code units in subdirectory: corpus
   This directory is excluded by the project's ignore rules; index it with: colgrep init /tmp/repo/corpus
   ```

Later commits, from stress-testing and review:
- **init resolution** now checks a path's own index before falling back to the enclosing project (search/clear/status already did) — without this, `init` on a nested project's root updated the outer index and per-project registrations never applied.
- The subdirectory search filter fix below, plus its Windows follow-up (stored paths carry native separators, so the component boundary must too).

The subdirectory filter bug this design made load-bearing: the subdirectory search filter used `LIKE '{subdir}%'`, so a search scoped to `repo/corpus` also returned documents from `repo/corpus-extra/`. Now anchored at a path separator.

## Behaviour

| scenario | before | after |
|---|---|---|
| `init` on a covered/reachable subdir | reuses parent | reuses parent (unchanged) |
| `init` on a **freshly created** folder | reuses parent, update picks it up | same (regression in this PR's first revision, fixed) |
| `init` on an **excluded** subdir | "up to date", indexes nothing | registers coverage + indexes into parent |
| colgrep upgrade (format bump), `clear`, full rebuild | n/a | covered dirs re-indexed automatically |
| search scoped to `corpus/` | also matched `corpus-extra/` | true descendants only |

## Tests

15 new unit tests: walk-rules reachability (new folder, gitignored, covered, nested, inner-gitignore, component boundary), covered-subtree scan merging + dedupe, and config add/remove/prune/roundtrip. Full e2e matrix run against debug builds in isolated `COLGREP_DATA_DIR`s, including a simulated `index_format_version` bump. `cargo test -p colgrep` (687 lib + 57 bin), `cargo fmt --check`, `cargo clippy --all-targets` clean.
