### PR TITLE
fix(onnx-export): support non-ModernBERT ColBERT models (LFM2, Jina-v2)

### DIFF
--- a/next-plaid-onnx/python/pyproject.toml
+++ b/next-plaid-onnx/python/pyproject.toml
@@ -34,9 +34,11 @@ dependencies = [
     "transformers>=4.30.0",
     "safetensors>=0.4.0",
     "onnx>=1.14.0",
+    "onnxscript>=0.1.0",
     "onnxruntime>=1.16.0",
     "numpy>=1.24.0",
     "huggingface-hub>=0.20.0",
+    "einops>=0.7.0",
 ]
 
 [project.optional-dependencies]

--- a/next-plaid-onnx/python/src/colbert_export/cli.py
+++ b/next-plaid-onnx/python/src/colbert_export/cli.py
@@ -80,6 +80,12 @@ Supported models:
     )
 
     parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow loading HF models that ship custom modeling code (e.g. jinaai/jina-colbert-v2)",
+    )
+
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s 1.6.5",
@@ -99,6 +105,7 @@ Supported models:
             quantize=not args.no_quantize,
             verbose=not args.quiet,
             force=args.force,
+            trust_remote_code=args.trust_remote_code,
         )
 
         # Push to Hub if requested

--- a/next-plaid-onnx/python/src/colbert_export/export.py
+++ b/next-plaid-onnx/python/src/colbert_export/export.py
@@ -12,6 +12,7 @@ IMPORTANT: Uses pylate's tokenizer which adds [Q] and [D] as special tokens.
 The ONNX model will have extended embeddings to support these tokens.
 """
 
+import inspect
 import json
 from pathlib import Path
 from typing import Optional
@@ -31,10 +32,12 @@ def detect_model_architecture(pylate_model: pylate_models.ColBERT) -> dict:
     auto_model = pylate_model[0].auto_model
     model_class_name = auto_model.__class__.__name__
 
-    # Check if model uses token_type_ids
-    uses_token_type_ids = True
-    if "ModernBert" in model_class_name:
-        uses_token_type_ids = False
+    # Whether the tokenizer actually emits token_type_ids varies by model
+    # family (e.g. Llama/LFM2-style tokenizers never produce it), so ask the
+    # tokenizer directly rather than guessing from the architecture name.
+    tokenizer = pylate_model[0].tokenizer
+    probe = tokenizer("probe", return_tensors="pt")
+    uses_token_type_ids = "token_type_ids" in probe
 
     # Get hidden size and output dimension
     config = auto_model.config
@@ -73,6 +76,12 @@ class ColBERTForONNX(nn.Module):
 
         self.uses_token_type_ids = uses_token_type_ids
 
+        # Decoder-style backbones (e.g. LFM2) default use_cache=True from their
+        # config, which builds a KV cache and triggers data-dependent control
+        # flow (cache_position[0] > 0) that torch.export can't trace. We only
+        # ever run a single forward pass here, so force it off when supported.
+        self.supports_use_cache = "use_cache" in inspect.signature(self.bert.forward).parameters
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -84,16 +93,19 @@ class ColBERTForONNX(nn.Module):
         Returns per-token embeddings [batch_size, seq_len, embedding_dim].
         """
         # Get hidden states from transformer
+        extra_kwargs = {"use_cache": False} if self.supports_use_cache else {}
         if self.uses_token_type_ids and token_type_ids is not None:
             outputs = self.bert(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 token_type_ids=token_type_ids,
+                **extra_kwargs,
             )
         else:
             outputs = self.bert(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
+                **extra_kwargs,
             )
         hidden_states = outputs.last_hidden_state
 
