### PR TITLE
fix(cli): a query is not a path, and a dash is not a flag

### DIFF
--- a/colgrep/src/cli.rs
+++ b/colgrep/src/cli.rs
@@ -300,7 +300,7 @@ pub struct Cli {
 
     // Default search arguments (when no subcommand is provided)
     /// Natural language query (runs search by default)
-    #[arg(value_name = "QUERY")]
+    #[arg(value_name = "QUERY", allow_hyphen_values = true)]
     pub query: Option<String>,
 
     /// Files or directories to search in (default: current directory)
@@ -483,6 +483,7 @@ pub enum Commands {
     #[command(after_help = SEARCH_HELP)]
     Search {
         /// Natural language query (optional if -e pattern is provided)
+        #[arg(value_name = "QUERY", allow_hyphen_values = true)]
         query: Option<String>,
 
         /// Files or directories to search in (default: current directory)
@@ -777,4 +778,61 @@ pub enum Commands {
         #[arg(long = "clear-force-include")]
         clear_force_include: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn a_query_starting_with_a_dash_parses_as_the_query() {
+        let cli = Cli::try_parse_from(["colgrep", "--glob flag option", "-k", "5"]).unwrap();
+        assert_eq!(cli.query.as_deref(), Some("--glob flag option"));
+        assert_eq!(cli.top_k, Some(5));
+    }
+
+    #[test]
+    fn a_dash_query_works_on_the_search_subcommand_too() {
+        let cli = Cli::try_parse_from(["colgrep", "search", "-k", "5", "--exclude flag"]).unwrap();
+        match cli.command {
+            Some(super::Commands::Search { query, top_k, .. }) => {
+                assert_eq!(query.as_deref(), Some("--exclude flag"));
+                assert_eq!(top_k, Some(5));
+            }
+            _ => panic!("expected the search subcommand"),
+        }
+    }
+
+    #[test]
+    fn known_flags_still_parse_as_flags() {
+        let cli = Cli::try_parse_from(["colgrep", "some query", "--json"]).unwrap();
+        assert_eq!(cli.query.as_deref(), Some("some query"));
+        assert!(cli.json);
+    }
+
+    #[test]
+    fn the_double_dash_separator_still_works() {
+        let cli = Cli::try_parse_from(["colgrep", "--", "-starts with dash"]).unwrap();
+        assert_eq!(cli.query.as_deref(), Some("-starts with dash"));
+    }
+
+    #[test]
+    fn query_with_e_pattern_and_flags_parses_each_into_its_slot() {
+        let cli = Cli::try_parse_from([
+            "colgrep",
+            "proxy auth on retries/redirects",
+            "-e",
+            "Client",
+            "-k",
+            "10",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.query.as_deref(),
+            Some("proxy auth on retries/redirects")
+        );
+        assert_eq!(cli.text_pattern.as_deref(), Some("Client"));
+        assert_eq!(cli.top_k, Some(10));
+    }
 }

--- a/colgrep/src/main.rs
+++ b/colgrep/src/main.rs
@@ -46,6 +46,25 @@ fn apply_coreml_cache_dir() {
     }
 }
 
+/// Whether a query positional given alongside `-e` is actually a misplaced PATH argument.
+///
+/// `colgrep -e pattern ./src` parses `./src` into the query slot, so a path-shaped query
+/// is moved back into the paths — but only when it could really be a path: it exists on
+/// disk, or it is a whitespace-free token shaped like a path (so a mistyped `./sr` still
+/// errors as a path instead of silently becoming a search). A natural-language query
+/// that merely mentions a path ("proxy auth on retries/redirects") stays a query.
+fn query_is_misplaced_path(query: &str) -> bool {
+    let path_shaped = query.starts_with('.')
+        || query.starts_with('/')
+        || query.starts_with('~')
+        || query.contains('/')
+        || query.contains('\\');
+    if !path_shaped {
+        return false;
+    }
+    std::path::Path::new(query).exists() || !query.chars().any(char::is_whitespace)
+}
+
 fn main() -> Result<()> {
     // Set up Ctrl+C handler for graceful interruption during indexing
     // This is non-fatal if it fails (e.g., in environments without signal support)
@@ -183,7 +202,7 @@ fn main() -> Result<()> {
                 // We want: query="pattern", paths=["./src"]
                 let (final_query, final_paths, final_text_pattern) = if text_pattern.is_some()
                     && original_query.is_some()
-                    && looks_like_path(&query)
+                    && query_is_misplaced_path(&query)
                 {
                     // The "query" is actually a path - use text_pattern as query
                     let text_pattern_str = text_pattern.clone().unwrap();
@@ -368,7 +387,7 @@ fn main() -> Result<()> {
                 // We want: query="pattern", paths=["./src"]
                 let (final_query, final_paths, final_text_pattern) = if cli.text_pattern.is_some()
                     && original_query.is_some()
-                    && looks_like_path(&query)
+                    && query_is_misplaced_path(&query)
                 {
                     // The "query" is actually a path - use text_pattern as query
                     let text_pattern = cli.text_pattern.clone().unwrap();
@@ -468,4 +487,37 @@ fn init_global_rayon_pool() {
         .num_threads(configured)
         .thread_name(|idx| format!("next-plaid-rayon-{idx}"))
         .build_global();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::query_is_misplaced_path;
+
+    #[test]
+    fn a_prose_query_mentioning_a_path_is_not_a_path() {
+        assert!(!query_is_misplaced_path("proxy auth on retries/redirects"));
+        assert!(!query_is_misplaced_path(
+            "update docs/readme for the new flag"
+        ));
+    }
+
+    #[test]
+    fn a_plain_query_without_path_shape_is_not_a_path() {
+        assert!(!query_is_misplaced_path("connection pooling"));
+    }
+
+    #[test]
+    fn an_existing_path_is_a_path_even_with_spaces() {
+        let dir = std::env::temp_dir().join("colgrep test dir with spaces");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(query_is_misplaced_path(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_whitespace_free_path_shaped_token_stays_a_path_even_when_missing() {
+        // Preserves the "Path does not exist" error for a mistyped path argument.
+        assert!(query_is_misplaced_path("./no-such-dir"));
+        assert!(query_is_misplaced_path("src/missing.rs"));
+    }
 }


### PR DESCRIPTION
Two CLI parsing bugs reported from agent-driven usage, both killing a correct search before it ran.

## Bug A — a slash in the query + `-e`

```
colgrep 'proxy auth on retries/redirects' -e Client -k 10
→ Error: Path does not exist: proxy auth on retries/redirects
```

The path-vs-query heuristic treated **any** query containing `/` as a misplaced PATH argument. The reclassification now fires only when the token could actually be a path:

- it **exists on disk** (so `colgrep -e pattern ./src` still moves `./src` into paths — spaces and all), or
- it is a **whitespace-free, path-shaped token** (so a mistyped `./sr` still gets the helpful "Path does not exist" error instead of silently becoming a search).

A natural-language query that merely mentions a path stays a query.

## Bug B — a query starting with `-`

```
colgrep '--glob flag option' -k 5
→ error: unexpected argument '--glob flag option' found
```

The query positional rejected hyphen values. Both query positionals (default command and `search`) now take `allow_hyphen_values`. Defined flags still parse as flags, and the `--` separator still works. Trade-off accepted: a mistyped long flag becomes a search instead of an error — the right default for a tool whose callers include LLM agents emitting queries *about* flags.

## Verification

- Unit tests for both parses and the classifier (9 new; whole crate green: 687 + 66 passing).
- A 22-case stress battery against a live 150-document index — the two verbatim repros, slash variants, leading single/double dashes, dash-query-after-flags, `--` separator, embedded quotes, `=`, backslashes, unicode, newline/tab in query, 800-word query, plus regression guards that existing-dir PATH args, existing-file reclassification, and path-typo errors all behave exactly as before: **22/22 pass**.