@@ -114,6 +126,7 @@ def export_model(
     quantize: bool = False,
     verbose: bool = True,
     force: bool = False,
+    trust_remote_code: bool = False,
 ) -> Path:
     """Export a ColBERT model from HuggingFace to ONNX format.
 
@@ -126,6 +139,8 @@ def export_model(
         quantize: Whether to also create an INT8 quantized version
         verbose: Whether to print progress messages
         force: Force re-export even if model already exists
+        trust_remote_code: Allow loading HF models that ship custom modeling code
+            (e.g. jinaai/jina-colbert-v2)
 
     Returns:
         Path to the output directory containing the exported model
@@ -171,10 +186,15 @@ def export_model(
     if verbose:
         print(f"Loading pylate model: {model_name}")
 
+    # Don't override do_query_expansion (or any other trained config): pylate
+    # defaults it from the model's own config_sentence_transformers.json, and
+    # that value gets baked into onnx_config.json for the Rust inference side
+    # to act on. Forcing it to False here would silently disable MASK-token
+    # query expansion for any model trained with it on (e.g. LFM2.5).
     pylate_model = pylate_models.ColBERT(
         model_name_or_path=model_name,
         device="cpu",
-        do_query_expansion=False,
+        trust_remote_code=trust_remote_code,
     )
 
     # Detect model architecture
@@ -188,6 +208,10 @@ def export_model(
 
     # Create ONNX wrapper using pylate's model
     model = ColBERTForONNX(pylate_model, uses_token_type_ids=arch_info["uses_token_type_ids"])
+    # Some checkpoints (e.g. LFM2) load in bfloat16 by default. ONNX Runtime's
+    # CPU EP doesn't support bfloat16 for several ops (e.g. Conv), so force
+    # fp32 before export regardless of the checkpoint's native dtype.
+    model = model.float()
     model.eval()
 
     # Use pylate's tokenizer (has [Q] and [D] as special tokens)
@@ -251,8 +275,12 @@ def export_model(
     if verbose:
         print(f"Saved ONNX config to: {onnx_config_output_path}")
 
-    # Create dummy inputs with reasonable dimensions
-    dummy_text = "[D] This is a sample text for ONNX export"
+    # Create dummy inputs with reasonable dimensions. Use batch_size=2 (not 1)
+    # so torch.export doesn't specialize the batch dim to a static size.
+    dummy_text = [
+        "[D] This is a sample text for ONNX export",
+        "[D] A second document to keep the batch dim genuinely dynamic",
+    ]
     inputs = tokenizer(
         dummy_text,
         return_tensors="pt",
@@ -261,7 +289,7 @@ def export_model(
         truncation=True,
     )
 
-    # Prepare inputs and dynamic axes based on architecture
+    # Prepare inputs based on architecture
     if arch_info["uses_token_type_ids"]:
         input_names = ["input_ids", "attention_mask", "token_type_ids"]
         example_inputs = (
@@ -269,20 +297,18 @@ def export_model(
             inputs["attention_mask"],
             inputs["token_type_ids"],
         )
-        dynamic_axes = {
-            "input_ids": {0: "batch_size", 1: "sequence_length"},
-            "attention_mask": {0: "batch_size", 1: "sequence_length"},
-            "token_type_ids": {0: "batch_size", 1: "sequence_length"},
-            "output": {0: "batch_size", 1: "sequence_length"},
-        }
     else:
         input_names = ["input_ids", "attention_mask"]
         example_inputs = (inputs["input_ids"], inputs["attention_mask"])
-        dynamic_axes = {
-            "input_ids": {0: "batch_size", 1: "sequence_length"},
-            "attention_mask": {0: "batch_size", 1: "sequence_length"},
-            "output": {0: "batch_size", 1: "sequence_length"},
-        }
+
+    # dynamic_axes is the legacy (dynamo=False) API and silently produces
+    # models with a statically-baked batch dimension under the current
+    # dynamo=True default exporter (e.g. LFM2's causal mask gets specialized
+    # to batch_size=1 and then fails at inference on any other batch size).
+    # dynamic_shapes is what the dynamo path actually respects.
+    from torch.export import Dim
+
+    dynamic_shapes = tuple({0: Dim.DYNAMIC, 1: Dim.DYNAMIC} for _ in example_inputs)
 
     # Export to ONNX
     if verbose:
@@ -295,7 +321,7 @@ def export_model(
             str(onnx_output_path),
             input_names=input_names,
             output_names=["output"],
-            dynamic_axes=dynamic_axes,
+            dynamic_shapes=dynamic_shapes,
             opset_version=14,
             do_constant_folding=True,
         )
@@ -307,8 +333,15 @@ def export_model(
     if verbose:
         print("Verifying exported model...")
 
-    onnx_model = onnx.load(str(onnx_output_path))
-    onnx.checker.check_model(onnx_model)
+    # Large models (e.g. Jina-v2's ~2.2GB fp32 weights) exceed protobuf's 2GB
+    # in-memory serialization limit, so loading full external data and
+    # checking the in-memory proto (which calls SerializeToString()
+    # internally) fails even though the on-disk model is valid. Passing the
+    # path directly lets the checker stream/handle external data without
+    # materializing everything in memory. Load without external data just to
+    # inspect the graph structure (input names).
+    onnx.checker.check_model(str(onnx_output_path))
+    onnx_model = onnx.load(str(onnx_output_path), load_external_data=False)
 
     if verbose:
         print("ONNX model verification passed!")


### PR DESCRIPTION
Fixes #93.

`pylate-onnx-export` only worked on ModernBERT-family checkpoints. Exporting `LiquidAI/LFM2.5-ColBERT-350M` or `jinaai/jina-colbert-v2` failed at several independent points — and two further bugs produced a model that exported *"successfully"* but was silently wrong or unusable at inference.

Bugs 1–5 correspond to the ones reported in #93; 6–8 surfaced only after the earlier ones were cleared.

## Bugs fixed

| # | Symptom | Cause / fix |
|---|---------|-------------|
| 1 | `KeyError: 'token_type_ids'` on any non-ModernBERT arch | `detect_model_architecture()` hardcoded a `"ModernBert"` class-name allowlist; everything else was assumed to use `token_type_ids`. Now probes the tokenizer directly. |
| 2 | `torch.export` fails on LFM2 | LFM2 defaults `use_cache=True`, building a KV cache and hitting data-dependent control flow (`cache_position[0] > 0`) that `torch.export` can't trace. Force `use_cache=False` where supported. |
| 3 | Exported model won't load in ORT | LFM2/Jina load in **bfloat16**; ORT's CPU EP rejects bf16 for several ops (e.g. `Conv`). The model passed `check_model` but failed at session creation. Cast to fp32 before export. |
| 4 | Jina-v2 can't be loaded at all | `trust_remote_code` was never forwarded. Added as a param + `--trust-remote-code` flag. |
| 5 | `No module named 'onnxscript'` / `einops` | Undeclared deps (`onnxscript` for torch's dynamo exporter, `einops` for Jina's custom modeling code). |
| 6 | **Batch dim silently baked static** | `dynamic_axes` is the legacy `dynamo=False` API and is not honored under the current `dynamo=True` default. LFM2's causal mask specialized to `batch_size=1`; inference then failed on *every* other batch size. Switched to `dynamic_shapes` + a 2-row dummy input. |
| 7 | **Query expansion silently disabled** | `do_query_expansion=False` was hardcoded, overriding the trained config. It's baked into `onnx_config.json` and acted on by the Rust side, so MASK-token query expansion was disabled for models trained with it (LFM2.5, Jina-v2). Invisible until now because `GTE-ModernColBERT-v1` also defaults to `False`. Now left to pylate to resolve. |
| 8 | Verification crash on large models | `onnx.load()` + `check_model()` on the in-memory proto exceeds protobuf's 2 GB serialization limit for Jina-v2's ~2.2 GB fp32 weights — failing on a model that is valid on disk. Check by path instead. |

Bugs 6 and 7 are the notable ones: both produce an export that *looks* successful. 6 fails loudly but only at batch > 1; 7 never fails at all, it just quietly degrades retrieval.

## Verification

Exported models were checked against pylate's own forward pass — not just "the export ran":

| Check | Result |
|---|---|
| Document encoding (Rust ONNX vs pylate native) | max abs diff **1.8e-6** |
| Query encoding (Rust ONNX vs pylate native) | max abs diff **9.2e-7** |
| Projection head vs checkpoint `linear.weight` | **bitwise identical** |

`GTE-ModernColBERT-v1` still exports unchanged (no regression), and the existing suite passes (`15 passed`), `ruff check` + `format --check` clean.

## End-to-end sanity check (LFM2.5, SciFact)

Full BEIR SciFact test queries (300) against a 1000-doc subset (all 283 qrels-relevant docs + 717 random distractors), encoded through the Rust `next-plaid-onnx` crate, brute-force MaxSim:

| Metric | LFM2.5 |
|---|---|
| nDCG@10 | 0.764 |
| nDCG@100 | 0.787 |
| Recall@10 | 0.856 |
| Recall@100 | 0.967 |
| MAP | 0.736 |

This is a **pipeline sanity check, not a quality claim** — it's a reduced-distractor subset, so it is not comparable to published full-corpus leaderboard numbers (BM25 scores 0.777 on this same subset; SciFact is a notoriously BM25-friendly dataset). The numerical-parity figures above are the actual correctness evidence.

## Note on jina-colbert-v2

Jina-v2 now exports and runs correctly, but scores unexpectedly low on SciFact (0.439 nDCG@10 on the full 5183-doc corpus — below BM25's 0.652 measured through the same harness). I could not attribute this to the export: ONNX output is numerically identical to pylate's own forward pass, so pylate reproduces the same behavior. The eval harness itself was validated against BM25 ground truth (0.652 vs published ~0.665), and a truncation hypothesis was tested and refuted (raising `document_length` 300→512 moved nDCG@10 by −0.003).

That points to a pylate↔Jina compatibility issue upstream of this PR rather than an export defect, and I did not chase it further. Flagging it in case it's of interest — happy to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)